### PR TITLE
Build libs for kfp v1 and v2 in the release.

### DIFF
--- a/kfp/kfp_support_lib/kfp_v1_workflow_support/Makefile
+++ b/kfp/kfp_support_lib/kfp_v1_workflow_support/Makefile
@@ -40,11 +40,16 @@ endif
 build-dist :: set-versions .defaults.build-dist
 
 publish:: .check-env
+ifeq ($(KFPv2), 1)
+	# we want to prevent execution of the rule, when we run `make build` in upper directories and KFPv2==1
+	echo "Skipping publish as KFPv2 is defined"
+else
 	@# Help: Publish the wheel to testpypi
 	if [ -d "dist"]; then rm -r dist; fi
 	${PYTHON} -m pip install --upgrade build
 	${PYTHON} -m twine check dist/*
 	${PYTHON} -m twine upload --verbose --non-interactive dist/*
+endif
 
 .PHONY: venv
 venv:

--- a/kfp/kfp_support_lib/kfp_v1_workflow_support/Makefile
+++ b/kfp/kfp_support_lib/kfp_v1_workflow_support/Makefile
@@ -29,37 +29,22 @@ set-versions:
 	mv tt.toml pyproject.toml
 
 build:: set-versions venv
-ifeq ($(KFPv2), 1)
-	# we want to prevent execution of the rule, when we run `make build` in upper directories and KFPv2==1
-	echo "Skipping build as KFPv2 is defined"
-else
 	@# Help: Build the distribution for publishing to a pypi
 	$(MAKE) build-dist
-endif
 
 build-dist :: set-versions .defaults.build-dist
 
 publish::
-ifeq ($(KFPv2), 1)
-	# we want to prevent execution of the rule, when we run `make publish` in upper directories and KFPv2==1
-	echo "Skipping publish as KFPv2 is defined"
-else
 	$(MAKE) publish-dist
-endif
 
 publish-dist :: .check-env .defaults.publish-dist
 
 .PHONY: venv
 venv:
-ifeq ($(KFPv2), 1)
-	# we want to prevent execution of the rule, when we run `make venv` in upper directories and KFPv2==1
-	echo "Skipping as KFPv2 is defined"
-else
 	@# Help: Create the virtual environment using pyproject.toml
 	$(MAKE) .defaults.create-venv .defaults.install-ray-lib-src-venv
 	@source venv/bin/activate; pip install -e ${REPOROOT}/kfp/kfp_support_lib/shared_workflow_support
 	$(MAKE) .defaults.install-local-requirements-venv
-endif
 
 test:: venv 
 ifeq ($(KFPv2), 1)

--- a/kfp/kfp_support_lib/kfp_v1_workflow_support/Makefile
+++ b/kfp/kfp_support_lib/kfp_v1_workflow_support/Makefile
@@ -41,7 +41,7 @@ build-dist :: set-versions .defaults.build-dist
 
 publish:: .check-env
 ifeq ($(KFPv2), 1)
-	# we want to prevent execution of the rule, when we run `make build` in upper directories and KFPv2==1
+	# we want to prevent execution of the rule, when we run `make publish` in upper directories and KFPv2==1
 	echo "Skipping publish as KFPv2 is defined"
 else
 	@# Help: Publish the wheel to testpypi

--- a/kfp/kfp_support_lib/kfp_v1_workflow_support/Makefile
+++ b/kfp/kfp_support_lib/kfp_v1_workflow_support/Makefile
@@ -39,17 +39,15 @@ endif
 
 build-dist :: set-versions .defaults.build-dist
 
-publish:: .check-env
+publish::
 ifeq ($(KFPv2), 1)
 	# we want to prevent execution of the rule, when we run `make publish` in upper directories and KFPv2==1
 	echo "Skipping publish as KFPv2 is defined"
 else
-	@# Help: Publish the wheel to testpypi
-	if [ -d "dist"]; then rm -r dist; fi
-	${PYTHON} -m pip install --upgrade build
-	${PYTHON} -m twine check dist/*
-	${PYTHON} -m twine upload --verbose --non-interactive dist/*
+	$(MAKE) publish-dist
 endif
+
+publish-dist :: .check-env .defaults.publish-dist
 
 .PHONY: venv
 venv:

--- a/kfp/kfp_support_lib/kfp_v2_workflow_support/Makefile
+++ b/kfp/kfp_support_lib/kfp_v2_workflow_support/Makefile
@@ -41,7 +41,7 @@ build-dist :: set-versions .defaults.build-dist
 
 publish:: .check-env
 ifneq ($(KFPv2), 1)
-	# we want to prevent execution of the rule, when we run `make build` in upper directories and KFPv2 is not set
+	# we want to prevent execution of the rule, when we run `make publish` in upper directories and KFPv2 is not set
 	echo "Skipping publish as KFPv2 is not defined"
 else
 	@# Help: Publish the wheel to testpypi

--- a/kfp/kfp_support_lib/kfp_v2_workflow_support/Makefile
+++ b/kfp/kfp_support_lib/kfp_v2_workflow_support/Makefile
@@ -39,17 +39,15 @@ endif
 
 build-dist :: set-versions .defaults.build-dist
 
-publish:: .check-env
+publish::
 ifneq ($(KFPv2), 1)
 	# we want to prevent execution of the rule, when we run `make publish` in upper directories and KFPv2 is not set
 	echo "Skipping publish as KFPv2 is not defined"
 else
-	@# Help: Publish the wheel to testpypi
-	if [ -d "dist"]; then rm -r dist; fi
-	${PYTHON} -m pip install --upgrade build
-	${PYTHON} -m twine check dist/*
-	${PYTHON} -m twine upload --verbose --non-interactive dist/*
+	$(MAKE) publish-dist
 endif
+
+publish-dist :: .check-env .defaults.publish-dist
 
 .PHONY: venv
 venv:

--- a/kfp/kfp_support_lib/kfp_v2_workflow_support/Makefile
+++ b/kfp/kfp_support_lib/kfp_v2_workflow_support/Makefile
@@ -29,37 +29,22 @@ set-versions:
 	mv tt.toml pyproject.toml
 
 build:: set-versions venv
-ifneq ($(KFPv2), 1)
-	# we want to prevent execution of the rule, when we run `make build` in upper directories and KFPv2 is not set
-	echo "Skipping build as KFPv2 is not defined"
-else
 	@# Help: Build the distribution for publishing to a pypi
 	$(MAKE) build-dist
-endif
 
 build-dist :: set-versions .defaults.build-dist
 
 publish::
-ifneq ($(KFPv2), 1)
-	# we want to prevent execution of the rule, when we run `make publish` in upper directories and KFPv2 is not set
-	echo "Skipping publish as KFPv2 is not defined"
-else
 	$(MAKE) publish-dist
-endif
 
 publish-dist :: .check-env .defaults.publish-dist
 
 .PHONY: venv
 venv:
-ifneq ($(KFPv2), 1)
-	# we want to prevent execution of the rule, when we run `make venv` in upper directories and KFPv2 is not set
-	echo "Skipping venv as KFPv2 is not defined"
-else
 	@# Help: Create the virtual environment using pyproject.toml
 	$(MAKE) .defaults.create-venv .defaults.install-ray-lib-src-venv
 	@source venv/bin/activate; pip install -e ${REPOROOT}/kfp/kfp_support_lib/shared_workflow_support
 	$(MAKE) .defaults.install-local-requirements-venv
-endif
 
 test:: 	venv
 ifneq ($(KFPv2), 1)

--- a/kfp/kfp_support_lib/kfp_v2_workflow_support/Makefile
+++ b/kfp/kfp_support_lib/kfp_v2_workflow_support/Makefile
@@ -40,11 +40,16 @@ endif
 build-dist :: set-versions .defaults.build-dist
 
 publish:: .check-env
+ifneq ($(KFPv2), 1)
+	# we want to prevent execution of the rule, when we run `make build` in upper directories and KFPv2 is not set
+	echo "Skipping publish as KFPv2 is not defined"
+else
 	@# Help: Publish the wheel to testpypi
 	if [ -d "dist"]; then rm -r dist; fi
 	${PYTHON} -m pip install --upgrade build
 	${PYTHON} -m twine check dist/*
 	${PYTHON} -m twine upload --verbose --non-interactive dist/*
+endif
 
 .PHONY: venv
 venv:

--- a/kfp/kfp_support_lib/shared_workflow_support/Makefile
+++ b/kfp/kfp_support_lib/shared_workflow_support/Makefile
@@ -30,12 +30,9 @@ build:: build-dist
 
 build-dist :: set-versions .defaults.build-dist
 
-publish:: .check-env
-	@# Help: Publish the wheel to testpypi
-	if [ -d "dist"]; then rm -r dist; fi
-	${PYTHON} -m pip install --upgrade build
-	${PYTHON} -m twine check dist/*
-	${PYTHON} -m twine upload --verbose --non-interactive dist/* || true
+publish:: publish-dist
+
+publish-dist :: .check-env .defaults.publish-dist
 
 .PHONY: venv
 venv:

--- a/kfp/kfp_support_lib/shared_workflow_support/Makefile
+++ b/kfp/kfp_support_lib/shared_workflow_support/Makefile
@@ -35,7 +35,7 @@ publish:: .check-env
 	if [ -d "dist"]; then rm -r dist; fi
 	${PYTHON} -m pip install --upgrade build
 	${PYTHON} -m twine check dist/*
-	${PYTHON} -m twine upload --verbose --non-interactive dist/*
+	${PYTHON} -m twine upload --verbose --non-interactive dist/* || true
 
 .PHONY: venv
 venv:

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -80,6 +80,7 @@ if [ -z "$debug" ]; then
     export KFPv2=1
     make set-versions -C kfp
     make build publish -C kfp
+    export KFPv2=0
 else
     # make -C data-processing-lib/spark image # Build the base image required by spark
     make -C transforms/universal/noop/python build publish

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -28,7 +28,7 @@ else
 fi
 
 # Make sure we're starting from the base branch
-get fetch
+git fetch
 git checkout $DEFAULT_BRANCH 
 
 # Get the currently defined version w/o any suffix.  This is the next release version

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -75,7 +75,6 @@ git push origin $tag
 # Now build with the updated version
 # Requires quay credentials in the environment, DPL_DOCKER_REGISTRY_USER, DPK_DOCKER_REGISTRY_KEY
 if [ -z "$debug" ]; then
-    export KFPv2=0
     make build publish
     export KFPv2=1
     make set-versions -C kfp

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -75,7 +75,11 @@ git push origin $tag
 # Now build with the updated version
 # Requires quay credentials in the environment, DPL_DOCKER_REGISTRY_USER, DPK_DOCKER_REGISTRY_KEY
 if [ -z "$debug" ]; then
+    export KFPv2=0
     make build publish
+    export KFPv2=1
+    make set-versions -C kfp
+    make build publish -C kfp
 else
     # make -C data-processing-lib/spark image # Build the base image required by spark
     make -C transforms/universal/noop/python build publish

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -78,7 +78,6 @@ if [ -z "$debug" ]; then
     make build publish
     export KFPv2=1
     make set-versions -C kfp
-    make build publish -C kfp/kfp_support_lib/kfp_v2_workflow_support/
     make build publish -C kfp/kfp_ray_components/
     export KFPv2=0
     make set-versions -C kfp

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -78,8 +78,10 @@ if [ -z "$debug" ]; then
     make build publish
     export KFPv2=1
     make set-versions -C kfp
-    make build publish -C kfp
+    make build publish -C kfp/kfp_support_lib/kfp_v2_workflow_support/
+    make build publish -C kfp/kfp_ray_components/
     export KFPv2=0
+    make set-versions -C kfp
 else
     # make -C data-processing-lib/spark image # Build the base image required by spark
     make -C transforms/universal/noop/python build publish


### PR DESCRIPTION
## Why are these changes needed?
Add building and publishing the two kfp images of kfp v1 and v2 when creating a new release.

## Related issue number (if any).


