### PR TITLE
Fix make run-cli-sample for code2parquet

### DIFF
--- a/transforms/code/code2parquet/python/Makefile
+++ b/transforms/code/code2parquet/python/Makefile
@@ -43,7 +43,14 @@ publish-dist:: .defaults.publish-dist
 
 test-image:: .transforms.python-test-image
 
-run-cli-sample: .transforms.run-cli-python-sample
+run-cli-sample: 
+	$(MAKE) RUN_FILE=$(TRANSFORM_NAME)_transform_python.py \
+	    RUN_ARGS="	\
+	    --data_local_config \" { 'input_folder' : '../test-data/input', 'output_folder' : '../output' } \"  \
+	    --data_files_to_use \"['.zip']\"  \
+	    --code2parquet_supported_langs_file ../test-data/languages/lang_extensions.json     \
+	    --code2parquet_detect_programming_lang True "       \
+	    .transforms.run-src-file
 
 run-local-sample: .transforms.run-local-sample
 

--- a/transforms/code/code2parquet/ray/Makefile
+++ b/transforms/code/code2parquet/ray/Makefile
@@ -40,7 +40,14 @@ build-dist:: set-versions .defaults.build-dist
 
 publish-dist:: .defaults.publish-dist
 
-run-cli-sample: .transforms.run-cli-ray-sample
+run-cli-sample: 
+	$(MAKE) RUN_FILE=$(TRANSFORM_NAME)_transform_ray.py \
+	    RUN_ARGS="--run_locally True \
+	    --data_local_config \" { 'input_folder' : '../test-data/input', 'output_folder' : '../output' } \"	\
+	    --data_files_to_use \"['.zip']\"  \
+	    --code2parquet_supported_langs_file ../test-data/languages/lang_extensions.json	\
+	    --code2parquet_detect_programming_lang True	"	\
+	    .transforms.run-src-file
 
 run-local-sample: .transforms.run-local-ray-sample
 


### PR DESCRIPTION
## Why are these changes needed?
Minor change to get the `run-cli-sample` targets working for code2parquet transform.

## Related issue number (if any).


