### PR TITLE
Tutorial README files fixes

### DIFF
--- a/data-processing-lib/doc/advanced-transform-tutorial.md
+++ b/data-processing-lib/doc/advanced-transform-tutorial.md
@@ -32,7 +32,7 @@ Finally, we show to use the command line to run the transform in a local ray clu
 
 One of the basic components of exact dedup implementation is a cache of hashes. That is why we will start
 from implementing this support actor. The implementation is fairly straight forward and can be
-found [here](../../transforms/universal/ededup/src/ededup_transform.py)
+found [here](../../transforms/universal/ededup/ray/src/ededup_transform.py)
 
 ## EdedupTransform
 
@@ -287,15 +287,14 @@ A single method `launch()` is then invoked to run the transform in a Ray cluster
 
 ## Running
 
-Assuming the above `main()` is placed in `ededup_transform.py` we can run the transform on data
-in COS as follows:
+> **Note:** You will need to run the setup commands in the [`README`](../ray/README.md) before running the following examples.
+
+Assuming the above `main()` is placed in `ededup_transform.py` we can run the transform on local data 
+as follows:
+
 
 ```shell
-python ededup_transform.py --hash_cpu 0.5 --num_hashes 2 --doc_column "contents" \
-  --run_locally True  \
-  --s3_cred "{'access_key': 'KEY', 'secret_key': 'SECRET', 'cos_url': 'https://s3.us-east.cloud-object-storage.appdomain.cloud'}" \
-  --s3_config "{'input_folder': 'cos-optimal-llm-pile/test/david/input/', 'output_folder': 'cos-optimal-llm-pile/test/david/output/'}"
+make run-cli-ray-sample
 ```
-This is a minimal set of options to run locally.
-See the [launcher options](ray-launcher-options) for a complete list of
+See the [launcher options](ray-launcher-options.md) for a complete list of
 transform-independent command line options.

--- a/data-processing-lib/doc/simplest-transform-tutorial.md
+++ b/data-processing-lib/doc/simplest-transform-tutorial.md
@@ -32,7 +32,7 @@ tutorial can be found in the
 
 Finally, we show how to use the command line to run the transform in a local ray cluster.
 
-> **Note:** You will need to run the setup commands in the [`../README`](..) before running the following examples.
+> **Note:** You will need to run the setup commands in the [`README`](../ray/README.md) before running the following examples.
 
 
 ## `NOOPTransform`
@@ -196,7 +196,7 @@ Assuming the above `main` code is placed in `noop_main.py` we can run the transf
 and create a temporary directory to hold the output:
 ```shell
 export DPK_REPOROOT=...
-export NOOP_INPUT=$DPK_REPOROOT/transforms/universal/noop/test-data/input
+export NOOP_INPUT=$DPK_REPOROOT/transforms/universal/noop/ray/test-data/input
 ```
 To run
 ```shell


### PR DESCRIPTION
Fixed some broken links in the 2 tutorials and changed the way to run the dedup example, to avoid using IBM COS. 

