### PR TITLE
fix template's Python and OS options

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -90,10 +90,12 @@ body:
               What operating system
           multiple: true
           options:
-              - Ubuntu
-              - Redhat
-              - Windows
-              - Other
+              - "Ubuntu"
+              - "Red Hat Enterprise Linux (RHEL)"
+              - "Fedora"
+              - "Windows WSL"
+              - "MacOS (limited support)"
+              - "Other"
       validations:
           required: true
 
@@ -104,9 +106,9 @@ body:
               What version of python
           multiple: true
           options:
-              - 3.10
-              - 3.11
-              - Other
+              - "3.10.x"
+              - "3.11.x"
+              - "Other"
       validations:
           required: true
 


### PR DESCRIPTION
## Why are these changes needed?
The current bug template provides the following Python options:

<img width="328" alt="image" src="https://github.com/IBM/data-prep-lab/assets/1816654/9d420ecc-fba2-4754-9173-15616422b15d">

The the OS list is not correct also. 

