### PR TITLE
add build-language job to build-images workflow

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -19,6 +19,16 @@ jobs:
               run: |
                   make -C data-processing-lib DOCKER=docker image 
                   make -C transforms/code DOCKER=docker test-image
+    build-language:
+        runs-on: ubuntu-latest
+        timeout-minutes: 30
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v4
+            - name: Build and Test Language Transforms
+              run: |
+                  make -C data-processing-lib DOCKER=docker image
+                  make -C transforms/language DOCKER=docker test-image
     build-universal:
         runs-on: ubuntu-latest
         timeout-minutes: 30

--- a/transforms/language/lang_id/python/src/lang_id_local.py
+++ b/transforms/language/lang_id/python/src/lang_id_local.py
@@ -40,6 +40,6 @@ if __name__ == "__main__":
     table = data_access.get_table(os.path.join(input_folder, "test_01.parquet"))
     print(f"input table: {table}")
     # Transform the table
-    table_list, metadata = transform.transform(table)
+    table_list, metadata = transform.transform(table[0])
     print(f"\noutput table: {table_list}")
     print(f"output metadata : {metadata}")

--- a/transforms/language/lang_id/python/src/lang_id_transform.py
+++ b/transforms/language/lang_id/python/src/lang_id_transform.py
@@ -53,7 +53,7 @@ class LangIdentificationTransform(AbstractTableTransform):
         )
         self.column_name = config.get(content_column_name_key)
 
-    def transform(self, table: pa.Table) -> tuple[list[pa.Table], dict[str, Any]]:
+    def transform(self, table: pa.Table, file_name: str = None) -> tuple[list[pa.Table], dict[str, Any]]:
         """
         Put Transform-specific to convert one Table to 0 or more tables. It also returns
         a dictionary of execution statistics - arbitrary dictionary


### PR DESCRIPTION
## Why are these changes needed?

To build images for language transforms. (Recently lang_id is added https://github.com/IBM/data-prep-kit/pull/256)

## Related issue number (if any).

https://github.com/IBM/data-prep-kit/issues/265
