### PR TITLE
Fix python definition

### DIFF
--- a/.make.defaults
+++ b/.make.defaults
@@ -26,7 +26,7 @@
 #######################################################################################
 SHELL=/bin/bash
 # Command to run python 
-PYTHON=python
+PYTHON?=python
 PIP=$(PYTHON) -m pip
 # Command to run pytest
 PYTEST=pytest -s


### PR DESCRIPTION
## Why are these changes needed?
Otherwise, we cannot re-define python command

Signed-off-by: Alexey Roytman [roytman@il.ibm.com](mailto:roytman@il.ibm.com)

