### PR TITLE
add new release docs and stop publishing in script for 0.2.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,51 +27,27 @@ include .make.defaults
 # Global rules that are generally to be implemented in the sub-directories and can
 # be overridden there (the double colon on the rule makes the overridable). 
 
-clean:: 
+clean: 
 	@# Help: Recursively $@ in all subdirs 
 	$(MAKE) RULE=$@ .recurse
 
-setup::
-	@# Help: Recursively $@ in all subdirs
-	@$(MAKE) RULE=$@ .recurse
-
-build:: 
+build: 
 	@# Help: Recursively $@ in all subdirs 
 	$(MAKE) RULE=$@ .recurse
 
-test::  
+test:  
 	@# Help: Recursively $@ in all subdirs 
 	@$(MAKE) RULE=$@ .recurse
 
-publish::
+publish:
 	@# Help: Recursively $@ in all subdirs 
 	@$(MAKE) RULE=$@ .recurse
 
 set-versions:  
-	@# Help: Recursively $@ in all subdirs 
+	@# Help: Recursively $@ in all subdirs. Should only be used when .make.versions is changed. 
 	@$(MAKE) RULE=$@ .recurse
-
-#set-release-verions:
-#	@# Help: Update all internally used versions to not include the release suffix. 
-#	@$(MAKE) DPK_VERSION_SUFFIX= set-versions
-
-#lib-release:
-#	@# Help: Set versions to be unsuffixed and publish libraries 
-#	@$(MAKE) set-release-versions 
-#	@$(MAKE) publish-lib 
 	
 show-version:
+	@# Help: Show the version defined in .make.versions 
 	@echo $(DPK_VERSION)
-
-#publish-lib:
-#	@# Help: Publish data-prep-kit $(DPK_LIB_VERSION) and data-prep-kit-kfp $(DPK_LIB_KFP_VERSION) libraries to pypi 
-#	@$(MAKE) -C $(DPK_PYTHON_LIB_DIR) build publish
-#	@$(MAKE) -C $(DPK_RAY_LIB_DIR) build publish
-#	@$(MAKE) -C $(DPK_SPARK_LIB_DIR) build publish
-#	@$(MAKE) -C kfp/kfp_support_lib build publish
-#	@echo ""
-#	@echo "This modified files in the repo. Please be sure to commit/push back to the repository."
-#	@echo ""
-
-
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -12,11 +12,7 @@ The following points are important:
    1. Corollary: `make set-versions` should ONLY be used from the top of the repo when `.make.versions` changes.
 1. The main branch always has the version suffix set to .dev\<N\>, which
 allows intermediate publishing from the main branch using version X.Y.Z.dev\<N\>.
-1. The `scripts/release-branch.sh` script automates the following:
-   1. Creating a `releases/vX.Y.Z` branch and `vX.Y.Z` tag.
-   2. Nulling out the version suffix in the new branch's `.make.version` file. 
-   3. Applying the unsuffixed versions to the artifacts published from the repo.
-   4. Incrementing the minor version and resetting the suffix in the main branch.
+1. The `scripts/release-branch.sh` script automates creation of a new release branch and tag and version numbers in `.make.versions` 
 1. Building and publishing is done manually, or soon via a git action, in the branch created by `scripts/release-branch.sh`. 
    1. Wheels can only be published once to pypi for a given version.
    1. Transform and kfp images may be republished to the docker registry.
@@ -24,11 +20,11 @@ allows intermediate publishing from the main branch using version X.Y.Z.dev\<N\>
 ## Cutting the release
 Creating the release involves
 
-1. Creating a release branch and tag.
-1. Building and publish pypi library wheels and docker registry image.
+1. Creating a release branch and tag and updating the main branch versions.
+1. Building and publishing pypi library wheels and docker registry image.
 1. Creating a github release from the release branch and tag.
 
-Each is discussed below
+Each is discussed below.
 
 ### Creating release branch and tag 
 The `scripts/release-branch.sh` is currently run manually to create the branch and tags as follows:

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,37 +1,39 @@
 # Release Management
 
+## Overview 
 Release are created from the main repository branch using the version
 numbers, including an intermediate version suffix, 
 defined in `.make.versions`.
 The following points are important:
 
+1. In general, common a version number is used for all published pypi wheels and docker images.
 1. `.make.versions` contains the version to be used when publishing the **next** release. 
 1. Whenever `.make.versions` is changed, `make set-versions` should be run from the top of the repo.
    1. Corollary: `make set-versions` should ONLY be used from the top of the repo when `.make.versions` changes.
-1. The main branch always has the version suffix set to .dev<N>, which
-allows intermediate publishing from the dev branch using version X.Y.Z.dev<N>.
-1. In general, common version number is used for all published pypi wheels and docker images.
+1. The main branch always has the version suffix set to .dev\<N\>, which
+allows intermediate publishing from the main branch using version X.Y.Z.dev\<N\>.
 1. The `scripts/release.sh` script automates the following:
-   1. Creating a `release/vX.Y.Z` branch and `vX.Y.Z` tag
+   1. Creating a `releases/vX.Y.Z` branch and `vX.Y.Z` tag.
    2. Nulling out the version suffix in the new branch's `.make.version` file. 
    3. Applying the unsuffixed versions to the artifacts published from the repo.
    4. Incrementing the minor version and resetting the suffix in the main branch.
-1. Building and publishing is done manually, or soon a git action, in the branch created by `scripts/release.sh`. 
-   1. Wheels can only be published once for a given version to pypi 
+1. Building and publishing is done manually, or soon via a git action, in the branch created by `scripts/release.sh`. 
+   1. Wheels can only be published once to pypi for a given version.
    1. Transform and kfp images may be republished to the docker registry.
    
-# Cutting the release
+## Cutting the release
 Creating the release involves
 
-1. Creating a release branch and tag
-1. Building and publish pypi library wheels and docker registry image
-1. Creating a github release from the release branch and tag
+1. Creating a release branch and tag.
+1. Building and publish pypi library wheels and docker registry image.
+1. Creating a github release from the release branch and tag.
 
 Each is discussed below
 
-## Creating release branch and tag 
+### Creating release branch and tag 
 The `scripts/release.sh` is currently run manually to create the branch and tags 
-for the next release.  The script performs the following:
+for the next release using versions in `.make.versions`.
+The script performs the following:
 
 1. Creates the `release/vX.Y.Z` and tag `vX.Y.Z` where `X.Y.Z` are defined in .make.versions 
 1. Resets main branch to version `X.Y.Z+1` with version suffix `.dev0`. 
@@ -49,8 +51,7 @@ To run the script from the top of the repo:
 scripts/release.sh
 ```
 
-
-## Publishing wheels and images
+### Publishing wheels and images
 After creating the release branch and tag using the `scripts/release.sh` script:
 
 1. Switch to a release branch (e.g. releases/v1.2.3) created by the `release.sh` script
@@ -70,7 +71,7 @@ this with environment variables).
 See [pypi](https://packaging.python.org/en/latest/specifications/pypirc/) for details.
 
 
-## Github release
+### Github release
 After running the `release.sh` script, to create tag `vX.Y.Z` and branch `releases/vX.Y.Z`
 1. Go to the [releases page](https://github.com/IBM/data-prep-kit/releases). 
 2. Select `Draft a new release`

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -6,23 +6,59 @@ defined in `.make.versions`.
 The following points are important:
 
 1. `.make.versions` contains the version to be used when publishing the **next** release. 
+1. Whenever `.make.versions` is changed, `make set-versions` should be run from the top of the repo.
+   1. Corollary: `make set-versions` should ONLY be used from the top of the repo when `.make.versions` changes.
 1. The main branch always has the version suffix set to .dev<N>, which
 allows intermediate publishing from the dev branch using version X.Y.Z.dev<N>.
-2. In general, common version number is used for all published pypi wheels and docker images.
-3. The `scripts/release.sh` script automates the following:
+1. In general, common version number is used for all published pypi wheels and docker images.
+1. The `scripts/release.sh` script automates the following:
    1. Creating a `release/vX.Y.Z` branch and `vX.Y.Z` tag
    2. Nulling out the version suffix in the new branch's `.make.version` file. 
    3. Applying the unsuffixed versions to the artifacts published from the repo.
-   4. Building and publishing the wheels to pypi and images to a docker registry. 
-   5. Incrementing the minor version and resetting the suffix in the main branch.
+   4. Incrementing the minor version and resetting the suffix in the main branch.
+1. Building and publishing is done manually, or soon a git action, in the branch created by `scripts/release.sh`. 
+   1. Wheels can only be published once for a given version to pypi 
+   1. Transform and kfp images may be republished to the docker registry.
    
 # Cutting the release
-Creating the release requires running the `release.sh` script and optionally
-generating a release on github.  The latter can be performed manually
-once the `release.sh` script has done its work.
+Creating the release involves
 
-## release.sh
-Running `release.sh` requires credentials to publish to the various cloud locations.
+1. Creating a release branch and tag
+1. Building and publish pypi library wheels and docker registry image
+1. Creating a github release from the release branch and tag
+
+Each is discussed below
+
+## Creating release branch and tag 
+The `scripts/release.sh` is currently run manually to create the branch and tags 
+for the next release.  The script performs the following:
+
+1. Creates the `release/vX.Y.Z` and tag `vX.Y.Z` where `X.Y.Z` are defined in .make.versions 
+1. Resets main branch to version `X.Y.Z+1` with version suffix `.dev0`. 
+
+To double-check the version that will be published from the main branch,
+```
+git checkout <main branch>
+make DPK_VERSION_SUFFIX= show-version
+```
+This will print for example, 1.2.3. 
+
+To run the script from the top of the repo:
+
+```shell
+scripts/release.sh
+```
+
+
+## Publishing wheels and images
+After creating the release branch and tag using the `scripts/release.sh` script:
+
+1. Switch to a release branch (e.g. releases/v1.2.3) created by the `release.sh` script
+1. Be sure you're at the top of the repository (`.../data-prep-kit`)
+1. Optionally, `make show-version` to see the version that will be published
+1. Running the following, either manually or in a git action
+    1. `make build`
+    1. `make publish`	(See credential requirements below)
 
 For docker registry publishing, the following environment variables/credentials are needed:
 
@@ -33,16 +69,6 @@ To publish to pypi, the credentials in `~/.pypirc` file (let us know if there is
 this with environment variables).
 See [pypi](https://packaging.python.org/en/latest/specifications/pypirc/) for details.
 
-To see the version that will be published,
-```
-make DPK_VERSION_SUFFIX= show-version
-```
-This will print for example, 1.2.3. 
-
-To generate the release :
-```shell
-bash scripts/release.sh
-```
 
 ## Github release
 After running the `release.sh` script, to create tag `vX.Y.Z` and branch `releases/vX.Y.Z`

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -12,12 +12,12 @@ The following points are important:
    1. Corollary: `make set-versions` should ONLY be used from the top of the repo when `.make.versions` changes.
 1. The main branch always has the version suffix set to .dev\<N\>, which
 allows intermediate publishing from the main branch using version X.Y.Z.dev\<N\>.
-1. The `scripts/release.sh` script automates the following:
+1. The `scripts/release-branch.sh` script automates the following:
    1. Creating a `releases/vX.Y.Z` branch and `vX.Y.Z` tag.
    2. Nulling out the version suffix in the new branch's `.make.version` file. 
    3. Applying the unsuffixed versions to the artifacts published from the repo.
    4. Incrementing the minor version and resetting the suffix in the main branch.
-1. Building and publishing is done manually, or soon via a git action, in the branch created by `scripts/release.sh`. 
+1. Building and publishing is done manually, or soon via a git action, in the branch created by `scripts/release-branch.sh`. 
    1. Wheels can only be published once to pypi for a given version.
    1. Transform and kfp images may be republished to the docker registry.
    
@@ -31,12 +31,17 @@ Creating the release involves
 Each is discussed below
 
 ### Creating release branch and tag 
-The `scripts/release.sh` is currently run manually to create the branch and tags 
-for the next release using versions in `.make.versions`.
-The script performs the following:
+The `scripts/release-branch.sh` is currently run manually to create the branch and tags as follows:
 
 1. Creates the `release/vX.Y.Z` and tag `vX.Y.Z` where `X.Y.Z` are defined in .make.versions 
-1. Resets main branch to version `X.Y.Z+1` with version suffix `.dev0`. 
+1. In the new branch:
+    1. Nulls out the version suffix in the new branch's `.make.version` file. 
+    1. Applies the unsuffixed versions to the artifacts published from the repo using `make set-versions`..
+    1. Commits and pushes branch and tag
+1. In the main branch:
+    1. Increments the minor version (i.e. Z+1) and resets the suffix in the main branch to `dev0` in `.make.versions`..
+    1. Commits and pushes branch 
+
 
 To double-check the version that will be published from the main branch,
 ```
@@ -48,13 +53,13 @@ This will print for example, 1.2.3.
 To run the script from the top of the repo:
 
 ```shell
-scripts/release.sh
+scripts/release-branch.sh
 ```
 
 ### Publishing wheels and images
-After creating the release branch and tag using the `scripts/release.sh` script:
+After creating the release branch and tag using the `scripts/release-branch.sh` script:
 
-1. Switch to a release branch (e.g. releases/v1.2.3) created by the `release.sh` script
+1. Switch to a release branch (e.g. releases/v1.2.3) created by the `release-branch.sh` script
 1. Be sure you're at the top of the repository (`.../data-prep-kit`)
 1. Optionally, `make show-version` to see the version that will be published
 1. Running the following, either manually or in a git action
@@ -72,7 +77,7 @@ See [pypi](https://packaging.python.org/en/latest/specifications/pypirc/) for de
 
 
 ### Github release
-After running the `release.sh` script, to create tag `vX.Y.Z` and branch `releases/vX.Y.Z`
+After running the `release-branch.sh` script, to create tag `vX.Y.Z` and branch `releases/vX.Y.Z`
 1. Go to the [releases page](https://github.com/IBM/data-prep-kit/releases). 
 2. Select `Draft a new release`
 3. Select `Choose a tag -> vX.Y.Z`

--- a/kfp/kfp_ray_components/Makefile
+++ b/kfp/kfp_ray_components/Makefile
@@ -9,8 +9,7 @@ include $(REPOROOT)/.make.defaults
 #DOCKER_IMG=${DOCKER_HOSTNAME}/${DOCKER_NAMESPACE}/${DOCKER_IMAGE_NAME}:${DOCKER_IMAGE_VERSION}
 DOCKER_IMG=$(DOCKER_LOCAL_IMAGE)
 
-.PHONY: .setImage
-.setImage::
+
 ifeq ($(KFPv2), 1)
         DOCKER_IMAGE_NAME=kfp-data-processing_v2
         DOCKER_IMAGE_VERSION=${KFP_DOCKER_VERSION_v2}
@@ -33,14 +32,14 @@ endif
 
 .PHONY: build
 build: Dockerfile requirements.txt
-	@$(make) .setImage
+	echo ${DOCKER_IMAGE_NAME}
+	echo $(DOCKER_REMOTE_IMAGE)
 	$(MAKE) set-versions 
 	$(MAKE) .lib-src-image
 
 
 .PHONY: .reconcile-requirements
 .reconcile-requirements:
-	@$(make) .setImage
 	@sed -i.back "s/kfp-data-processing.*:[0-9].*/$(DOCKER_IMAGE_NAME):${DOCKER_IMAGE_VERSION}\"/" ${FILE}
 
 .PHONY: set-versions 
@@ -58,26 +57,16 @@ endif
 .PHONY: load-image
 load-image:
 	@# Help: Load the image to the kind cluster created with make setup.
-	@$(make) .setImage
 	kind load docker-image $(DOCKER_REMOTE_IMAGE) --name=$(KIND_CLUSTER_NAME)
 
 
 .PHONY: publish
 publish:
-	CURRENT_KFPv2=$(KFPv2)
-	unset KFPv2
-	@$(make) .setImage
-	@echo "Publishing $DOCKER_IMAGE_NAME"
-	@$(make) build
-	$(MAKE) .defaults.publish-image
-	export KFPv2=1
-	@$(make) .setImage
-	@echo "Publishing $DOCKER_IMAGE_NAME"
-	@$(make) build
-	$(MAKE) .defaults.publish-image
-ifeq ($(CURRENT_KFPv2), 1)
-	export KFPv2=CURRENT_KFPv2
-endif
+	echo "Publishing ${DOCKER_IMAGE_NAME}"
+	$(MAKE) KFPv2=0 DOCKER_IMAGE_NAME="kfp-data-processing" DOCKER_IMAGE_VERSION=${KFP_DOCKER_VERSION} build .defaults.publish-image
+	echo "Publishing ${DOCKER_IMAGE_NAME}"
+	$(MAKE) KFPv2=1 DOCKER_IMAGE_NAME="kfp-data-processing_v2" DOCKER_IMAGE_VERSION=${KFP_DOCKER_VERSION_v2} build .defaults.publish-image
+	$(MAKE) set-versions
 
 test::
 

--- a/kfp/kfp_ray_components/Makefile
+++ b/kfp/kfp_ray_components/Makefile
@@ -32,9 +32,6 @@ endif
 
 .PHONY: build
 build: Dockerfile requirements.txt
-	echo ${DOCKER_IMAGE_NAME}
-	echo $(DOCKER_REMOTE_IMAGE)
-	$(MAKE) set-versions 
 	$(MAKE) .lib-src-image
 
 
@@ -43,7 +40,10 @@ build: Dockerfile requirements.txt
 	@sed -i.back "s/kfp-data-processing.*:[0-9].*/$(DOCKER_IMAGE_NAME):${DOCKER_IMAGE_VERSION}\"/" ${FILE}
 
 .PHONY: set-versions 
-set-versions:
+set-versions::
+
+.PHONE: set-image
+set-image:
 	@# Help: Update yaml files to build images tagged as version $(KFP_DOCKER_VERSION)
 	@$(MAKE) .reconcile-requirements FILE=createRayClusterComponent.yaml
 	@$(MAKE) .reconcile-requirements FILE=deleteRayClusterComponent.yaml
@@ -66,7 +66,6 @@ publish:
 	$(MAKE) KFPv2=0 DOCKER_IMAGE_NAME="kfp-data-processing" DOCKER_IMAGE_VERSION=${KFP_DOCKER_VERSION} build .defaults.publish-image
 	echo "Publishing ${DOCKER_IMAGE_NAME}"
 	$(MAKE) KFPv2=1 DOCKER_IMAGE_NAME="kfp-data-processing_v2" DOCKER_IMAGE_VERSION=${KFP_DOCKER_VERSION_v2} build .defaults.publish-image
-	$(MAKE) set-versions
 
 test::
 

--- a/kfp/kfp_ray_components/Makefile
+++ b/kfp/kfp_ray_components/Makefile
@@ -62,15 +62,15 @@ load-image:
 
 .PHONY: publish
 publish:
-	echo "Publishing ${DOCKER_IMAGE_NAME}"
+	echo "Publishing kfp-data-processing"
 	$(MAKE) KFPv2=0 DOCKER_IMAGE_NAME="kfp-data-processing" DOCKER_IMAGE_VERSION=${KFP_DOCKER_VERSION} build .defaults.publish-image
-	echo "Publishing ${DOCKER_IMAGE_NAME}"
+	echo "Publishing kfp-data-processing_v2"
 	$(MAKE) KFPv2=1 DOCKER_IMAGE_NAME="kfp-data-processing_v2" DOCKER_IMAGE_VERSION=${KFP_DOCKER_VERSION_v2} build .defaults.publish-image
 
 test::
 
 .PHONY: clean
 clean:
-	@# Help: Remove $(IMG) 
+	@# Help: Remove $(IMG)
 	-rm  makeenv
 	rm -rf *.back || true

--- a/kfp/kfp_ray_components/Makefile
+++ b/kfp/kfp_ray_components/Makefile
@@ -31,7 +31,10 @@ endif
 	rm -rf workflow_support_lib
 
 .PHONY: build
-build: Dockerfile requirements.txt
+build: image
+
+.PHONY: image
+image: Dockerfile requirements.txt
 	$(MAKE) .lib-src-image
 
 

--- a/kfp/kfp_ray_components/Makefile
+++ b/kfp/kfp_ray_components/Makefile
@@ -9,6 +9,8 @@ include $(REPOROOT)/.make.defaults
 #DOCKER_IMG=${DOCKER_HOSTNAME}/${DOCKER_NAMESPACE}/${DOCKER_IMAGE_NAME}:${DOCKER_IMAGE_VERSION}
 DOCKER_IMG=$(DOCKER_LOCAL_IMAGE)
 
+.PHONY: .setImage
+.setImage::
 ifeq ($(KFPv2), 1)
         DOCKER_IMAGE_NAME=kfp-data-processing_v2
         DOCKER_IMAGE_VERSION=${KFP_DOCKER_VERSION_v2}
@@ -29,14 +31,16 @@ endif
 	rm -rf shared_workflow_support_lib
 	rm -rf workflow_support_lib
 
-.PHONY: image
-image: Dockerfile requirements.txt
+.PHONY: build
+build: Dockerfile requirements.txt
+	@$(make) .setImage
 	$(MAKE) set-versions 
 	$(MAKE) .lib-src-image
 
 
 .PHONY: .reconcile-requirements
 .reconcile-requirements:
+	@$(make) .setImage
 	@sed -i.back "s/kfp-data-processing.*:[0-9].*/$(DOCKER_IMAGE_NAME):${DOCKER_IMAGE_VERSION}\"/" ${FILE}
 
 .PHONY: set-versions 
@@ -54,14 +58,26 @@ endif
 .PHONY: load-image
 load-image:
 	@# Help: Load the image to the kind cluster created with make setup.
+	@$(make) .setImage
 	kind load docker-image $(DOCKER_REMOTE_IMAGE) --name=$(KIND_CLUSTER_NAME)
 
-.PHONY: build
-build: image
 
 .PHONY: publish
 publish:
-	$(MAKE) image .defaults.publish-image
+	CURRENT_KFPv2=$(KFPv2)
+	unset KFPv2
+	@$(make) .setImage
+	@echo "Publishing $DOCKER_IMAGE_NAME"
+	@$(make) build
+	$(MAKE) .defaults.publish-image
+	export KFPv2=1
+	@$(make) .setImage
+	@echo "Publishing $DOCKER_IMAGE_NAME"
+	@$(make) build
+	$(MAKE) .defaults.publish-image
+ifeq ($(CURRENT_KFPv2), 1)
+	export KFPv2=CURRENT_KFPv2
+endif
 
 test::
 

--- a/kfp/kfp_support_lib/kfp_v1_workflow_support/Makefile
+++ b/kfp/kfp_support_lib/kfp_v1_workflow_support/Makefile
@@ -12,13 +12,14 @@ VENV_ACTIVATE=venv/bin/activate
 
 DEPLOY_KUBEFLOW ?= 0
 
+.PHONY: clean
 clean::
 	@# Help: Clean up the distribution build and the venv
 	rm -r dist venv || true
 	rm -rf src/*egg-info || true
 	rm -rf *.back || true
 
-
+.PHONY: .check-env
 .check-env:: .check_python_version
 	@echo "Checks passed"
 
@@ -28,35 +29,16 @@ set-versions:
 	cat pyproject.toml | sed -e 's/"kfp\([=><][=><]\).*",/"kfp\1$(KFP_v1)",/' > tt.toml
 	mv tt.toml pyproject.toml
 
-build:: set-versions venv
-ifeq ($(KFPv2), 1)
-	# we want to prevent execution of the rule, when we run `make build` in upper directories and KFPv2==1
-	echo "Skipping build as KFPv2 is defined"
-else
-	@# Help: Build the distribution for publishing to a pypi
-	$(MAKE) build-dist
-endif
+build:: .check-env .defaults.build-dist
 
-build-dist :: set-versions .defaults.build-dist
-
-publish:: .check-env
-	@# Help: Publish the wheel to testpypi
-	if [ -d "dist"]; then rm -r dist; fi
-	${PYTHON} -m pip install --upgrade build
-	${PYTHON} -m twine check dist/*
-	${PYTHON} -m twine upload --verbose --non-interactive dist/*
+publish:: .check-env  .defaults.publish-dist
 
 .PHONY: venv
 venv:
-ifeq ($(KFPv2), 1)
-	# we want to prevent execution of the rule, when we run `make venv` in upper directories and KFPv2==1
-	echo "Skipping as KFPv2 is defined"
-else
 	@# Help: Create the virtual environment using pyproject.toml
 	$(MAKE) .defaults.create-venv .defaults.install-ray-lib-src-venv
 	@source venv/bin/activate; pip install -e ${REPOROOT}/kfp/kfp_support_lib/shared_workflow_support
 	$(MAKE) .defaults.install-local-requirements-venv
-endif
 
 test:: venv 
 ifeq ($(KFPv2), 1)

--- a/kfp/kfp_support_lib/kfp_v2_workflow_support/Makefile
+++ b/kfp/kfp_support_lib/kfp_v2_workflow_support/Makefile
@@ -12,13 +12,14 @@ VENV_ACTIVATE=venv/bin/activate
 
 DEPLOY_KUBEFLOW ?= 0
 
+.PHONY: clean
 clean::
 	@# Help: Clean up the distribution build and the venv
 	rm -r dist venv || true
 	rm -rf src/*egg-info || true
 	rm -rf *.back || true
 
-
+.PHONY: .check-env
 .check-env:: .check_python_version
 	@echo "Checks passed"
 
@@ -28,35 +29,17 @@ set-versions:
 	cat pyproject.toml | sed -e 's/"kfp\([=><][=><]\).*",/"kfp\1$(KFP_v2)",/' > tt.toml
 	mv tt.toml pyproject.toml
 
-build:: set-versions venv
-ifneq ($(KFPv2), 1)
-	# we want to prevent execution of the rule, when we run `make build` in upper directories and KFPv2 is not set
-	echo "Skipping build as KFPv2 is not defined"
-else
-	@# Help: Build the distribution for publishing to a pypi
-	$(MAKE) build-dist
-endif
 
-build-dist :: set-versions .defaults.build-dist
+build:: .check-env .defaults.build-dist
 
-publish:: .check-env
-	@# Help: Publish the wheel to testpypi
-	if [ -d "dist"]; then rm -r dist; fi
-	${PYTHON} -m pip install --upgrade build
-	${PYTHON} -m twine check dist/*
-	${PYTHON} -m twine upload --verbose --non-interactive dist/*
+publish:: .check-env  .defaults.publish-dist
 
 .PHONY: venv
 venv:
-ifneq ($(KFPv2), 1)
-	# we want to prevent execution of the rule, when we run `make venv` in upper directories and KFPv2 is not set
-	echo "Skipping venv as KFPv2 is not defined"
-else
 	@# Help: Create the virtual environment using pyproject.toml
 	$(MAKE) .defaults.create-venv .defaults.install-ray-lib-src-venv
 	@source venv/bin/activate; pip install -e ${REPOROOT}/kfp/kfp_support_lib/shared_workflow_support
 	$(MAKE) .defaults.install-local-requirements-venv
-endif
 
 test:: 	venv
 ifneq ($(KFPv2), 1)

--- a/kfp/kfp_support_lib/shared_workflow_support/Makefile
+++ b/kfp/kfp_support_lib/shared_workflow_support/Makefile
@@ -12,6 +12,7 @@ VENV_ACTIVATE=venv/bin/activate
 
 DEPLOY_KUBEFLOW ?= 0
 
+.PHONY: clean
 clean::
 	@# Help: Clean up the distribution build and the venv
 	rm -r dist venv || true
@@ -19,23 +20,16 @@ clean::
 	rm -rf *.back || true
 
 .PHONY: .check-env
-.check-env::
+.check-env:: .check_python_version
 	@echo "Checks passed"
 
 .PHONY: set-versions
 set-versions:
 	$(MAKE) TOML_VERSION=$(DPK_LIB_KFP_VERSION) .defaults.update-toml
 
-build:: build-dist
+build:: .check-env .defaults.build-dist
 
-build-dist :: set-versions .defaults.build-dist
-
-publish:: .check-env
-	@# Help: Publish the wheel to testpypi
-	if [ -d "dist"]; then rm -r dist; fi
-	${PYTHON} -m pip install --upgrade build
-	${PYTHON} -m twine check dist/*
-	${PYTHON} -m twine upload --verbose --non-interactive dist/*
+publish:: .check-env  .defaults.publish-dist
 
 .PHONY: venv
 venv:

--- a/release-notes.md
+++ b/release-notes.md
@@ -1,0 +1,30 @@
+# Data Prep Kit Release notes
+
+## Release 0.2.0 - 6/28/2024
+
+### data-prep-toolkit libraries (python, ray, spark) 
+
+1. Split libraries into 3 runtime-specific implementations
+1. Fix missing final count of processed and add percentages
+1. Report Global Retry Metric 
+1. Support for binary data transforms
+1. Updated to Ray version to 2.24
+
+### data-prep-toolkit-kfp libraries 
+
+1. KFPv2 support with workarounds
+1. Create a distinct (timestamped) execution.log file for each retry
+1. Support for multiple inputs/outputs
+
+### Transforms
+
+1. Added language/lang_id - detects language in documents
+1. Added universal/profiler - counts works/tokens in documents
+1. Split transforms, as appropriate, into python, ray and/or spark.
+
+## Release 0.1.1 - 5/24/2024
+
+## Release 0.1.0 - 5/15/2024
+
+## Release 0.1.0 - 5/08/2024
+

--- a/release-notes.md
+++ b/release-notes.md
@@ -2,17 +2,25 @@
 
 ## Release 0.2.0 - 6/28/2024
 
+### General 
+1. Many bug fixes across the repo, plus the following specifics.
+1. Enhanced CI/CD and makefile improvements  include definition of top-level targets (clean, set-verions, build, publish, test)
+1. Automation of release process branch/tag management
+1. Documentation improvements 
+
 ### data-prep-toolkit libraries (python, ray, spark) 
 
 1. Split libraries into 3 runtime-specific implementations
 1. Fix missing final count of processed and add percentages
-1. Report Global Retry Metric 
+1. Improved fault tolerance in python and ray runtimes 
+1. Report global DataAccess retry metric  
 1. Support for binary data transforms
 1. Updated to Ray version to 2.24
+1. Updated to PyArrow version 16.1.0
 
-### data-prep-toolkit-kfp libraries 
+### KFP Workloads 
 
-1. KFPv2 support with workarounds
+1. Add KFP V2 support 
 1. Create a distinct (timestamped) execution.log file for each retry
 1. Support for multiple inputs/outputs
 
@@ -20,8 +28,11 @@
 
 1. Added language/lang_id - detects language in documents
 1. Added universal/profiler - counts works/tokens in documents
+1. Converted ingest2parquet tool to transform named code2parquet
 1. Split transforms, as appropriate, into python, ray and/or spark.
 1. Added spark implementations of filter, doc_id and noop transforms.
+1. Switch from using requirements.txt to pyproject.toml file for each transform runtime
+1. Repository restructured to move kfp workflow definitions to associated transform project directory
 
 ## Release 0.1.1 - 5/24/2024
 

--- a/release-notes.md
+++ b/release-notes.md
@@ -21,6 +21,7 @@
 1. Added language/lang_id - detects language in documents
 1. Added universal/profiler - counts works/tokens in documents
 1. Split transforms, as appropriate, into python, ray and/or spark.
+1. Added spark implementations of filter, doc_id and noop transforms.
 
 ## Release 0.1.1 - 5/24/2024
 

--- a/scripts/release-branch.sh
+++ b/scripts/release-branch.sh
@@ -28,7 +28,7 @@ else
 fi
 
 # Make sure we're starting from the base branch
-get fetch
+git fetch
 git checkout $DEFAULT_BRANCH 
 
 # Get the currently defined version w/o any suffix.  This is the next release version

--- a/scripts/release-branch.sh
+++ b/scripts/release-branch.sh
@@ -4,11 +4,7 @@ dbg_suffix=.dev7
 reporoot=$(dirname $0)/..
 cd $reporoot
 
-if [ -z "$debug" ]; then
-    DEFAULT_BRANCH=dev
-else
-    DEFAULT_BRANCH=releasing-copy
-fi
+DEFAULT_BRANCH=dev
 
 # Make sure we're starting from the base branch
 git fetch

--- a/scripts/release-branch.sh
+++ b/scripts/release-branch.sh
@@ -4,23 +4,6 @@ dbg_suffix=.dev7
 reporoot=$(dirname $0)/..
 cd $reporoot
 
-# Make sure required env vars are set
-if [ -z "$DPK_DOCKER_REGISTRY_USER" ]; then
-    echo DPK_DOCKER_REGISTRY_USER env var must be set
-    exit 1
-elif [ -z "$DPK_DOCKER_REGISTRY_KEY" ]; then
-    echo DPK_DOCKER_REGISTRY_KEY env var must be set
-    exit 1
-fi
-if [ ! -e ~/.pypirc ]; then
-   cat << EOF
-You need a ~/.pypirc containing pypi.org credentials.
-See https://packaging.python.org/en/latest/specifications/pypirc/ for details.
-EOF
-    exit
-fi
-exit
-
 if [ -z "$debug" ]; then
     DEFAULT_BRANCH=dev
 else
@@ -33,6 +16,7 @@ git checkout $DEFAULT_BRANCH
 
 # Get the currently defined version w/o any suffix.  This is the next release version
 version=$(make DPK_VERSION_SUFFIX= show-version)
+echo Building release branch and tag for version $version
 
 if [ -z "$debug" ]; then
     tag=v$version
@@ -50,8 +34,8 @@ if [ ! -z "$debug" ]; then
     git push --delete origin $tag
     git push --delete origin $release_branch
 fi
+echo Creating $release_branch branch
 git checkout -b $release_branch 
-
 
 # Remove the release suffix in this branch
 # Apply the unsuffixed version to the repo and check it into this release branch
@@ -63,23 +47,17 @@ else
     mv tt .make.versions
 fi
 # Apply the version change to all files in the repo 
+echo Applying $version to $release_branch branch 
 make set-versions
 
 # Commit the changes to the release branch and tag it
 git status
+echo Committing and pushing version changes in $release_branch branch. 
 git commit -s -a -m "Cut release $version"
 git push --set-upstream origin $release_branch 
+echo Committing and pushing tag $tag in $release_branch branch
 git tag -a -s -m "Cut release $version" $tag 
 git push origin $tag 
-
-# Now build with the updated version
-# Requires quay credentials in the environment, DPL_DOCKER_REGISTRY_USER, DPK_DOCKER_REGISTRY_KEY
-#if [ -z "$debug" ]; then
-#    make build publish
-#else
-#    # make -C data-processing-lib/spark image # Build the base image required by spark
-#    make -C transforms/universal/noop/python build publish
-#fi
 
 # Now go back to the default branch so we can bump the minor version number and reset the version suffix
 git checkout $DEFAULT_BRANCH
@@ -91,11 +69,13 @@ cat .make.versions | sed -e "s/^DPK_MICRO_VERSION=.*/DPK_MICRO_VERSION=$micro/" 
  			 -e "s/^DPK_VERSION_SUFFIX=.*/DPK_VERSION_SUFFIX=.dev0/"  > tt
 mv tt .make.versions
 # Apply the version change to all files in the repo 
+next_version=$(make show-version)
+echo Applying updated version $next_version to $DEFAULT_BRANCH  branch
 make set-versions
 
 # Push the version change back to the origin
-next_version=$(make show-version)
 if [ -z "$debug" ]; then
+    echo Committing and pushing version $next_version to $DEFAULT_BRANCH branch.
     git commit -s -a -m "Bump micro version to $next_version after cutting release $version into branch $release_branch"
     git diff origin/$DEFAULT_BRANCH $DEFAULT_BRANCH
     git push origin

--- a/scripts/release-branch.sh
+++ b/scripts/release-branch.sh
@@ -44,7 +44,7 @@ else
 fi
 # Apply the version change to all files in the repo 
 echo Applying $version to $release_branch branch 
-make set-versions
+make set-versions > /dev/null
 
 # Commit the changes to the release branch and tag it
 git status
@@ -67,7 +67,7 @@ mv tt .make.versions
 # Apply the version change to all files in the repo 
 next_version=$(make show-version)
 echo Applying updated version $next_version to $DEFAULT_BRANCH  branch
-make set-versions
+make set-versions > /dev/null
 
 # Push the version change back to the origin
 if [ -z "$debug" ]; then

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -74,12 +74,12 @@ git push origin $tag
 
 # Now build with the updated version
 # Requires quay credentials in the environment, DPL_DOCKER_REGISTRY_USER, DPK_DOCKER_REGISTRY_KEY
-if [ -z "$debug" ]; then
-    make build publish
-else
-    # make -C data-processing-lib/spark image # Build the base image required by spark
-    make -C transforms/universal/noop/python build publish
-fi
+#if [ -z "$debug" ]; then
+#    make build publish
+#else
+#    # make -C data-processing-lib/spark image # Build the base image required by spark
+#    make -C transforms/universal/noop/python build publish
+#fi
 
 # Now go back to the default branch so we can bump the minor version number and reset the version suffix
 git checkout $DEFAULT_BRANCH
@@ -95,8 +95,11 @@ make set-versions
 
 # Push the version change back to the origin
 next_version=$(make show-version)
-git commit -s -a -m "Bump micro version to $next_version after cutting release $version into branch $release_branch"
-git diff origin/$DEFAULT_BRANCH $DEFAULT_BRANCH
 if [ -z "$debug" ]; then
+    git commit -s -a -m "Bump micro version to $next_version after cutting release $version into branch $release_branch"
+    git diff origin/$DEFAULT_BRANCH $DEFAULT_BRANCH
     git push origin
+else
+    git status
+    echo In non-debug mode, the above diffs would have been commited to the $DEFAULT_BRANCH branch
 fi

--- a/transforms/.make.workflows
+++ b/transforms/.make.workflows
@@ -23,6 +23,7 @@ set-versions:
 
 .PHONY: .workflows.compile-pipeline
 .workflows.compile-pipeline:
+	$(MAKE) -C ${REPOROOT}/kfp/kfp_ray_components set-image
 	. ${WORKFLOW_VENV_ACTIVATE} && ${PYTHON} ${WF_NAME}.py
 
 KFP_LIB_SRC_FILES := $(shell find ${REPOROOT}/kfp/kfp_support_lib/${WORKFLOW_SUPPORT_LIB}/src/ -name '*.py')
@@ -54,7 +55,8 @@ ${WORKFLOW_VENV_ACTIVATE}: ${REPOROOT}/.make.versions ${REPOROOT}/kfp/kfp_ray_co
 	$(MAKE) -C ${REPOROOT}/transforms .defaults.ray-lib-src-venv
 	. ${WORKFLOW_VENV_ACTIVATE};     \
 	pip install -e $(REPOROOT)/kfp/kfp_support_lib/shared_workflow_support; \
-	pip install -e $(REPOROOT)/kfp/kfp_support_lib/$(WORKFLOW_SUPPORT_LIB);
+	pip install -e $(REPOROOT)/kfp/kfp_support_lib/$(WORKFLOW_SUPPORT_LIB); \
+	$(MAKE) -C ${REPOROOT}/kfp/kfp_ray_components set-image
 	@# Help: Create the virtual environment common to all workflows
 
 .PHONY: .workflows.upload-pipeline


### PR DESCRIPTION
Update to release documentation
Renamed release.sh script to release-branch.sh and don't publish from it anymore.
No more setup target at the top of the repo makefile
Make kfp publish publish both v1 and v2 kfp content.

## Why are these changes needed?
For the next pending 0.2.0 release.

## Related issue number (if any).


