### PR TITLE
Update advanced-transform-tutorial.md

### DIFF
--- a/data-processing-lib/doc/advanced-transform-tutorial.md
+++ b/data-processing-lib/doc/advanced-transform-tutorial.md
@@ -294,7 +294,7 @@ as follows:
 
 
 ```shell
-make run-cli-ray-sample
+make run-cli-sample
 ```
 See the [launcher options](ray-launcher-options.md) for a complete list of
 transform-independent command line options.


### PR DESCRIPTION
We have now changed the make option from **run-cli-ray-sample** to **run-cli-sample**, hence the needed change in the README file.  


