### PR TITLE
remove globals in ray transforms that should insteads be references to the python transform globals

### DIFF
--- a/transforms/code/code_quality/ray/src/code_quality_transform_ray.py
+++ b/transforms/code/code_quality/ray/src/code_quality_transform_ray.py
@@ -27,13 +27,6 @@ from data_processing_ray.runtime.ray.runtime_configuration import (
 )
 
 
-CODE_QUALITY_PARAMS = "code_quality_params"
-os.environ["TOKENIZERS_PARALLELISM"] = "false"
-
-
-# CODEPARROT FILTERS
-
-
 class CodeQualityRayTransformConfiguration(RayTransformRuntimeConfiguration):
     def __init__(self):
         super().__init__(transform_config=CodeQualityTransformConfiguration())

--- a/transforms/universal/noop/ray/src/noop_transform_ray.py
+++ b/transforms/universal/noop/ray/src/noop_transform_ray.py
@@ -29,13 +29,6 @@ from noop_transform import NOOPTransformConfiguration
 
 logger = get_logger(__name__)
 
-short_name = "noop"
-cli_prefix = f"{short_name}_"
-sleep_key = "sleep_sec"
-pwd_key = "pwd"
-sleep_cli_param = f"{cli_prefix}{sleep_key}"
-pwd_cli_param = f"{cli_prefix}{pwd_key}"
-
 
 class NOOPRayTransformConfiguration(RayTransformRuntimeConfiguration):
     """

--- a/transforms/universal/noop/ray/test/test_noop_ray.py
+++ b/transforms/universal/noop/ray/test/test_noop_ray.py
@@ -16,7 +16,8 @@ from data_processing.test_support.launch.transform_test import (
     AbstractTransformLauncherTest,
 )
 from data_processing_ray.runtime.ray import RayTransformLauncher
-from noop_transform_ray import NOOPRayTransformConfiguration, sleep_cli_param
+from noop_transform import sleep_cli_param
+from noop_transform_ray import NOOPRayTransformConfiguration
 
 
 class TestRayNOOPTransform(AbstractTransformLauncherTest):

--- a/transforms/universal/tokenization/ray/src/tokenization_transform_ray.py
+++ b/transforms/universal/tokenization/ray/src/tokenization_transform_ray.py
@@ -20,8 +20,6 @@ from tokenization_transform import TokenizationTransformConfiguration
 
 logger = get_logger(__name__)
 
-CHUNK_CHECKPOINT_INTERVAL = 100
-
 
 class TokenizationRayConfiguration(RayTransformRuntimeConfiguration):
     def __init__(self):


### PR DESCRIPTION
Some ray transforms, that are based on a pure python implementation, were redefining constants such as short_name, cli parameters, and config keys.  They were copies of the definitions in the python transform file.

## Why are these changes needed?
It was redundant, misleading and prone to future errors.

## Related issue number (if any).


