### PR TITLE
small changes to get ready for pdf

### DIFF
--- a/data-processing-lib/python/src/data_processing/data_access/data_access_factory_base.py
+++ b/data-processing-lib/python/src/data_processing/data_access/data_access_factory_base.py
@@ -38,6 +38,7 @@ class DataAccessFactoryBase(CLIArgumentProvider):
         self.max_files = -1
         self.n_samples = -1
         self.files_to_use = []
+        self.files_to_checkpoint = []
         self.cli_arg_prefix = cli_arg_prefix
         self.params = {}
         self.logger = get_logger(__name__ + str(uuid.uuid4()))

--- a/data-processing-lib/python/src/data_processing/runtime/transform_file_processor.py
+++ b/data-processing-lib/python/src/data_processing/runtime/transform_file_processor.py
@@ -59,8 +59,7 @@ class AbstractTransformFileProcessor:
             # execute local processing
             name_extension = TransformUtils.get_file_extension(f_name)
             self.logger.debug(f"Begin transforming file {f_name}")
-            out_files, stats = self.transform.transform_binary(
-                base_name=TransformUtils.get_file_basename(f_name), byte_array=filedata)
+            out_files, stats = self.transform.transform_binary(file_name=f_name, byte_array=filedata)
             self.logger.debug(f"Done transforming file {f_name}, got {len(out_files)} files")
             self.last_file_name = name_extension[0]
             self.last_file_name_next_index = None

--- a/data-processing-lib/python/src/data_processing/test_support/transform/binary_transform_test.py
+++ b/data-processing-lib/python/src/data_processing/test_support/transform/binary_transform_test.py
@@ -63,7 +63,7 @@ class AbstractBinaryTransformTest(AbstractTest):
         all_files_list = []
         all_metadata_list = []
         for in_file in in_binary_list:
-            files_list, metadata = transform.transform_binary(base_name=in_file[0], byte_array=in_file[1])
+            files_list, metadata = transform.transform_binary(file_name=in_file[0], byte_array=in_file[1])
             all_files_list.extend(files_list)
             all_metadata_list.append(metadata)
 

--- a/data-processing-lib/python/src/data_processing/test_support/transform/noop_transform.py
+++ b/data-processing-lib/python/src/data_processing/test_support/transform/noop_transform.py
@@ -50,7 +50,7 @@ class NOOPTransform(AbstractTableTransform):
         super().__init__(config)
         self.sleep = config.get("sleep_sec", 1)
 
-    def transform(self, table: pa.Table) -> tuple[list[pa.Table], dict[str, Any]]:
+    def transform(self, table: pa.Table, file_name: str = None) -> tuple[list[pa.Table], dict[str, Any]]:
         """
         Put Transform-specific to convert one Table to 0 or more tables. It also returns
         a dictionary of execution statistics - arbitrary dictionary

--- a/data-processing-lib/python/src/data_processing/transform/abstract_transform.py
+++ b/data-processing-lib/python/src/data_processing/transform/abstract_transform.py
@@ -5,11 +5,12 @@ DATA = TypeVar("DATA")
 
 
 class AbstractTransform(Generic[DATA]):
-    def transform(self, data: DATA) -> tuple[list[DATA], dict[str, Any]]:
+    def transform(self, data: DATA, file_name: str = None) -> tuple[list[DATA], dict[str, Any]]:
         """
         Converts input table into an output table.
         If there is an error, an exception must be raised - exit()ing is not generally allowed when running in Ray.
-        :param table: input table
+        :param data: input table
+        :param file_name: optional - name of the input file
         :return: a tuple of a list of 0 or more converted tables and a dictionary of statistics that will be
         propagated to metadata
         """

--- a/data-processing-lib/python/src/data_processing/transform/binary_transform.py
+++ b/data-processing-lib/python/src/data_processing/transform/binary_transform.py
@@ -32,12 +32,12 @@ class AbstractBinaryTransform(AbstractTransform[DATA]):
         """
         self.config = config
 
-    def transform_binary(self, base_name: str, byte_array: bytes) -> tuple[list[tuple[bytes, str]], dict[str, Any]]:
+    def transform_binary(self, file_name: str, byte_array: bytes) -> tuple[list[tuple[bytes, str]], dict[str, Any]]:
         """
         Converts input file into o or more output files.
         If there is an error, an exception must be raised - exit()ing is not generally allowed.
         :param byte_array: contents of the input file to be transformed.
-        :param base_name: the base name of the file containing the given byte_array.
+        :param file_name: the name of the file containing the given byte_array.
         :return: a tuple of a list of 0 or more tuples and a dictionary of statistics that will be propagated
                 to metadata.  Each element of the return list, is a tuple of the transformed bytes and a string
                 holding the extension to be used when writing out the new bytes.

--- a/data-processing-lib/python/src/data_processing/transform/table_transform.py
+++ b/data-processing-lib/python/src/data_processing/transform/table_transform.py
@@ -32,19 +32,19 @@ class AbstractTableTransform(AbstractBinaryTransform[pa.Table]):
         """
         super().__init__(config)
 
-    def transform_binary(self, base_name: str, byte_array: bytes) -> tuple[list[tuple[bytes, str]], dict[str, Any]]:
+    def transform_binary(self, file_name: str, byte_array: bytes) -> tuple[list[tuple[bytes, str]], dict[str, Any]]:
         """
         Converts input file into o or more output files.
         If there is an error, an exception must be raised - exit()ing is not generally allowed.
         :param byte_array: contents of the input file to be transformed.
-        :param base_name: the base name of the file containing the given byte_array.
+        :param file_name: the file name of the file containing the given byte_array.
         :return: a tuple of a list of 0 or more tuples and a dictionary of statistics that will be propagated
                 to metadata.  Each element of the return list, is a tuple of the transformed bytes and a string
                 holding the extension to be used when writing out the new bytes.
         """
         # validate extension
-        if TransformUtils.get_file_extension(base_name)[1] != ".parquet":
-            logger.warning(f"Get wrong file type {base_name}")
+        if TransformUtils.get_file_extension(file_name)[1] != ".parquet":
+            logger.warning(f"Get wrong file type {file_name}")
             return [], {"wrong file type": 1}
         # convert to table
         table = TransformUtils.convert_binary_to_arrow(data=byte_array)

--- a/data-processing-lib/python/src/data_processing/transform/table_transform.py
+++ b/data-processing-lib/python/src/data_processing/transform/table_transform.py
@@ -56,7 +56,7 @@ class AbstractTableTransform(AbstractBinaryTransform[pa.Table]):
             logger.warning(f"table is empty, skipping processing")
             return [], {"skipped empty tables": 1}
         # transform table
-        out_tables, stats = self.transform(table=table)
+        out_tables, stats = self.transform(table=table, file_name=file_name)
         # Add number of rows to stats
         stats = stats | {"source_doc_count": table.num_rows}
         # convert tables to files

--- a/transforms/code/code_quality/ray/src/code_quality_transform_ray.py
+++ b/transforms/code/code_quality/ray/src/code_quality_transform_ray.py
@@ -206,7 +206,7 @@ class CodeQualityTransform(AbstractTableTransform):
             self.code_quality["tokenizer"], use_auth_token=self.code_quality["hf_token"]
         )
 
-    def transform(self, table: pa.Table) -> tuple[list[pa.Table], dict]:
+    def transform(self, table: pa.Table, file_name: str = None) -> tuple[list[pa.Table], dict]:
         """
         Chain all preprocessing steps into one function to not fill cache.
         """

--- a/transforms/code/ingest_2_parquet/ray/src/ingest_2_parquet_local.py
+++ b/transforms/code/ingest_2_parquet/ray/src/ingest_2_parquet_local.py
@@ -49,6 +49,6 @@ if __name__ == "__main__":
     byte_array, _ = data_access.get_file(file_to_process)
     # Transform the table
     files_list, metadata = transform.transform_binary(
-        base_name=TransformUtils.get_file_basename(file_to_process), byte_array=byte_array)
+        file_name=file_to_process, byte_array=byte_array)
     print(f"Got {len(files_list)} output files")
     print(f"output metadata : {metadata}")

--- a/transforms/code/ingest_2_parquet/ray/src/ingest_2_parquet_transform_ray.py
+++ b/transforms/code/ingest_2_parquet/ray/src/ingest_2_parquet_transform_ray.py
@@ -95,13 +95,13 @@ class IngestToParquetTransform(AbstractBinaryTransform):
             lang = self.languages_supported.get(ext, lang)
         return lang
 
-    def transform_binary(self, base_name: str, byte_array: bytes) -> tuple[list[tuple[bytes, str]], dict[str, Any]]:
+    def transform_binary(self, file_name: str, byte_array: bytes) -> tuple[list[tuple[bytes, str]], dict[str, Any]]:
         """
         Converts raw data file (ZIP) to Parquet format
         """
         # We currently only process .zip files
-        if TransformUtils.get_file_extension(base_name)[1] != ".zip":
-            logger.warning(f"Got unsupported file type {base_name}, skipping")
+        if TransformUtils.get_file_extension(file_name)[1] != ".zip":
+            logger.warning(f"Got unsupported file type {file_name}, skipping")
             return [], {}
         data = []
         number_of_rows = 0
@@ -119,7 +119,7 @@ class IngestToParquetTransform(AbstractBinaryTransform):
                                 ext = TransformUtils.get_file_extension(member.filename)[1]
                                 row_data = {
                                     "title": member.filename,
-                                    "document": base_name,
+                                    "document": TransformUtils.get_file_basename(file_name),
                                     "contents": content_string,
                                     "document_id": TransformUtils.str_to_hash(content_string),
                                     "ext": ext,

--- a/transforms/code/ingest_2_parquet/ray/test/test_ingest_to_parquet.py
+++ b/transforms/code/ingest_2_parquet/ray/test/test_ingest_to_parquet.py
@@ -37,7 +37,7 @@ class TestIngestToParquetTransform(AbstractBinaryTransformTest):
         lang_supported_file = os.path.abspath(os.path.join(basedir, "languages/lang_extensions.json"))
         input_dir = os.path.join(basedir, "input")
         input_files = get_files_in_folder(input_dir, ".zip")
-        input_files = [(TransformUtils.get_file_basename(name), binary) for name, binary in input_files.items()]
+        input_files = [(name, binary) for name, binary in input_files.items()]
         expected_metadata_list = [{'number of rows': 2}, {'number of rows': 52}, {}]
         config = {
             ingest_supported_langs_file_key: lang_supported_file,

--- a/transforms/code/malware/ray/src/malware_transform_ray.py
+++ b/transforms/code/malware/ray/src/malware_transform_ray.py
@@ -102,7 +102,7 @@ class MalwareTransform(AbstractTableTransform):
                         raise err
         del cd
 
-    def transform(self, table: pa.Table) -> tuple[list[pa.Table], dict[str, Any]]:
+    def transform(self, table: pa.Table, file_name: str = None) -> tuple[list[pa.Table], dict[str, Any]]:
         """
         Put Transform-specific to convert one Table to 0 or more tables. It also returns
         a dictionary of execution statistics - arbitrary dictionary

--- a/transforms/code/proglang_select/ray/src/proglang_select_transform_ray.py
+++ b/transforms/code/proglang_select/ray/src/proglang_select_transform_ray.py
@@ -87,7 +87,7 @@ class ProgLangSelectTransform(AbstractTableTransform):
                 logger.info(f"Exception loading languages list from ray object storage {e}")
                 raise RuntimeError(f"exception loading from object storage for key {languages_include_ref}")
 
-    def transform(self, table: pa.Table) -> tuple[list[pa.Table], dict]:
+    def transform(self, table: pa.Table, file_name: str = None) -> tuple[list[pa.Table], dict]:
         """
         Select the rows for which the column `self.lang_column` has a value in the list `self.languages_include`.
         """

--- a/transforms/universal/doc_id/ray/src/doc_id_transform_ray.py
+++ b/transforms/universal/doc_id/ray/src/doc_id_transform_ray.py
@@ -93,7 +93,7 @@ class DocIDTransform(AbstractTableTransform):
                 "Integer id generation requested, but there is no id generating actor defined (are we running Ray?)."
             )
 
-    def transform(self, table: pa.Table) -> tuple[list[pa.Table], dict[str, Any]]:
+    def transform(self, table: pa.Table, file_name: str = None) -> tuple[list[pa.Table], dict[str, Any]]:
         """
         Put Transform-specific to convert one Table to 0 or more tables. It also returns
         a dictionary of execution statistics - arbitrary dictionary

--- a/transforms/universal/ededup/ray/src/ededup_transform_ray.py
+++ b/transforms/universal/ededup/ray/src/ededup_transform_ray.py
@@ -88,7 +88,7 @@ class EdedupTransform(AbstractTableTransform):
         self.doc_column = config.get("doc_column", "")
         self.hashes = config.get("hashes", [])
 
-    def transform(self, table: pa.Table) -> tuple[list[pa.Table], dict[str, Any]]:
+    def transform(self, table: pa.Table, file_name: str = None) -> tuple[list[pa.Table], dict[str, Any]]:
         """
         De duping table content.
         :param table: table

--- a/transforms/universal/fdedup/ray/src/fdedup_transform_ray.py
+++ b/transforms/universal/fdedup/ray/src/fdedup_transform_ray.py
@@ -168,7 +168,7 @@ class FdedupTransform(AbstractTableTransform):
         # wait for completion
         RayUtils.wait_for_execution_completion(replies=remote_replies)
 
-    def transform(self, table: pa.Table) -> tuple[list[pa.Table], dict[str, Any]]:
+    def transform(self, table: pa.Table, file_name: str = None) -> tuple[list[pa.Table], dict[str, Any]]:
         """
         Preprocessing table content.
         :param table: table
@@ -246,7 +246,7 @@ class FdedupFilter(AbstractTableTransform):
         self.docs = config.get("remote_docs", "")
         self.random_delay_limit = config.get("random_delay_limit", 10)
 
-    def transform(self, table: pa.Table) -> tuple[list[pa.Table], dict[str, Any]]:
+    def transform(self, table: pa.Table, file_name: str = None) -> tuple[list[pa.Table], dict[str, Any]]:
         """
         De duping (filtering) table content.
         :param table: table

--- a/transforms/universal/filter/python/src/filter_transform.py
+++ b/transforms/universal/filter/python/src/filter_transform.py
@@ -73,7 +73,7 @@ class FilterTransform(AbstractTableTransform):
         self.logical_operator = config.get(filter_logical_operator_key, filter_logical_operator_default)
         self.columns_to_drop = config.get(filter_columns_to_drop_key, filter_columns_to_drop_default)
 
-    def transform(self, table: pa.Table) -> tuple[list[pa.Table], dict]:
+    def transform(self, table: pa.Table, file_name: str = None) -> tuple[list[pa.Table], dict]:
         """
         This implementation filters the input table using a SQL statement and
         returns the filtered table and execution stats

--- a/transforms/universal/noop/python/src/noop_transform.py
+++ b/transforms/universal/noop/python/src/noop_transform.py
@@ -50,7 +50,7 @@ class NOOPTransform(AbstractTableTransform):
         super().__init__(config)
         self.sleep = config.get("sleep_sec", 1)
 
-    def transform(self, table: pa.Table) -> tuple[list[pa.Table], dict[str, Any]]:
+    def transform(self, table: pa.Table, file_name: str = None) -> tuple[list[pa.Table], dict[str, Any]]:
         """
         Put Transform-specific to convert one Table to 0 or more tables. It also returns
         a dictionary of execution statistics - arbitrary dictionary

--- a/transforms/universal/tokenization/python/src/tokenization_transform.py
+++ b/transforms/universal/tokenization/python/src/tokenization_transform.py
@@ -58,7 +58,7 @@ class TokenizationTransform(AbstractTableTransform):
         # overwrite tokenizer:
         self.tokenizer = load_tokenizer(tokenizer_name=self.tokenizer, tokenizer_args=self.tokenizer_args)
 
-    def transform(self, table: pa.Table) -> tuple[list[pa.Table], dict[str, Any]]:
+    def transform(self, table: pa.Table, file_name: str = None) -> tuple[list[pa.Table], dict[str, Any]]:
         """
         Put Transform-specific to convert one Table to 0 or more tables. It also returns
         a dictionary of execution statistics - arbitrary dictionary


### PR DESCRIPTION
## Why are these changes needed?

There are currently 2 main issues for implementing pdf conversion:
1. PDF conversion is based on 2 files - *.csv and *.pdf. So we do need to process them as a pair. Both files have the same name but two different extensions. The solution is to only read *.csv file and then convert the name to get a pdf extension. Something like this:
```
pdf_name = TransformUtils.get_file_extension(file_name)[0] + ".pdf" 
```
and then read a pdf file

2. As PDF is doing conversion from *.csv to *.parquet, the checkpointing is broken. Here checkpointing is fixed by:
    a. introducing a new parameter `files_to_checkpoint`. default is [.parquet]
    b. comparing just the full names without extensions for the purposes of checkpointing

## Related issue number (if any).


