### PR TITLE
small fixes

### DIFF
--- a/kfp/doc/setup.md
+++ b/kfp/doc/setup.md
@@ -74,7 +74,7 @@ You can create a Kind cluster with all required software installed using the fol
 from this main package directory or from the `kind` directory.
 If you do not want to upload the testing data into the locally deployed Minio, and reduce memory footprint, please set:
 ```bash
-export POPULATE_TEST_DATA ?= 0
+export POPULATE_TEST_DATA=0
 ```
 You can access the KFP dashboard at http://localhost:8080/ and the MinIO dashboard at http://localhost:8090/
 

--- a/kfp/superworkflows/Makefile
+++ b/kfp/superworkflows/Makefile
@@ -21,3 +21,9 @@ workflow-upload:
 .PHONY: workflow-reconcile-requirements
 workflow-reconcile-requirements:
 	$(MAKE) -C ray/kfp_v1 workflow-reconcile-requirements
+
+clean::
+
+build::
+
+test::


### PR DESCRIPTION
## Why are these changes needed?

fixes the export setting in the setup.md file, adds common make rules to the `kfp/superworkflows/Makefile`


