### PR TITLE
Add RayTransformConfiguration to a capture runtime_class

### DIFF
--- a/.make.defaults
+++ b/.make.defaults
@@ -254,7 +254,7 @@ __check_defined = \
 
 .PHONY: .defaults.check.installed
 .defaults.check.installed::
-	if [ ! command -v $(CHECK_RUNNABLE) &>/dev/null ]; then \
+	@if [ ! command -v $(CHECK_RUNNABLE) &>/dev/null ]; then \
 	    echo $(CHECK_RUNNABLE) must be installed;		\
 	    exit 1;						\
 	fi

--- a/data-processing-lib/src/data_processing/launch/ray/transform_configuration.py
+++ b/data-processing-lib/src/data_processing/launch/ray/transform_configuration.py
@@ -1,0 +1,33 @@
+from data_processing.launch.ray import DefaultTableTransformRuntimeRay
+from data_processing.transform.transform_configuration import (
+    TransformConfiguration,
+    TransformConfigurationProxy,
+)
+
+
+class RayTransformConfiguration(TransformConfigurationProxy):
+    def __init__(
+        self,
+        transform_config: TransformConfiguration,
+        runtime_class: type[DefaultTableTransformRuntimeRay] = DefaultTableTransformRuntimeRay,
+    ):
+        """
+        Initialization
+        :param transform_class: implementation of the transform
+        :param runtime_class: implementation of the transform runtime
+        :param base: base transform configuration class
+        :param name: transform name
+        :param remove_from_metadata: list of parameters to remove from metadata
+        :return:
+        """
+        super().__init__(
+            proxied_transform_config=transform_config,
+        )
+        self.runtime_class = runtime_class
+
+    def create_transform_runtime(self) -> DefaultTableTransformRuntimeRay:
+        """
+        Create transform runtime with the parameters captured during apply_input_params()
+        :return: transform runtime object
+        """
+        return self.runtime_class(self.params)

--- a/data-processing-lib/src/data_processing/launch/ray/transform_launcher.py
+++ b/data-processing-lib/src/data_processing/launch/ray/transform_launcher.py
@@ -16,13 +16,15 @@ import time
 
 import ray
 from data_processing.data_access import DataAccessFactory, DataAccessFactoryBase
-from data_processing.transform import TransformConfiguration
 from data_processing.launch.ray import (
+    DefaultTableTransformRuntimeRay,
     RayLauncherConfiguration,
     TransformOrchestratorConfiguration,
-    orchestrate, DefaultTableTransformRuntimeRay,
+    orchestrate,
 )
+from data_processing.launch.ray.transform_configuration import RayTransformConfiguration
 from data_processing.launch.transform_launcher import AbstractTransformLauncher
+from data_processing.transform import TransformConfiguration
 from data_processing.utils import get_logger, str2bool
 
 
@@ -36,8 +38,8 @@ class RayTransformLauncher(AbstractTransformLauncher):
 
     def __init__(
         self,
-        transform_config: TransformConfiguration,
-        runtime_class: type[DefaultTableTransformRuntimeRay]=DefaultTableTransformRuntimeRay,
+        transform_config: RayTransformConfiguration,
+        # runtime_class: type[DefaultTableTransformRuntimeRay]=DefaultTableTransformRuntimeRay,
         data_access_factory: DataAccessFactoryBase = DataAccessFactory(),
     ):
         """
@@ -46,7 +48,7 @@ class RayTransformLauncher(AbstractTransformLauncher):
         :param data_access_factory: the factory to create DataAccess instances.
         """
         super().__init__(transform_config, data_access_factory)
-        self.transform_runtime_config = RayLauncherConfiguration(transform_config, runtime_class)
+        self.transform_runtime_config = RayLauncherConfiguration(transform_config, transform_config.runtime_class)
         self.ray_orchestrator = TransformOrchestratorConfiguration(name=self.name)
 
     def __get_parameters(self) -> bool:

--- a/data-processing-lib/src/data_processing/test_support/transform/noop_transform.py
+++ b/data-processing-lib/src/data_processing/test_support/transform/noop_transform.py
@@ -15,8 +15,8 @@ from argparse import ArgumentParser, Namespace
 from typing import Any
 
 import pyarrow as pa
-
 from data_processing.launch.pure_python import PythonTransformLauncher
+from data_processing.launch.ray.transform_configuration import RayTransformConfiguration
 from data_processing.transform import AbstractTableTransform, TransformConfiguration
 from data_processing.utils import CLIArgumentProvider, get_logger
 
@@ -64,6 +64,7 @@ class NOOPTransform(AbstractTableTransform):
         logger.debug(f"Transformed one table with {len(table)} rows")
         metadata = {"nfiles": 1, "nrows": len(table)}
         return [table], metadata
+
 
 class NOOPTransformConfiguration(TransformConfiguration):
 
@@ -118,6 +119,10 @@ class NOOPTransformConfiguration(TransformConfiguration):
         return True
 
 
+class NOOPRayTransformConfiguration(RayTransformConfiguration):
+    def __init__(self):
+        super().__init__(NOOPTransformConfiguration())
+
 
 #
 # class NOOPTransformConfigurationRayLauncherConfiguration(RayLauncherConfiguration):
@@ -141,7 +146,7 @@ class NOOPTransformConfiguration(TransformConfiguration):
 #
 
 if __name__ == "__main__":
-    #launcher = PythonTransformLauncher(transform_runtime_config=NOOPPythonLauncherConfigurationPython())
+    # launcher = PythonTransformLauncher(transform_runtime_config=NOOPPythonLauncherConfigurationPython())
     launcher = PythonTransformLauncher(transform_runtime_config=NOOPTransformConfiguration())
     logger.info("Launching noop transform")
     launcher.launch()

--- a/data-processing-lib/src/data_processing/transform/transform_configuration.py
+++ b/data-processing-lib/src/data_processing/transform/transform_configuration.py
@@ -9,8 +9,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 ################################################################################
-
+import argparse
 from argparse import ArgumentParser
+from typing import Any
 
 from data_processing.transform import AbstractTableTransform
 from data_processing.utils import CLIArgumentProvider
@@ -21,7 +22,7 @@ class TransformConfiguration(CLIArgumentProvider):
     This is a base transform configuration class defining transform's input/output parameter
     """
 
-    def __init__(self, name:str, transform_class:AbstractTableTransform, remove_from_metadata: list[str] = []):
+    def __init__(self, name: str, transform_class: AbstractTableTransform, remove_from_metadata: list[str] = []):
         """
         Initialization
         """
@@ -29,6 +30,29 @@ class TransformConfiguration(CLIArgumentProvider):
         self.transform_class = transform_class
         self.remove_from_metadata = remove_from_metadata
         self.params = {}
+
+
+class TransformConfigurationProxy(TransformConfiguration):
+    def __init__(self, proxied_transform_config: TransformConfiguration):
+        self.proxied_transform_config = proxied_transform_config
+        # Python probably has a better way of doing this using the proxied transform config
+        self.name = proxied_transform_config.name
+        self.transform_class = proxied_transform_config.transform_class
+        self.remove_from_metadata = proxied_transform_config.remove_from_metadata
+        self.params = {}
+
+    def add_input_params(self, parser: argparse.ArgumentParser) -> None:
+        self.proxied_transform_config.add_input_params(parser)
+
+    def apply_input_params(self, args: argparse.Namespace) -> bool:
+        is_valid = self.proxied_transform_config.apply_input_params(args)
+        if is_valid:
+            self.params = self.proxied_transform_config.params
+        return is_valid
+
+    def get_input_params(self) -> dict[str, Any]:
+        return self.params
+
 
 def get_transform_config(
     transform_configuration: TransformConfiguration, argv: list[str], parser: ArgumentParser = None

--- a/data-processing-lib/test/data_processing_tests/launch/ray/launcher_test.py
+++ b/data-processing-lib/test/data_processing_tests/launch/ray/launcher_test.py
@@ -13,11 +13,13 @@
 import os
 import sys
 
-from data_processing.transform import TransformConfiguration
-from data_processing.launch.ray import (
-    RayTransformLauncher,
+from data_processing.launch.ray import RayTransformLauncher
+from data_processing.launch.ray.transform_configuration import RayTransformConfiguration
+from data_processing.test_support.transform import NOOPTransformConfiguration
+from data_processing.test_support.transform.noop_transform import (
+    NOOPRayTransformConfiguration,
 )
-from data_processing.transform import AbstractTableTransform
+from data_processing.transform import AbstractTableTransform, TransformConfiguration
 from data_processing.utils import ParamsUtils
 
 
@@ -43,15 +45,13 @@ worker_options = {"num_cpu": 0.8}
 code_location = {"github": "github", "commit_hash": "12345", "path": "path"}
 
 
-class TestingTransformConfiguration(TransformConfiguration):
-    def __init__(self):
-        super().__init__("test", transform_class=AbstractTableTransform)
 class TestLauncherTransformLauncher(RayTransformLauncher):
     """
     Test driver for validation of the functionality
     """
+
     def __init__(self):
-        super().__init__( TestingTransformConfiguration())
+        super().__init__(NOOPRayTransformConfiguration())
 
     def _submit_for_execution(self) -> int:
         """
@@ -88,8 +88,6 @@ def test_launcher():
     params["data_s3_cred"] = ParamsUtils.convert_to_ast(s3_cred)
     sys.argv = ParamsUtils.dict_to_req(d=params)
     res = TestLauncherTransformLauncher().launch()
-
-
 
     assert 0 == res
     # Add local config, should fail because now three different configs exist

--- a/data-processing-lib/test/data_processing_tests/launch/ray/test_noop_launch.py
+++ b/data-processing-lib/test/data_processing_tests/launch/ray/test_noop_launch.py
@@ -13,10 +13,15 @@
 import os
 
 import pyarrow as pa
-
 from data_processing.launch.ray import RayTransformLauncher
-from data_processing.test_support.launch.transform_test import AbstractTransformLauncherTest
+from data_processing.test_support.launch.transform_test import (
+    AbstractTransformLauncherTest,
+)
 from data_processing.test_support.transform import NOOPTransformConfiguration
+from data_processing.test_support.transform.noop_transform import (
+    NOOPRayTransformConfiguration,
+)
+
 
 table = pa.Table.from_pydict({"name": pa.array(["Tom"]), "age": pa.array([23])})
 expected_table = table  # We're a noop after all.
@@ -32,6 +37,6 @@ class TestRayNOOPTransform(AbstractTransformLauncherTest):
     def get_test_transform_fixtures(self) -> list[tuple]:
         basedir = "../../../../test-data/data_processing/ray/noop/"
         basedir = os.path.abspath(os.path.join(os.path.dirname(__file__), basedir))
-        launcher = RayTransformLauncher(NOOPTransformConfiguration())
+        launcher = RayTransformLauncher(NOOPRayTransformConfiguration())
         fixtures = [(launcher, {"noop_sleep_sec": 0}, basedir + "/input", basedir + "/expected")]
         return fixtures

--- a/transforms/code/code_quality/src/code_quality_local_ray.py
+++ b/transforms/code/code_quality/src/code_quality_local_ray.py
@@ -14,7 +14,8 @@ import os
 import sys
 from pathlib import Path
 
-from code_quality_transform import CodeQualityRayLauncher
+from code_quality_transform import CodeQualityRayTransformConfiguration
+from data_processing.launch.ray import RayTransformLauncher
 from data_processing.utils import ParamsUtils
 
 
@@ -26,7 +27,7 @@ local_conf = {
 }
 
 # create launcher
-launcher = CodeQualityRayLauncher()
+launcher = RayTransformLauncher(CodeQualityRayTransformConfiguration())
 
 
 worker_options = {"num_cpus": 0.8}

--- a/transforms/code/code_quality/src/code_quality_s3_ray.py
+++ b/transforms/code/code_quality/src/code_quality_s3_ray.py
@@ -12,7 +12,8 @@
 
 import sys
 
-from code_quality_transform import CodeQualityRayLauncher
+from code_quality_transform import CodeQualityRayTransformConfiguration
+from data_processing.launch.ray import RayTransformLauncher
 from data_processing.utils import ParamsUtils
 
 
@@ -27,7 +28,7 @@ s3_conf = {
 }
 
 # create launcher
-launcher = CodeQualityRayLauncher()
+launcher = RayTransformLauncher(CodeQualityRayTransformConfiguration())
 
 
 worker_options = {"num_cpus": 0.8}

--- a/transforms/code/code_quality/src/code_quality_transform.py
+++ b/transforms/code/code_quality/src/code_quality_transform.py
@@ -24,9 +24,9 @@ from argparse import ArgumentParser, Namespace
 import numpy as np
 import pyarrow as pa
 from bs4 import BeautifulSoup
-from data_processing.transform import TransformConfiguration
 from data_processing.launch.ray import RayTransformLauncher
-from data_processing.transform import AbstractTableTransform
+from data_processing.launch.ray.transform_configuration import RayTransformConfiguration
+from data_processing.transform import AbstractTableTransform, TransformConfiguration
 from data_processing.utils import TransformUtils
 from transformers import AutoTokenizer
 
@@ -285,10 +285,7 @@ class CodeQualityTransform(AbstractTableTransform):
 
 class CodeQualityTransformConfiguration(TransformConfiguration):
     def __init__(self):
-        super().__init__(
-            name="code_quality",
-            transform_class=CodeQualityTransform
-        )
+        super().__init__(name="code_quality", transform_class=CodeQualityTransform)
 
     def add_input_params(self, parser: ArgumentParser) -> None:
         parser.add_argument(
@@ -339,28 +336,11 @@ class CodeQualityTransformConfiguration(TransformConfiguration):
         return True
 
 
-# class CodeQualityRayLauncherConfiguration(RayLauncherConfiguration):
-#     def __init__(self):
-#         super().__init__(
-#             name="code_quality",
-#             transform_class=CodeQualityTransform,
-#             launcher_configuration=CodeQualityTransformConfiguration(),
-#         )
-#
-#
-# class CodeQualityPythonLauncherConfiguration(PythonLauncherConfiguration):
-#     def __init__(self):
-#         super().__init__(
-#             name="code_quality",
-#             transform_class=CodeQualityTransform,
-#             launcher_configuration=CodeQualityTransformConfiguration(),
-#         )
-#         self.base = CodeQualityTransformConfiguration()
-
-class CodeQualityRayLauncher(RayTransformLauncher):
+class CodeQualityRayTransformConfiguration(RayTransformConfiguration):
     def __init__(self):
         super().__init__(transform_config=CodeQualityTransformConfiguration())
 
+
 if __name__ == "__main__":
-    launcher = CodeQualityRayLauncher()
+    launcher = RayTransformLauncher(CodeQualityRayTransformConfiguration())
     launcher.launch()

--- a/transforms/code/code_quality/test/test_code_quality_launcher.py
+++ b/transforms/code/code_quality/test/test_code_quality_launcher.py
@@ -12,8 +12,11 @@
 
 import os
 
-from code_quality_transform import CodeQualityRayLauncher
-from data_processing.test_support.launch.transform_test import AbstractTransformLauncherTest
+from code_quality_transform import CodeQualityRayTransformConfiguration
+from data_processing.launch.ray import RayTransformLauncher
+from data_processing.test_support.launch.transform_test import (
+    AbstractTransformLauncherTest,
+)
 
 
 class TestCodeQualityTransform(AbstractTransformLauncherTest):
@@ -30,6 +33,6 @@ class TestCodeQualityTransform(AbstractTransformLauncherTest):
         }
         basedir = "../test-data"
         basedir = os.path.abspath(os.path.join(os.path.dirname(__file__), basedir))
-        launcher = CodeQualityRayLauncher()
+        launcher = RayTransformLauncher(CodeQualityRayTransformConfiguration())
         fixtures = [(launcher, cli, basedir + "/input", basedir + "/expected")]
         return fixtures

--- a/transforms/code/malware/src/malware_local_ray.py
+++ b/transforms/code/malware/src/malware_local_ray.py
@@ -14,8 +14,10 @@ import os
 import sys
 from pathlib import Path
 
+from data_processing.launch.ray import RayTransformLauncher
 from data_processing.utils import ParamsUtils
-from malware_transform import check_clamd, MalwareRayLauncher
+from malware_transform import MalwareRayTransformConfiguration, check_clamd
+
 
 TEST_SOCKET = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".tmp", "clamd.ctl"))
 # create parameters
@@ -51,6 +53,6 @@ if __name__ == "__main__":
     # Set the simulated command line args
     sys.argv = ParamsUtils.dict_to_req(d=params | malware_params)
     # create launcher
-    launcher = MalwareRayLauncher()
+    launcher = RayTransformLauncher(MalwareRayTransformConfiguration())
     # Launch the ray actor(s) to process the input
     launcher.launch()

--- a/transforms/code/malware/src/malware_transform.py
+++ b/transforms/code/malware/src/malware_transform.py
@@ -18,10 +18,13 @@ from typing import Any
 
 import clamd
 import pyarrow as pa
-from data_processing.transform import TransformConfiguration
-from data_processing.launch.pure_python import PythonTransformLauncher, PythonLauncherConfiguration
+from data_processing.launch.pure_python import (
+    PythonLauncherConfiguration,
+    PythonTransformLauncher,
+)
 from data_processing.launch.ray import RayTransformLauncher
-from data_processing.transform import AbstractTableTransform
+from data_processing.launch.ray.transform_configuration import RayTransformConfiguration
+from data_processing.transform import AbstractTableTransform, TransformConfiguration
 from data_processing.utils import get_logger
 from data_processing.utils.transform_utils import TransformUtils
 
@@ -202,11 +205,12 @@ class MalwareTransformConfiguration(TransformConfiguration):
 #             name="Malware", transform_class=MalwareTransform, launcher_configuration=MalwareTransformConfiguration()
 #         )
 #
-class MalwareRayLauncher(RayTransformLauncher):
+class MalwareRayTransformConfiguration(RayTransformConfiguration):
     def __init__(self):
         super().__init__(transform_config=MalwareTransformConfiguration())
 
+
 if __name__ == "__main__":
-    launcher = MalwareRayLauncher()
+    launcher = RayTransformLauncher(MalwareRayTransformConfiguration())
     logger.info("Launching malware transform")
     launcher.launch()

--- a/transforms/code/malware/test/test_malware_ray.py
+++ b/transforms/code/malware/test/test_malware_ray.py
@@ -15,11 +15,15 @@
 
 import os
 
-from data_processing.test_support.launch.transform_test import AbstractTransformLauncherTest
+from data_processing.launch.ray import RayTransformLauncher
+from data_processing.launch.ray.transform_configuration import RayTransformConfiguration
+from data_processing.test_support.launch.transform_test import (
+    AbstractTransformLauncherTest,
+)
 from malware_transform import (
     INPUT_COLUMN_KEY,
     OUTPUT_COLUMN_KEY,
-    MalwareRayLauncher,
+    MalwareRayTransformConfiguration,
 )
 
 
@@ -34,7 +38,7 @@ class TestRayNOOPTransform(AbstractTransformLauncherTest):
         basedir = os.path.abspath(os.path.join(os.path.dirname(__file__), basedir))
         fixtures = [
             (
-                MalwareRayLauncher(),
+                RayTransformLauncher(MalwareRayTransformConfiguration()),
                 {INPUT_COLUMN_KEY: "contents", OUTPUT_COLUMN_KEY: "virus_detection"},
                 basedir + "/input",
                 basedir + "/expected",

--- a/transforms/code/proglang_select/src/proglang_select_local_ray.py
+++ b/transforms/code/proglang_select/src/proglang_select_local_ray.py
@@ -13,13 +13,14 @@
 import os
 import sys
 
+from data_processing.launch.ray import RayTransformLauncher
 from data_processing.utils import ParamsUtils
 from proglang_select_transform import (
+    ProgLangSelectRayConfiguration,
     lang_allowed_langs_file_key,
     lang_lang_column_key,
-    lang_output_column_key, ProgLangSelectRayLauncher,
+    lang_output_column_key,
 )
-
 
 
 # create parameters
@@ -61,6 +62,6 @@ params = {
 if __name__ == "__main__":
     sys.argv = ParamsUtils.dict_to_req(d=params)
     # create launcher
-    launcher = ProgLangSelectRayLauncher()
+    launcher = RayTransformLauncher(ProgLangSelectRayConfiguration())
     # launch
     launcher.launch()

--- a/transforms/code/proglang_select/src/proglang_select_transform.py
+++ b/transforms/code/proglang_select/src/proglang_select_transform.py
@@ -20,13 +20,16 @@ from data_processing.data_access import (
     DataAccessFactory,
     DataAccessFactoryBase,
 )
-from data_processing.transform import TransformConfiguration
-from data_processing.launch.pure_python import PythonTransformLauncher, PythonLauncherConfiguration
+from data_processing.launch.pure_python import (
+    PythonLauncherConfiguration,
+    PythonTransformLauncher,
+)
 from data_processing.launch.ray import (
     DefaultTableTransformRuntimeRay,
     RayTransformLauncher,
 )
-from data_processing.transform import AbstractTableTransform
+from data_processing.launch.ray.transform_configuration import RayTransformConfiguration
+from data_processing.transform import AbstractTableTransform, TransformConfiguration
 from data_processing.utils import TransformUtils, get_logger
 from ray.actor import ActorHandle
 
@@ -237,10 +240,12 @@ class ProgLangSelectTransformConfiguration(TransformConfiguration):
 #         )
 #
 
-class ProgLangSelectRayLauncher(RayTransformLauncher):
+
+class ProgLangSelectRayConfiguration(RayTransformConfiguration):
     def __init__(self):
         super().__init__(ProgLangSelectTransformConfiguration(), ProgLangSelectRuntime)
 
+
 if __name__ == "__main__":
-    launcher = ProgLangSelectRayLauncher()
+    launcher = RayTransformLauncher(ProgLangSelectRayConfiguration())
     launcher.launch()

--- a/transforms/code/proglang_select/test/test_proglang_select_ray.py
+++ b/transforms/code/proglang_select/test/test_proglang_select_ray.py
@@ -12,12 +12,15 @@
 
 import os
 
-
-from data_processing.test_support.launch.transform_test import AbstractTransformLauncherTest
+from data_processing.launch.ray import RayTransformLauncher
+from data_processing.test_support.launch.transform_test import (
+    AbstractTransformLauncherTest,
+)
 from proglang_select_transform import (
+    ProgLangSelectRayConfiguration,
     lang_allowed_langs_file_key,
     lang_lang_column_key,
-    lang_output_column_key, ProgLangSelectRayLauncher,
+    lang_output_column_key,
 )
 
 
@@ -44,7 +47,7 @@ class TestRayProgLangSelectTransform(AbstractTransformLauncherTest):
         }
         fixtures = [
             (
-                ProgLangSelectRayLauncher(),
+                RayTransformLauncher(ProgLangSelectRayConfiguration()),
                 config,
                 basedir + "/input",
                 basedir + "/expected",

--- a/transforms/universal/doc_id/src/doc_id_local_ray.py
+++ b/transforms/universal/doc_id/src/doc_id_local_ray.py
@@ -13,8 +13,10 @@
 import os
 import sys
 
+from data_processing.launch.ray import RayTransformLauncher
 from data_processing.utils import ParamsUtils
-from doc_id_transform import DocIDRayLauncher
+from doc_id_transform import DocIDRayTransformConfiguration
+
 
 # create parameters
 input_folder = os.path.abspath(os.path.join(os.path.dirname(__file__), "../test-data/input"))
@@ -45,6 +47,6 @@ params = {
 sys.argv = ParamsUtils.dict_to_req(d=params)
 # create launcher
 
-launcher = DocIDRayLauncher()
+launcher = RayTransformLauncher(DocIDRayTransformConfiguration())
 # launch
 launcher.launch()

--- a/transforms/universal/doc_id/src/doc_id_s3_ray.py
+++ b/transforms/universal/doc_id/src/doc_id_s3_ray.py
@@ -12,13 +12,15 @@
 
 import sys
 
+from data_processing.launch.ray import RayTransformLauncher
 from data_processing.utils import ParamsUtils
-from doc_id_transform import DocIDRayLauncher
+from doc_id_transform import DocIDRayTransformConfiguration
+
 
 # create launcher
 
 
-launcher = DocIDRayLauncher()
+launcher = RayTransformLauncher(DocIDRayTransformConfiguration())
 # create parameters
 s3_cred = {
     "access_key": "localminioaccesskey",

--- a/transforms/universal/doc_id/src/doc_id_transform.py
+++ b/transforms/universal/doc_id/src/doc_id_transform.py
@@ -15,15 +15,17 @@ from typing import Any
 
 import pyarrow as pa
 import ray
-from data_processing.transform import TransformConfiguration
 from data_processing.data_access import DataAccessFactoryBase
-from data_processing.launch.pure_python import PythonTransformLauncher, PythonLauncherConfiguration
+from data_processing.launch.pure_python import (
+    PythonLauncherConfiguration,
+    PythonTransformLauncher,
+)
 from data_processing.launch.ray import (
     DefaultTableTransformRuntimeRay,
     RayTransformLauncher,
 )
-from data_processing.transform import AbstractTableTransform
-
+from data_processing.launch.ray.transform_configuration import RayTransformConfiguration
+from data_processing.transform import AbstractTableTransform, TransformConfiguration
 from data_processing.utils import CLIArgumentProvider, TransformUtils, get_logger
 from ray.actor import ActorHandle
 
@@ -196,30 +198,11 @@ class DocIDTransformConfiguration(TransformConfiguration):
         return True
 
 
-# class DocIDRayLauncherConfiguration(RayLauncherConfiguration):
-#
-#     """
-#     Provides support for configuring and using the associated Transform class include
-#     configuration with CLI args and combining of metadata.
-#     """
-#
-#     def __init__(self):
-#         super().__init__(
-#             transform_config = DocIDTransformConfiguration(),
-#             runtime_class=DocIDRuntime,
-#         )
-#
-
-# class DocIDPythonLauncherConfiguration(PythonLauncherConfiguration):
-#     def __init__(self):
-#         super().__init__(
-#             name=short_name, transform_class=DocIDTransform, launcher_configuration=DocIDTransformConfiguration()
-#         )
-#
-class DocIDRayLauncher(RayTransformLauncher):
+class DocIDRayTransformConfiguration(RayTransformConfiguration):
     def __init__(self):
         super().__init__(transform_config=DocIDTransformConfiguration(), runtime_class=DocIDRuntime)
 
+
 if __name__ == "__main__":
-    launcher = DocIDRayLauncher()
+    launcher = RayTransformLauncher(DocIDRayTransformConfiguration())
     launcher.launch()

--- a/transforms/universal/doc_id/test/test_doc_id_ray.py
+++ b/transforms/universal/doc_id/test/test_doc_id_ray.py
@@ -12,11 +12,15 @@
 
 import os
 
-from data_processing.test_support.launch.transform_test import AbstractTransformLauncherTest
+from data_processing.launch.ray import RayTransformLauncher
+from data_processing.test_support.launch.transform_test import (
+    AbstractTransformLauncherTest,
+)
 from doc_id_transform import (
+    DocIDRayTransformConfiguration,
     doc_column_name_cli_param,
     hash_column_name_cli_param,
-    int_column_name_cli_param, DocIDRayLauncher,
+    int_column_name_cli_param,
 )
 
 
@@ -34,6 +38,6 @@ class TestRayDocIDTransform(AbstractTransformLauncherTest):
             hash_column_name_cli_param: "doc_hash",
             int_column_name_cli_param: "doc_int",
         }
-        launcher = DocIDRayLauncher()
+        launcher = RayTransformLauncher(DocIDRayTransformConfiguration())
         fixtures.append((launcher, transform_config, basedir + "/input", basedir + "/expected"))
         return fixtures

--- a/transforms/universal/ededup/src/ededup_local_ray.py
+++ b/transforms/universal/ededup/src/ededup_local_ray.py
@@ -13,11 +13,13 @@
 import os
 import sys
 
+from data_processing.launch.ray import RayTransformLauncher
 from data_processing.utils import ParamsUtils
-from ededup_transform import EdedupRayLauncher
+from ededup_transform import EdedupRayTransformConfiguration
+
 
 # create launcher
-launcher = EdedupRayLauncher()
+launcher = RayTransformLauncher(EdedupRayTransformConfiguration())
 # create parameters
 input_folder = os.path.abspath(os.path.join(os.path.dirname(__file__), "../test-data/input"))
 output_folder = os.path.abspath(os.path.join(os.path.dirname(__file__), "../output"))

--- a/transforms/universal/ededup/src/ededup_s3_ray.py
+++ b/transforms/universal/ededup/src/ededup_s3_ray.py
@@ -12,11 +12,13 @@
 
 import sys
 
+from data_processing.launch.ray import RayTransformLauncher
 from data_processing.utils import ParamsUtils
-from ededup_transform import EdedupRayLauncher
+from ededup_transform import EdedupRayTransformConfiguration
+
 
 # create launcher
-launcher = EdedupRayLauncher()
+launcher = RayTransformLauncher(EdedupRayTransformConfiguration())
 # create parameters
 s3_cred = {
     "access_key": "localminioaccesskey",

--- a/transforms/universal/ededup/src/ededup_transform.py
+++ b/transforms/universal/ededup/src/ededup_transform.py
@@ -16,13 +16,13 @@ from typing import Any
 import pyarrow as pa
 import ray
 from data_processing.data_access import DataAccessFactoryBase
-from data_processing.transform import TransformConfiguration
 from data_processing.launch.ray import (
     DefaultTableTransformRuntimeRay,
-    RayUtils,
     RayTransformLauncher,
+    RayUtils,
 )
-from data_processing.transform import AbstractTableTransform
+from data_processing.launch.ray.transform_configuration import RayTransformConfiguration
+from data_processing.transform import AbstractTableTransform, TransformConfiguration
 from data_processing.utils import GB, CLIArgumentProvider, TransformUtils, get_logger
 from ray.actor import ActorHandle
 
@@ -223,6 +223,7 @@ class EdedupTableTransformConfiguration(TransformConfiguration):
     Provides support for configuring and using the associated Transform class include
     configuration with CLI args and combining of metadata.
     """
+
     def __init__(self):
         super().__init__(
             name=short_name,
@@ -251,10 +252,12 @@ class EdedupTableTransformConfiguration(TransformConfiguration):
         logger.info(f"exact dedup params are {self.params}")
         return True
 
-class EdedupRayLauncher(RayTransformLauncher):
+
+class EdedupRayTransformConfiguration(RayTransformConfiguration):
     def __init__(self):
         super().__init__(transform_config=EdedupTableTransformConfiguration(), runtime_class=EdedupRuntime)
 
+
 if __name__ == "__main__":
-    launcher = EdedupRayLauncher()
+    launcher = RayTransformLauncher(EdedupRayTransformConfiguration())
     launcher.launch()

--- a/transforms/universal/ededup/test/test_ededup_ray.py
+++ b/transforms/universal/ededup/test/test_ededup_ray.py
@@ -12,8 +12,11 @@
 
 import os
 
-from data_processing.test_support.launch.transform_test import AbstractTransformLauncherTest
-from ededup_transform import EdedupRayLauncher
+from data_processing.launch.ray import RayTransformLauncher
+from data_processing.test_support.launch.transform_test import (
+    AbstractTransformLauncherTest,
+)
+from ededup_transform import EdedupRayTransformConfiguration
 
 
 class TestRayBlocklistTransform(AbstractTransformLauncherTest):
@@ -31,6 +34,6 @@ class TestRayBlocklistTransform(AbstractTransformLauncherTest):
             "ededup_num_hashes": 2,
             "ededup_doc_column": "contents",
         }
-        launcher = EdedupRayLauncher()
+        launcher = RayTransformLauncher(EdedupRayTransformConfiguration())
         fixtures = [(launcher, config, basedir + "/input", basedir + "/expected")]
         return fixtures

--- a/transforms/universal/fdedup/src/fdedup_local_ray.py
+++ b/transforms/universal/fdedup/src/fdedup_local_ray.py
@@ -13,11 +13,13 @@
 import os
 import sys
 
+from data_processing.launch.ray import RayTransformLauncher
 from data_processing.utils import ParamsUtils
-from fdedup_transform import FdedupRayLauncher
+from fdedup_transform import FdedupRayTransformConfiguration
+
 
 # create launcher
-launcher = FdedupRayLauncher()
+launcher = RayTransformLauncher(FdedupRayTransformConfiguration())
 # create parameters
 input_folder = os.path.abspath(os.path.join(os.path.dirname(__file__), "../test-data/input"))
 output_folder = os.path.abspath(os.path.join(os.path.dirname(__file__), "../output"))

--- a/transforms/universal/fdedup/src/fdedup_s3_ray.py
+++ b/transforms/universal/fdedup/src/fdedup_s3_ray.py
@@ -12,11 +12,13 @@
 
 import sys
 
+from data_processing.launch.ray import RayTransformLauncher
 from data_processing.utils import ParamsUtils
-from fdedup_transform import FdedupRayLauncher
+from fdedup_transform import FdedupRayTransformConfiguration
+
 
 # create launcher
-launcher = FdedupRayLauncher()
+launcher = RayTransformLauncher(FdedupRayTransformConfiguration())
 # create parameters
 s3_cred = {
     "access_key": "localminioaccesskey",

--- a/transforms/universal/fdedup/src/fdedup_transform.py
+++ b/transforms/universal/fdedup/src/fdedup_transform.py
@@ -20,14 +20,14 @@ import numpy as np
 import pyarrow as pa
 import ray
 from data_processing.data_access import DataAccessFactoryBase
-from data_processing.transform import TransformConfiguration
 from data_processing.launch.ray import (
     DefaultTableTransformRuntimeRay,
-    RayUtils,
     RayTransformLauncher,
+    RayUtils,
     TransformTableProcessorRay,
 )
-from data_processing.transform import AbstractTableTransform
+from data_processing.launch.ray.transform_configuration import RayTransformConfiguration
+from data_processing.transform import AbstractTableTransform, TransformConfiguration
 from data_processing.utils import (
     RANDOM_SEED,
     CLIArgumentProvider,
@@ -794,10 +794,12 @@ class FdedupTableTransformConfiguration(TransformConfiguration):
         logger.info(f"fuzzy dedup params are {self.params}")
         return True
 
-class FdedupRayLauncher(RayTransformLauncher):
+
+class FdedupRayTransformConfiguration(RayTransformConfiguration):
     def __init__(self):
         super().__init__(transform_config=FdedupTableTransformConfiguration(), runtime_class=FdedupRuntime)
 
+
 if __name__ == "__main__":
-    launcher = FdedupRayLauncher()
+    launcher = RayTransformLauncher(FdedupRayTransformConfiguration())
     launcher.launch()

--- a/transforms/universal/fdedup/test/test_fdedup_ray.py
+++ b/transforms/universal/fdedup/test/test_fdedup_ray.py
@@ -12,9 +12,11 @@
 
 import os
 
-
-from data_processing.test_support.launch.transform_test import AbstractTransformLauncherTest
-from fdedup_transform import FdedupRayLauncher
+from data_processing.launch.ray import RayTransformLauncher
+from data_processing.test_support.launch.transform_test import (
+    AbstractTransformLauncherTest,
+)
+from fdedup_transform import FdedupRayTransformConfiguration
 
 
 class TestRayBlocklistTransform(AbstractTransformLauncherTest):
@@ -52,6 +54,6 @@ class TestRayBlocklistTransform(AbstractTransformLauncherTest):
             "fdedup_use_doc_snapshot": False,
             "fdedup_use_bucket_snapshot": False,
         }
-        launcher = FdedupRayLauncher()
+        launcher = RayTransformLauncher(FdedupRayTransformConfiguration())
         fixtures = [(launcher, config, basedir + "/input", basedir + "/expected")]
         return fixtures

--- a/transforms/universal/filter/src/filter_local_ray.py
+++ b/transforms/universal/filter/src/filter_local_ray.py
@@ -13,11 +13,13 @@
 import os
 import sys
 
+from data_processing.launch.ray import RayTransformLauncher
 from data_processing.utils import ParamsUtils
 from filter_transform import (
+    FilterRayTransformConfiguration,
     filter_columns_to_drop_cli_param,
     filter_criteria_cli_param,
-    filter_logical_operator_cli_param, FilterRayLauncher,
+    filter_logical_operator_cli_param,
 )
 
 
@@ -64,6 +66,6 @@ if __name__ == "__main__":
     # Create the CLI args as will be parsed by the launcher
     sys.argv = ParamsUtils.dict_to_req(launcher_params | filter_params)
     # Create the longer to launch with the blocklist transform.
-    launcher = FilterRayLauncher()
+    launcher = RayTransformLauncher(FilterRayTransformConfiguration())
     # Launch the ray actor(s) to process the input
     launcher.launch()

--- a/transforms/universal/filter/src/filter_s3_ray.py
+++ b/transforms/universal/filter/src/filter_s3_ray.py
@@ -12,11 +12,13 @@
 
 import sys
 
+from data_processing.launch.ray import RayTransformLauncher
 from data_processing.utils import ParamsUtils
 from filter_transform import (
+    FilterRayTransformConfiguration,
     filter_columns_to_drop_cli_param,
     filter_criteria_cli_param,
-    filter_logical_operator_cli_param, FilterRayLauncher,
+    filter_logical_operator_cli_param,
 )
 
 
@@ -67,6 +69,6 @@ if __name__ == "__main__":
     # Create the CLI args as will be parsed by the launcher
     sys.argv = ParamsUtils.dict_to_req(launcher_params | filter_params)
     # Create the longer to launch with the blocklist transform.
-    launcher = FilterRayLauncher()
+    launcher = RayTransformLauncher(FilterRayTransformConfiguration())
     # Launch the ray actor(s) to process the input
     launcher.launch()

--- a/transforms/universal/filter/src/filter_transform.py
+++ b/transforms/universal/filter/src/filter_transform.py
@@ -16,10 +16,13 @@ import json
 
 import duckdb
 import pyarrow as pa
-from data_processing.transform import TransformConfiguration
-from data_processing.launch.pure_python import PythonTransformLauncher, PythonLauncherConfiguration
+from data_processing.launch.pure_python import (
+    PythonLauncherConfiguration,
+    PythonTransformLauncher,
+)
 from data_processing.launch.ray import RayTransformLauncher
-from data_processing.transform import AbstractTableTransform
+from data_processing.launch.ray.transform_configuration import RayTransformConfiguration
+from data_processing.transform import AbstractTableTransform, TransformConfiguration
 from data_processing.utils import CLIArgumentProvider, get_logger
 
 
@@ -198,23 +201,12 @@ class FilterTransformConfiguration(TransformConfiguration):
         return True
 
 
-
-# class FilterPythonLauncherConfiguration(PythonLauncherConfiguration):
-#     """
-#     Provides support for configuring and using the associated Transform class include
-#     configuration with CLI args and combining of metadata.
-#     """
-#
-#     def __init__(self):
-#         super().__init__(
-#             name=short_name, transform_class=FilterTransform, launcher_configuration=FilterTransformConfiguration()
-#         )
-#
-class FilterRayLauncher(RayTransformLauncher):
+class FilterRayTransformConfiguration(RayTransformConfiguration):
     def __init__(self):
         super().__init__(transform_config=FilterTransformConfiguration())
 
+
 if __name__ == "__main__":
-    launcher = FilterRayLauncher()
+    launcher = RayTransformLauncher(FilterRayTransformConfiguration())
     logger.info("Launching filtering")
     launcher.launch()

--- a/transforms/universal/filter/test/test_filter_ray.py
+++ b/transforms/universal/filter/test/test_filter_ray.py
@@ -12,13 +12,16 @@
 
 import os
 
-
-from data_processing.test_support.launch.transform_test import AbstractTransformLauncherTest
+from data_processing.launch.ray import RayTransformLauncher
+from data_processing.test_support.launch.transform_test import (
+    AbstractTransformLauncherTest,
+)
 from filter_transform import (
+    FilterRayTransformConfiguration,
     filter_columns_to_drop_cli_param,
     filter_criteria_cli_param,
     filter_logical_operator_cli_param,
-    filter_logical_operator_default, FilterRayLauncher,
+    filter_logical_operator_default,
 )
 
 
@@ -34,7 +37,7 @@ class TestRayFilterTransform(AbstractTransformLauncherTest):
 
         fixtures.append(
             (
-                FilterRayLauncher(),
+                RayTransformLauncher(FilterRayTransformConfiguration()),
                 {
                     filter_criteria_cli_param: [
                         "docq_total_words > 100 AND docq_total_words < 200",
@@ -50,7 +53,7 @@ class TestRayFilterTransform(AbstractTransformLauncherTest):
 
         fixtures.append(
             (
-                FilterRayLauncher(),
+                RayTransformLauncher(FilterRayTransformConfiguration()),
                 {
                     filter_criteria_cli_param: [
                         "docq_total_words > 100 AND docq_total_words < 200",
@@ -66,7 +69,7 @@ class TestRayFilterTransform(AbstractTransformLauncherTest):
 
         fixtures.append(
             (
-                FilterRayLauncher(),
+                RayTransformLauncher(FilterRayTransformConfiguration()),
                 {
                     filter_criteria_cli_param: [],
                     filter_logical_operator_cli_param: filter_logical_operator_default,
@@ -79,7 +82,7 @@ class TestRayFilterTransform(AbstractTransformLauncherTest):
 
         fixtures.append(
             (
-                FilterRayLauncher(),
+                RayTransformLauncher(FilterRayTransformConfiguration()),
                 {
                     filter_criteria_cli_param: [
                         "date_acquired BETWEEN '2023-07-04' AND '2023-07-08'",
@@ -95,7 +98,7 @@ class TestRayFilterTransform(AbstractTransformLauncherTest):
 
         fixtures.append(
             (
-                FilterRayLauncher(),
+                RayTransformLauncher(FilterRayTransformConfiguration()),
                 {
                     filter_criteria_cli_param: [
                         "document IN ('CC-MAIN-20190221132217-20190221154217-00305.warc.gz', 'CC-MAIN-20200528232803-20200529022803-00154.warc.gz', 'CC-MAIN-20190617103006-20190617125006-00025.warc.gz')",

--- a/transforms/universal/noop/src/noop_local_ray.py
+++ b/transforms/universal/noop/src/noop_local_ray.py
@@ -13,8 +13,10 @@
 import os
 import sys
 
+from data_processing.launch.ray import RayTransformLauncher
 from data_processing.utils import ParamsUtils
-from noop_transform import NOOPRayLauncher
+from noop_transform import NOOPRayTransformConfiguration
+
 
 # create parameters
 input_folder = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "test-data", "input"))
@@ -44,6 +46,6 @@ if __name__ == "__main__":
     # Set the simulated command line args
     sys.argv = ParamsUtils.dict_to_req(d=params)
     # create launcher
-    launcher = NOOPRayLauncher()
+    launcher = RayTransformLauncher(NOOPRayTransformConfiguration())
     # Launch the ray actor(s) to process the input
     launcher.launch()

--- a/transforms/universal/noop/src/noop_s3_ray.py
+++ b/transforms/universal/noop/src/noop_s3_ray.py
@@ -13,12 +13,14 @@
 import os
 import sys
 
+from data_processing.launch.ray import RayTransformLauncher
 from data_processing.utils import ParamsUtils
-from noop_transform import NOOPRayLauncher
+from noop_transform import NOOPRayTransformConfiguration
+
 
 print(os.environ)
 # create launcher
-launcher =  NOOPRayLauncher()
+launcher = RayTransformLauncher(NOOPRayTransformConfiguration())
 # create parameters
 s3_cred = {
     "access_key": "localminioaccesskey",

--- a/transforms/universal/noop/src/noop_transform.py
+++ b/transforms/universal/noop/src/noop_transform.py
@@ -15,12 +15,13 @@ from argparse import ArgumentParser, Namespace
 from typing import Any
 
 import pyarrow as pa
-
-from data_processing.transform import TransformConfiguration
-from data_processing.launch.pure_python import PythonTransformLauncher, PythonLauncherConfiguration
+from data_processing.launch.pure_python import (
+    PythonLauncherConfiguration,
+    PythonTransformLauncher,
+)
 from data_processing.launch.ray import RayTransformLauncher
-from data_processing.transform import AbstractTableTransform
-
+from data_processing.launch.ray.transform_configuration import RayTransformConfiguration
+from data_processing.transform import AbstractTableTransform, TransformConfiguration
 from data_processing.utils import CLIArgumentProvider, get_logger
 
 
@@ -120,11 +121,21 @@ class NOOPTransformConfiguration(TransformConfiguration):
         self.params = self.params | captured
         logger.info(f"noop parameters are : {self.params}")
         return True
-class NOOPRayLauncher(RayTransformLauncher):
+
+
+class NOOPRayTransformConfiguration(RayTransformConfiguration):
+    """
+    Implements the RayTransformConfiguration for NOOP as required by the RayTransformLauncher.
+    NOOP does not use a RayRuntime class so the superclass only needs the base
+    python-only configuration.
+    """
+
     def __init__(self):
-        super().__init__(transform_config=NOOPTransformConfiguration())
+        super().__init__(NOOPTransformConfiguration())
+
 
 if __name__ == "__main__":
-    launcher = NOOPRayLauncher()
+    # launcher = NOOPRayLauncher()
+    launcher = RayTransformLauncher(NOOPRayTransformConfiguration())
     logger.info("Launching noop transform")
     launcher.launch()

--- a/transforms/universal/noop/test/test_noop_ray.py
+++ b/transforms/universal/noop/test/test_noop_ray.py
@@ -13,8 +13,15 @@
 import os
 
 from data_processing.launch.pure_python import PythonTransformLauncher
-from data_processing.test_support.launch.transform_test import AbstractTransformLauncherTest
-from noop_transform import sleep_cli_param, NOOPRayLauncher, NOOPTransformConfiguration
+from data_processing.launch.ray import RayTransformLauncher
+from data_processing.test_support.launch.transform_test import (
+    AbstractTransformLauncherTest,
+)
+from noop_transform import (
+    NOOPRayTransformConfiguration,
+    NOOPTransformConfiguration,
+    sleep_cli_param,
+)
 
 
 class TestRayNOOPTransform(AbstractTransformLauncherTest):
@@ -29,6 +36,7 @@ class TestRayNOOPTransform(AbstractTransformLauncherTest):
         fixtures = []
         launcher = PythonTransformLauncher(NOOPTransformConfiguration())
         fixtures.append((launcher, {sleep_cli_param: 0}, basedir + "/input", basedir + "/expected"))
-        launcher = NOOPRayLauncher()
+        # launcher = NOOPRayLauncher()
+        launcher = RayTransformLauncher(NOOPRayTransformConfiguration())
         fixtures.append((launcher, {sleep_cli_param: 0}, basedir + "/input", basedir + "/expected"))
         return fixtures

--- a/transforms/universal/tokenization/src/tokenization_local_ray.py
+++ b/transforms/universal/tokenization/src/tokenization_local_ray.py
@@ -13,8 +13,10 @@
 import os
 import sys
 
+from data_processing.launch.ray import RayTransformLauncher
 from data_processing.utils import ParamsUtils
-from tokenization_transform import TokenizationRayLauncher
+from tokenization_transform import TokenizationRayConfiguration
+
 
 # create parameters
 input_folder = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "test-data", "ds01", "input"))
@@ -42,6 +44,6 @@ if __name__ == "__main__":
 
     sys.argv = ParamsUtils.dict_to_req(d=params)
     # create launcher
-    launcher = TokenizationRayLauncher()
+    launcher = RayTransformLauncher(TokenizationRayConfiguration())
     # Launch the ray actor(s) to process the input
     launcher.launch()

--- a/transforms/universal/tokenization/src/tokenization_local_ray_long_doc.py
+++ b/transforms/universal/tokenization/src/tokenization_local_ray_long_doc.py
@@ -13,8 +13,10 @@
 import os
 import sys
 
+from data_processing.launch.ray import RayTransformLauncher
 from data_processing.utils import ParamsUtils
-from tokenization_transform import TokenizationRayLauncher
+from tokenization_transform import TokenizationRayConfiguration
+
 
 # create parameters
 input_folder = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "test-data", "ds02", "input"))
@@ -50,6 +52,6 @@ if __name__ == "__main__":
 
     sys.argv = ParamsUtils.dict_to_req(d=params)
     # create launcher
-    launcher = TokenizationRayLauncher()
+    launcher = RayTransformLauncher(TokenizationRayConfiguration())
     # Launch the ray actor(s) to process the input
     launcher.launch()

--- a/transforms/universal/tokenization/src/tokenization_s3_long_doc.py
+++ b/transforms/universal/tokenization/src/tokenization_s3_long_doc.py
@@ -12,8 +12,10 @@
 
 import sys
 
+from data_processing.launch.ray import RayTransformLauncher
 from data_processing.utils import ParamsUtils
-from tokenization_transform import TokenizationRayLauncher
+from tokenization_transform import TokenizationRayConfiguration
+
 
 # create parameters
 s3_cred = {
@@ -53,6 +55,6 @@ if __name__ == "__main__":
 
     sys.argv = ParamsUtils.dict_to_req(d=params)
     # create launcher
-    launcher = TokenizationRayLauncher()
+    launcher = RayTransformLauncher(TokenizationRayConfiguration())
     # Launch the ray actor(s) to process the input
     launcher.launch()

--- a/transforms/universal/tokenization/src/tokenization_s3_ray.py
+++ b/transforms/universal/tokenization/src/tokenization_s3_ray.py
@@ -13,12 +13,14 @@
 import os
 import sys
 
+from data_processing.launch.ray import RayTransformLauncher
 from data_processing.utils import ParamsUtils
-from tokenization_transform import TokenizationRayLauncher
+from tokenization_transform import TokenizationRayConfiguration
+
 
 print(os.environ)
 # create launcher
-launcher = TokenizationRayLauncher()
+launcher = RayTransformLauncher(TokenizationRayConfiguration())
 # create parameters
 s3_cred = {
     "access_key": "localminioaccesskey",

--- a/transforms/universal/tokenization/src/tokenization_transform.py
+++ b/transforms/universal/tokenization/src/tokenization_transform.py
@@ -20,9 +20,9 @@ from argparse import ArgumentParser, Namespace
 from typing import Any
 
 import pyarrow as pa
-from data_processing.transform import TransformConfiguration
 from data_processing.launch.ray import RayTransformLauncher
-from data_processing.transform import AbstractTableTransform
+from data_processing.launch.ray.transform_configuration import RayTransformConfiguration
+from data_processing.transform import AbstractTableTransform, TransformConfiguration
 from data_processing.utils import get_logger
 from tokenization_utils import is_valid_argument_string, load_tokenizer, split_text
 
@@ -285,11 +285,12 @@ class TokenizationTransformConfiguration(TransformConfiguration):
 #             launcher_configuration=TokenizationTransformConfiguration(),
 #         )
 #
-class TokenizationRayLauncher(RayTransformLauncher):
+class TokenizationRayConfiguration(RayTransformConfiguration):
     def __init__(self):
         super().__init__(transform_config=TokenizationTransformConfiguration())
 
+
 if __name__ == "__main__":
-    launcher = TokenizationRayLauncher()
+    launcher = RayTransformLauncher(TokenizationRayConfiguration())
     logger.info("Launching Tokenization transform")
     launcher.launch()

--- a/transforms/universal/tokenization/test/test_tokenization_launch_long_doc.py
+++ b/transforms/universal/tokenization/test/test_tokenization_launch_long_doc.py
@@ -12,9 +12,12 @@
 
 import os
 
+from data_processing.launch.ray import RayTransformLauncher
+from data_processing.test_support.launch.transform_test import (
+    AbstractTransformLauncherTest,
+)
+from tokenization_transform import TokenizationRayConfiguration
 
-from data_processing.test_support.launch.transform_test import AbstractTransformLauncherTest
-from tokenization_transform import TokenizationRayLauncher
 
 tkn_params = {
     "tkn_tokenizer": "hf-internal-testing/llama-tokenizer",
@@ -36,8 +39,6 @@ class TestRayTokenizationTransform(AbstractTransformLauncherTest):
     def get_test_transform_fixtures(self) -> list[tuple]:
         basedir = "../test-data"
         basedir = os.path.abspath(os.path.join(os.path.dirname(__file__), basedir))
-        launcher =TokenizationRayLauncher()
-        fixtures = [
-            (launcher, tkn_params, basedir + "/ds02/input", basedir + "/ds02/expected")
-        ]
+        launcher = RayTransformLauncher(TokenizationRayConfiguration())
+        fixtures = [(launcher, tkn_params, basedir + "/ds02/input", basedir + "/ds02/expected")]
         return fixtures

--- a/transforms/universal/tokenization/test/test_tokenization_ray.py
+++ b/transforms/universal/tokenization/test/test_tokenization_ray.py
@@ -12,9 +12,12 @@
 
 import os
 
+from data_processing.launch.ray import RayTransformLauncher
+from data_processing.test_support.launch.transform_test import (
+    AbstractTransformLauncherTest,
+)
+from tokenization_transform import TokenizationRayConfiguration
 
-from data_processing.test_support.launch.transform_test import AbstractTransformLauncherTest
-from tokenization_transform import TokenizationRayLauncher
 
 tkn_params = {
     "tkn_tokenizer": "hf-internal-testing/llama-tokenizer",
@@ -34,8 +37,6 @@ class TestRayTokenizationTransform(AbstractTransformLauncherTest):
     def get_test_transform_fixtures(self) -> list[tuple]:
         basedir = "../test-data"
         basedir = os.path.abspath(os.path.join(os.path.dirname(__file__), basedir))
-        launcher = TokenizationRayLauncher()
-        fixtures = [
-            (launcher, tkn_params, basedir + "/ds01/input", basedir + "/ds01/expected")
-        ]
+        launcher = RayTransformLauncher(TokenizationRayConfiguration())
+        fixtures = [(launcher, tkn_params, basedir + "/ds01/input", basedir + "/ds01/expected")]
         return fixtures


### PR DESCRIPTION
## Why are these changes needed?
Centralizes all transform configuration into a single configuration class for the ray launcher.

## Related issue number (if any).


