### PR TITLE
Installation of minio added to the transform README files

### DIFF
--- a/transforms/code/code_quality/ray/README.md
+++ b/transforms/code/code_quality/ray/README.md
@@ -53,7 +53,9 @@ To run the samples, use the following `make` targets
 * `run-cli-ray-sample` - runs src/code_quality_transform.py using command line args
 * `run-local-ray-sample` - runs src/code_quality_local_ray.py
 * `run-s3-ray-sample` - runs src/code_quality_s3_ray.py
-    * Requires prior invocation of `make minio-start` to load data into local minio for S3 access.
+    * Requires prior installation of minio, depending on your platform (e.g., from [here](https://min.io/docs/minio/macos/index.html)
+     and [here](https://min.io/docs/minio/linux/index.html) 
+     and invocation of `make minio-start` to load data into local minio for S3 access.
 
 These targets will activate the virtual environment and set up any configuration needed.
 Use the `-n` option of `make` to see the detail of what is done to run the sample.

--- a/transforms/code/proglang_select/ray/README.md
+++ b/transforms/code/proglang_select/ray/README.md
@@ -60,7 +60,9 @@ To run the samples, use the following `make` targets
 * `run-local-sample` - runs src/proglang_select_local.py
 * `run-local-ray-sample` - runs src/proglang_select_local_ray.py
 * `run-s3-ray-sample` - runs src/proglang_select_s3_ray.py
-    * Requires prior invocation of `make minio-start` to load data into local minio for S3 access.
+    * Requires prior installation of minio, depending on your platform (e.g., from [here](https://min.io/docs/minio/macos/index.html)
+     and [here](https://min.io/docs/minio/linux/index.html) 
+     and invocation of `make minio-start` to load data into local minio for S3 access.
 
 These targets will activate the virtual environment and set up any configuration needed.
 Use the `-n` option of `make` to see the detail of what is done to run the sample.

--- a/transforms/language/lang_id/ray/README.md
+++ b/transforms/language/lang_id/ray/README.md
@@ -25,7 +25,9 @@ To run the samples, use the following `make` targets
 * `run-cli-sample` - runs src/lang_id_transform.py using command line args
 * `run-local-sample` - runs src/lang_id_local_ray.py
 * `run-s3-sample` - runs src/lang_id_s3_ray.py
-    * Requires prior invocation of `make minio-start` to load data into local minio for S3 access.
+    * Requires prior installation of minio, depending on your platform (e.g., from [here](https://min.io/docs/minio/macos/index.html)
+     and [here](https://min.io/docs/minio/linux/index.html) 
+     and invocation of `make minio-start` to load data into local minio for S3 access.
 
 These targets will activate the virtual environment and set up any configuration needed.
 Use the `-n` option of `make` to see the detail of what is done to run the sample.

--- a/transforms/universal/doc_id/ray/Readme.md
+++ b/transforms/universal/doc_id/ray/Readme.md
@@ -66,7 +66,9 @@ To run the samples, use the following `make` targets
 * `run-local-sample` - runs src/doc_id_local.py
 * `run-local-python-only-sample` - runs src/doc_id_local_ray.py
 * `run-s3-sample` - runs src/doc_id_s3_ray.py
-    * Requires prior invocation of `make minio-start` to load data into local minio for S3 access.
+    * Requires prior installation of minio, depending on your platform (e.g., from [here](https://min.io/docs/minio/macos/index.html)
+     and [here](https://min.io/docs/minio/linux/index.html) 
+     and invocation of `make minio-start` to load data into local minio for S3 access.
 
 These targets will activate the virtual environment and set up any configuration needed.
 Use the `-n` option of `make` to see the detail of what is done to run the sample.

--- a/transforms/universal/ededup/ray/Readme.md
+++ b/transforms/universal/ededup/ray/Readme.md
@@ -72,7 +72,9 @@ To run the samples, use the following `make` targets
 * `run-cli-sample` - runs src/ededup_transform_ray.py using command line args
 * `run-local-sample` - runs src/ededup_local_ray.py
 * `run-s3-sample` - runs src/ededup_s3_ray.py
-    * Requires prior invocation of `make minio-start` to load data into local minio for S3 access.
+    * Requires prior installation of minio, depending on your platform (e.g., from [here](https://min.io/docs/minio/macos/index.html)
+     and [here](https://min.io/docs/minio/linux/index.html) 
+     and invocation of `make minio-start` to load data into local minio for S3 access.
 
 These targets will activate the virtual environment and set up any configuration needed.
 Use the `-n` option of `make` to see the detail of what is done to run the sample.

--- a/transforms/universal/fdedup/ray/Readme.md
+++ b/transforms/universal/fdedup/ray/Readme.md
@@ -167,7 +167,9 @@ To run the samples, use the following `make` targets
 * `run-cli-sample` - runs src/fdedup_transform_ray.py using command line args
 * `run-local-sample` - runs src/fdedup_local_ray.py
 * `run-s3-sample` - runs src/fdedup_s3_ray.py
-    * Requires prior invocation of `make minio-start` to load data into local minio for S3 access.
+    * Requires prior installation of minio, depending on your platform (e.g., from [here](https://min.io/docs/minio/macos/index.html)
+     and [here](https://min.io/docs/minio/linux/index.html) 
+     and invocation of `make minio-start` to load data into local minio for S3 access.
 
 These targets will activate the virtual environment and set up any configuration needed.
 Use the `-n` option of `make` to see the detail of what is done to run the sample.

--- a/transforms/universal/filter/python/README.md
+++ b/transforms/universal/filter/python/README.md
@@ -260,7 +260,9 @@ To run the samples, use the following `make` targets
 * `run-local-python-only-sample` - runs src/filter_local.py
 * `run-local-sample` - runs src/filter_local_ray.py
 * `run-s3-sample` - runs src/filter_s3_ray.py
-    * Requires prior invocation of `make minio-start` to load data into local minio for S3 access.
+    * Requires prior installation of minio, depending on your platform (e.g., from [here](https://min.io/docs/minio/macos/index.html)
+     and [here](https://min.io/docs/minio/linux/index.html) 
+     and invocation of `make minio-start` to load data into local minio for S3 access.
 
 These targets will activate the virtual environment and set up any configuration needed.
 Use the `-n` option of `make` to see the detail of what is done to run the sample.

--- a/transforms/universal/filter/ray/README.md
+++ b/transforms/universal/filter/ray/README.md
@@ -25,7 +25,9 @@ To run the samples, use the following `make` targets
 * `run-cli-sample` - runs src/filter_transform.py using command line args
 * `run-local-sample` - runs src/filter_local_ray.py
 * `run-s3-sample` - runs src/filter_s3_ray.py
-    * Requires prior invocation of `make minio-start` to load data into local minio for S3 access.
+    * Requires prior installation of minio, depending on your platform (e.g., from [here](https://min.io/docs/minio/macos/index.html)
+     and [here](https://min.io/docs/minio/linux/index.html) 
+     and invocation of `make minio-start` to load data into local minio for S3 access.
 
 These targets will activate the virtual environment and set up any configuration needed.
 Use the `-n` option of `make` to see the detail of what is done to run the sample.

--- a/transforms/universal/noop/ray/README.md
+++ b/transforms/universal/noop/ray/README.md
@@ -24,7 +24,9 @@ To run the samples, use the following `make` targets
 * `run-cli-sample` - runs src/noop_transform.py using command line args
 * `run-local-sample` - runs src/noop_local_ray.py
 * `run-s3-sample` - runs src/noop_s3_ray.py
-    * Requires prior invocation of `make minio-start` to load data into local minio for S3 access.
+    * Requires prior installation of minio, depending on your platform (e.g., from [here](https://min.io/docs/minio/macos/index.html)
+     and [here](https://min.io/docs/minio/linux/index.html) 
+     and invocation of `make minio-start` to load data into local minio for S3 access.
 
 These targets will activate the virtual environment and set up any configuration needed.
 Use the `-n` option of `make` to see the detail of what is done to run the sample.

--- a/transforms/universal/noop/spark/README.md
+++ b/transforms/universal/noop/spark/README.md
@@ -23,7 +23,9 @@ To run the samples, use the following `make` targets
 
 * `run-cli-sample` - runs src/noop_transform.py using command line args
 * `run-local-sample` - runs src/noop_local_spark.py
-    * Requires prior invocation of `make minio-start` to load data into local minio for S3 access.
+    * Requires prior installation of minio, depending on your platform (e.g., from [here](https://min.io/docs/minio/macos/index.html)
+     and [here](https://min.io/docs/minio/linux/index.html) 
+     and invocation of `make minio-start` to load data into local minio for S3 access.
 
 These targets will activate the virtual environment and set up any configuration needed.
 Use the `-n` option of `make` to see the detail of what is done to run the sample.

--- a/transforms/universal/profiler/ray/Readme.md
+++ b/transforms/universal/profiler/ray/Readme.md
@@ -63,7 +63,9 @@ To run the samples, use the following `make` targets
 * `run-cli-sample` - runs src/ededup_transform_ray.py using command line args
 * `run-local-sample` - runs src/ededup_local_ray.py
 * `run-s3-sample` - runs src/ededup_s3_ray.py
-    * Requires prior invocation of `make minio-start` to load data into local minio for S3 access.
+    * Requires prior installation of minio, depending on your platform (e.g., from [here](https://min.io/docs/minio/macos/index.html)
+     and [here](https://min.io/docs/minio/linux/index.html) 
+     and invocation of `make minio-start` to load data into local minio for S3 access.
 
 These targets will activate the virtual environment and set up any configuration needed.
 Use the `-n` option of `make` to see the detail of what is done to run the sample.

--- a/transforms/universal/tokenization/ray/README.md
+++ b/transforms/universal/tokenization/ray/README.md
@@ -24,7 +24,9 @@ To run the samples, use the following `make` targets
 * `run-cli-sample` - runs src/tokenization_transform_ray.py using command line args
 * `run-local-sample` - runs src/tokenization_local_ray.py
 * `run-s3-sample` - runs src/filter_s3_ray.py
-    * Requires prior invocation of `make minio-start` to load data into local minio for S3 access.
+    * Requires prior installation of minio, depending on your platform (e.g., from [here](https://min.io/docs/minio/macos/index.html)
+     and [here](https://min.io/docs/minio/linux/index.html) 
+     and invocation of `make minio-start` to load data into local minio for S3 access.
 
 These targets will activate the virtual environment and set up any configuration needed.
 Use the `-n` option of `make` to see the detail of what is done to run the sample.


### PR DESCRIPTION
In the transform README files, with the S3 option, we need to add a sentence about installing minio as a pre-requisite. 





