### PR TITLE
Updated transform readmes to reference correct runtime when describing cli params.

### DIFF
--- a/transforms/language/lang_id/python/README.md
+++ b/transforms/language/lang_id/python/README.md
@@ -20,8 +20,7 @@ configuration for values are as follows:
 ## Running
 
 ### Launched Command Line Options 
-When running the transform with the Ray launcher (i.e. TransformLauncher),
-the following command line arguments are available in addition to 
+The following command line arguments are available in addition to 
 the options provided by 
 the [python launcher](../../../../data-processing-lib/doc/python-launcher-options.md).
 ```

--- a/transforms/universal/filter/python/README.md
+++ b/transforms/universal/filter/python/README.md
@@ -233,10 +233,9 @@ As shown in the output of the local run of filtering, the metadata contains seve
 ## Running
 
 ### Launched Command Line Options 
-When running the transform with the Ray launcher (i.e. TransformLauncher),
-the following command line arguments are available in addition to 
-the options provided by the [ray launcher](../../../../data-processing-lib/doc/ray-launcher-options.md)
-and the [python launcher](../../../../data-processing-lib/doc/python-launcher-options.md).
+The following command line arguments are available in addition to 
+the options provided by 
+the [python launcher](../../../../data-processing-lib/doc/python-launcher-options.md).
 
 ```
   --filter_criteria_list FILTER_CRITERIA_LIST

--- a/transforms/universal/filter/ray/README.md
+++ b/transforms/universal/filter/ray/README.md
@@ -15,7 +15,6 @@ Noop configuration and command line options are the same as for the base python 
 ## Running
 
 ### Launched Command Line Options 
-When running the transform with the Ray launcher (i.e. TransformLauncher),
 In addition to those available to the transform as defined in [here](../python/README.md),
 the set of 
 [ray launcher](../../../../data-processing-lib/doc/ray-launcher-options.md) are available.

--- a/transforms/universal/noop/python/README.md
+++ b/transforms/universal/noop/python/README.md
@@ -26,8 +26,7 @@ as an example of metadata that we want to not include in logging.
 ## Running
 
 ### Launched Command Line Options 
-When running the transform with the Ray launcher (i.e. TransformLauncher),
-the following command line arguments are available in addition to 
+The following command line arguments are available in addition to 
 the options provided by 
 the [python launcher](../../../../data-processing-lib/doc/python-launcher-options.md).
 ```

--- a/transforms/universal/noop/ray/README.md
+++ b/transforms/universal/noop/ray/README.md
@@ -14,7 +14,6 @@ Noop configuration and command line options are the same as for the base python 
 ## Running
 
 ### Launched Command Line Options 
-When running the transform with the Ray launcher (i.e. TransformLauncher),
 In addition to those available to the transform as defined in [here](../python/README.md),
 the set of 
 [ray launcher](../../../../data-processing-lib/doc/ray-launcher-options.md) are available.

--- a/transforms/universal/noop/spark/README.md
+++ b/transforms/universal/noop/spark/README.md
@@ -14,7 +14,6 @@ Noop configuration and command line options are the same as for the base python 
 ## Running
 
 ### Launched Command Line Options
-When running the transform with the Ray launcher (i.e. TransformLauncher),
 In addition to those available to the transform as defined in [here](../python/README.md),
 the set of
 [spark launcher](../../../../data-processing-lib/doc/spark-launcher-options.md) are available.
@@ -23,8 +22,7 @@ the set of
 To run the samples, use the following `make` targets
 
 * `run-cli-sample` - runs src/noop_transform.py using command line args
-* `run-local-sample` - runs src/noop_local_ray.py
-* `run-s3-sample` - runs src/noop_s3_ray.py
+* `run-local-sample` - runs src/noop_local_spark.py
     * Requires prior invocation of `make minio-start` to load data into local minio for S3 access.
 
 These targets will activate the virtual environment and set up any configuration needed.

--- a/transforms/universal/tokenization/python/README.md
+++ b/transforms/universal/tokenization/python/README.md
@@ -54,8 +54,7 @@ By default, the value of `--tkn_chunk_size` is `0`, indicating that each documen
 ## Running
 
 ### CLI Options
-When running the transform with the Python launcher,
-the following command line arguments are available in addition to 
+The following command line arguments are available in addition to 
 the options provided by the [python launcher](../../../../data-processing-lib/doc/python-launcher-options.md)
 and the [python launcher](../../../../data-processing-lib/doc/python-launcher-options.md).
 ```

--- a/transforms/universal/tokenization/ray/README.md
+++ b/transforms/universal/tokenization/ray/README.md
@@ -14,7 +14,6 @@ Noop configuration and command line options are the same as for the base python 
 ## Running
 
 ### Launched Command Line Options 
-When running the transform with the Ray launcher (i.e. TransformLauncher),
 In addition to those available to the transform as defined in [here](../python/README.md),
 the set of 
 [ray launcher](../../../../data-processing-lib/doc/ray-launcher-options.md) are available.


### PR DESCRIPTION

## Why are these changes needed?
Doc correctness.

## Related issue number (if any).


