### PR TITLE
update the kfp release process

### DIFF
--- a/kfp/kfp_ray_components/Makefile
+++ b/kfp/kfp_ray_components/Makefile
@@ -9,8 +9,7 @@ include $(REPOROOT)/.make.defaults
 #DOCKER_IMG=${DOCKER_HOSTNAME}/${DOCKER_NAMESPACE}/${DOCKER_IMAGE_NAME}:${DOCKER_IMAGE_VERSION}
 DOCKER_IMG=$(DOCKER_LOCAL_IMAGE)
 
-.PHONY: .setImage
-.setImage::
+
 ifeq ($(KFPv2), 1)
         DOCKER_IMAGE_NAME=kfp-data-processing_v2
         DOCKER_IMAGE_VERSION=${KFP_DOCKER_VERSION_v2}
@@ -33,14 +32,14 @@ endif
 
 .PHONY: build
 build: Dockerfile requirements.txt
-	@$(make) .setImage
+	echo ${DOCKER_IMAGE_NAME}
+	echo $(DOCKER_REMOTE_IMAGE)
 	$(MAKE) set-versions 
 	$(MAKE) .lib-src-image
 
 
 .PHONY: .reconcile-requirements
 .reconcile-requirements:
-	@$(make) .setImage
 	@sed -i.back "s/kfp-data-processing.*:[0-9].*/$(DOCKER_IMAGE_NAME):${DOCKER_IMAGE_VERSION}\"/" ${FILE}
 
 .PHONY: set-versions 
@@ -58,26 +57,16 @@ endif
 .PHONY: load-image
 load-image:
 	@# Help: Load the image to the kind cluster created with make setup.
-	@$(make) .setImage
 	kind load docker-image $(DOCKER_REMOTE_IMAGE) --name=$(KIND_CLUSTER_NAME)
 
 
 .PHONY: publish
 publish:
-	CURRENT_KFPv2=$(KFPv2)
-	unset KFPv2
-	@$(make) .setImage
-	@echo "Publishing $DOCKER_IMAGE_NAME"
-	@$(make) build
-	$(MAKE) .defaults.publish-image
-	export KFPv2=1
-	@$(make) .setImage
-	@echo "Publishing $DOCKER_IMAGE_NAME"
-	@$(make) build
-	$(MAKE) .defaults.publish-image
-ifeq ($(CURRENT_KFPv2), 1)
-	export KFPv2=CURRENT_KFPv2
-endif
+	echo "Publishing ${DOCKER_IMAGE_NAME}"
+	$(MAKE) KFPv2=0 DOCKER_IMAGE_NAME="kfp-data-processing" DOCKER_IMAGE_VERSION=${KFP_DOCKER_VERSION} build .defaults.publish-image
+	echo "Publishing ${DOCKER_IMAGE_NAME}"
+	$(MAKE) KFPv2=1 DOCKER_IMAGE_NAME="kfp-data-processing_v2" DOCKER_IMAGE_VERSION=${KFP_DOCKER_VERSION_v2} build .defaults.publish-image
+	$(MAKE) set-versions
 
 test::
 

--- a/kfp/kfp_ray_components/Makefile
+++ b/kfp/kfp_ray_components/Makefile
@@ -32,9 +32,6 @@ endif
 
 .PHONY: build
 build: Dockerfile requirements.txt
-	echo ${DOCKER_IMAGE_NAME}
-	echo $(DOCKER_REMOTE_IMAGE)
-	$(MAKE) set-versions 
 	$(MAKE) .lib-src-image
 
 
@@ -43,7 +40,10 @@ build: Dockerfile requirements.txt
 	@sed -i.back "s/kfp-data-processing.*:[0-9].*/$(DOCKER_IMAGE_NAME):${DOCKER_IMAGE_VERSION}\"/" ${FILE}
 
 .PHONY: set-versions 
-set-versions:
+set-versions::
+
+.PHONE: set-image
+set-image:
 	@# Help: Update yaml files to build images tagged as version $(KFP_DOCKER_VERSION)
 	@$(MAKE) .reconcile-requirements FILE=createRayClusterComponent.yaml
 	@$(MAKE) .reconcile-requirements FILE=deleteRayClusterComponent.yaml
@@ -66,7 +66,6 @@ publish:
 	$(MAKE) KFPv2=0 DOCKER_IMAGE_NAME="kfp-data-processing" DOCKER_IMAGE_VERSION=${KFP_DOCKER_VERSION} build .defaults.publish-image
 	echo "Publishing ${DOCKER_IMAGE_NAME}"
 	$(MAKE) KFPv2=1 DOCKER_IMAGE_NAME="kfp-data-processing_v2" DOCKER_IMAGE_VERSION=${KFP_DOCKER_VERSION_v2} build .defaults.publish-image
-	$(MAKE) set-versions
 
 test::
 

--- a/kfp/kfp_ray_components/Makefile
+++ b/kfp/kfp_ray_components/Makefile
@@ -62,15 +62,15 @@ load-image:
 
 .PHONY: publish
 publish:
-	echo "Publishing ${DOCKER_IMAGE_NAME}"
+	echo "Publishing kfp-data-processing"
 	$(MAKE) KFPv2=0 DOCKER_IMAGE_NAME="kfp-data-processing" DOCKER_IMAGE_VERSION=${KFP_DOCKER_VERSION} build .defaults.publish-image
-	echo "Publishing ${DOCKER_IMAGE_NAME}"
+	echo "Publishing kfp-data-processing_v2"
 	$(MAKE) KFPv2=1 DOCKER_IMAGE_NAME="kfp-data-processing_v2" DOCKER_IMAGE_VERSION=${KFP_DOCKER_VERSION_v2} build .defaults.publish-image
 
 test::
 
 .PHONY: clean
 clean:
-	@# Help: Remove $(IMG) 
+	@# Help: Remove $(IMG)
 	-rm  makeenv
 	rm -rf *.back || true

--- a/kfp/kfp_ray_components/Makefile
+++ b/kfp/kfp_ray_components/Makefile
@@ -9,6 +9,8 @@ include $(REPOROOT)/.make.defaults
 #DOCKER_IMG=${DOCKER_HOSTNAME}/${DOCKER_NAMESPACE}/${DOCKER_IMAGE_NAME}:${DOCKER_IMAGE_VERSION}
 DOCKER_IMG=$(DOCKER_LOCAL_IMAGE)
 
+.PHONY: .setImage
+.setImage::
 ifeq ($(KFPv2), 1)
         DOCKER_IMAGE_NAME=kfp-data-processing_v2
         DOCKER_IMAGE_VERSION=${KFP_DOCKER_VERSION_v2}
@@ -29,14 +31,16 @@ endif
 	rm -rf shared_workflow_support_lib
 	rm -rf workflow_support_lib
 
-.PHONY: image
-image: Dockerfile requirements.txt
+.PHONY: build
+build: Dockerfile requirements.txt
+	@$(make) .setImage
 	$(MAKE) set-versions 
 	$(MAKE) .lib-src-image
 
 
 .PHONY: .reconcile-requirements
 .reconcile-requirements:
+	@$(make) .setImage
 	@sed -i.back "s/kfp-data-processing.*:[0-9].*/$(DOCKER_IMAGE_NAME):${DOCKER_IMAGE_VERSION}\"/" ${FILE}
 
 .PHONY: set-versions 
@@ -54,14 +58,26 @@ endif
 .PHONY: load-image
 load-image:
 	@# Help: Load the image to the kind cluster created with make setup.
+	@$(make) .setImage
 	kind load docker-image $(DOCKER_REMOTE_IMAGE) --name=$(KIND_CLUSTER_NAME)
 
-.PHONY: build
-build: image
 
 .PHONY: publish
 publish:
-	$(MAKE) image .defaults.publish-image
+	CURRENT_KFPv2=$(KFPv2)
+	unset KFPv2
+	@$(make) .setImage
+	@echo "Publishing $DOCKER_IMAGE_NAME"
+	@$(make) build
+	$(MAKE) .defaults.publish-image
+	export KFPv2=1
+	@$(make) .setImage
+	@echo "Publishing $DOCKER_IMAGE_NAME"
+	@$(make) build
+	$(MAKE) .defaults.publish-image
+ifeq ($(CURRENT_KFPv2), 1)
+	export KFPv2=CURRENT_KFPv2
+endif
 
 test::
 

--- a/kfp/kfp_support_lib/kfp_v1_workflow_support/Makefile
+++ b/kfp/kfp_support_lib/kfp_v1_workflow_support/Makefile
@@ -12,13 +12,14 @@ VENV_ACTIVATE=venv/bin/activate
 
 DEPLOY_KUBEFLOW ?= 0
 
+.PHONY: clean
 clean::
 	@# Help: Clean up the distribution build and the venv
 	rm -r dist venv || true
 	rm -rf src/*egg-info || true
 	rm -rf *.back || true
 
-
+.PHONY: .check-env
 .check-env:: .check_python_version
 	@echo "Checks passed"
 
@@ -28,35 +29,16 @@ set-versions:
 	cat pyproject.toml | sed -e 's/"kfp\([=><][=><]\).*",/"kfp\1$(KFP_v1)",/' > tt.toml
 	mv tt.toml pyproject.toml
 
-build:: set-versions venv
-ifeq ($(KFPv2), 1)
-	# we want to prevent execution of the rule, when we run `make build` in upper directories and KFPv2==1
-	echo "Skipping build as KFPv2 is defined"
-else
-	@# Help: Build the distribution for publishing to a pypi
-	$(MAKE) build-dist
-endif
+build:: .check-env .defaults.build-dist
 
-build-dist :: set-versions .defaults.build-dist
-
-publish:: .check-env
-	@# Help: Publish the wheel to testpypi
-	if [ -d "dist"]; then rm -r dist; fi
-	${PYTHON} -m pip install --upgrade build
-	${PYTHON} -m twine check dist/*
-	${PYTHON} -m twine upload --verbose --non-interactive dist/*
+publish:: .check-env  .defaults.publish-dist
 
 .PHONY: venv
 venv:
-ifeq ($(KFPv2), 1)
-	# we want to prevent execution of the rule, when we run `make venv` in upper directories and KFPv2==1
-	echo "Skipping as KFPv2 is defined"
-else
 	@# Help: Create the virtual environment using pyproject.toml
 	$(MAKE) .defaults.create-venv .defaults.install-ray-lib-src-venv
 	@source venv/bin/activate; pip install -e ${REPOROOT}/kfp/kfp_support_lib/shared_workflow_support
 	$(MAKE) .defaults.install-local-requirements-venv
-endif
 
 test:: venv 
 ifeq ($(KFPv2), 1)

--- a/kfp/kfp_support_lib/kfp_v2_workflow_support/Makefile
+++ b/kfp/kfp_support_lib/kfp_v2_workflow_support/Makefile
@@ -12,13 +12,14 @@ VENV_ACTIVATE=venv/bin/activate
 
 DEPLOY_KUBEFLOW ?= 0
 
+.PHONY: clean
 clean::
 	@# Help: Clean up the distribution build and the venv
 	rm -r dist venv || true
 	rm -rf src/*egg-info || true
 	rm -rf *.back || true
 
-
+.PHONY: .check-env
 .check-env:: .check_python_version
 	@echo "Checks passed"
 
@@ -28,35 +29,17 @@ set-versions:
 	cat pyproject.toml | sed -e 's/"kfp\([=><][=><]\).*",/"kfp\1$(KFP_v2)",/' > tt.toml
 	mv tt.toml pyproject.toml
 
-build:: set-versions venv
-ifneq ($(KFPv2), 1)
-	# we want to prevent execution of the rule, when we run `make build` in upper directories and KFPv2 is not set
-	echo "Skipping build as KFPv2 is not defined"
-else
-	@# Help: Build the distribution for publishing to a pypi
-	$(MAKE) build-dist
-endif
 
-build-dist :: set-versions .defaults.build-dist
+build:: .check-env .defaults.build-dist
 
-publish:: .check-env
-	@# Help: Publish the wheel to testpypi
-	if [ -d "dist"]; then rm -r dist; fi
-	${PYTHON} -m pip install --upgrade build
-	${PYTHON} -m twine check dist/*
-	${PYTHON} -m twine upload --verbose --non-interactive dist/*
+publish:: .check-env  .defaults.publish-dist
 
 .PHONY: venv
 venv:
-ifneq ($(KFPv2), 1)
-	# we want to prevent execution of the rule, when we run `make venv` in upper directories and KFPv2 is not set
-	echo "Skipping venv as KFPv2 is not defined"
-else
 	@# Help: Create the virtual environment using pyproject.toml
 	$(MAKE) .defaults.create-venv .defaults.install-ray-lib-src-venv
 	@source venv/bin/activate; pip install -e ${REPOROOT}/kfp/kfp_support_lib/shared_workflow_support
 	$(MAKE) .defaults.install-local-requirements-venv
-endif
 
 test:: 	venv
 ifneq ($(KFPv2), 1)

--- a/kfp/kfp_support_lib/shared_workflow_support/Makefile
+++ b/kfp/kfp_support_lib/shared_workflow_support/Makefile
@@ -12,6 +12,7 @@ VENV_ACTIVATE=venv/bin/activate
 
 DEPLOY_KUBEFLOW ?= 0
 
+.PHONY: clean
 clean::
 	@# Help: Clean up the distribution build and the venv
 	rm -r dist venv || true
@@ -19,23 +20,16 @@ clean::
 	rm -rf *.back || true
 
 .PHONY: .check-env
-.check-env::
+.check-env:: .check_python_version
 	@echo "Checks passed"
 
 .PHONY: set-versions
 set-versions:
 	$(MAKE) TOML_VERSION=$(DPK_LIB_KFP_VERSION) .defaults.update-toml
 
-build:: build-dist
+build:: .check-env .defaults.build-dist
 
-build-dist :: set-versions .defaults.build-dist
-
-publish:: .check-env
-	@# Help: Publish the wheel to testpypi
-	if [ -d "dist"]; then rm -r dist; fi
-	${PYTHON} -m pip install --upgrade build
-	${PYTHON} -m twine check dist/*
-	${PYTHON} -m twine upload --verbose --non-interactive dist/*
+publish:: .check-env  .defaults.publish-dist
 
 .PHONY: venv
 venv:

--- a/transforms/.make.workflows
+++ b/transforms/.make.workflows
@@ -23,6 +23,7 @@ set-versions:
 
 .PHONY: .workflows.compile-pipeline
 .workflows.compile-pipeline:
+	$(MAKE) -C ${REPOROOT}/kfp/kfp_ray_components set-image
 	. ${WORKFLOW_VENV_ACTIVATE} && ${PYTHON} ${WF_NAME}.py
 
 KFP_LIB_SRC_FILES := $(shell find ${REPOROOT}/kfp/kfp_support_lib/${WORKFLOW_SUPPORT_LIB}/src/ -name '*.py')
@@ -54,7 +55,8 @@ ${WORKFLOW_VENV_ACTIVATE}: ${REPOROOT}/.make.versions ${REPOROOT}/kfp/kfp_ray_co
 	$(MAKE) -C ${REPOROOT}/transforms .defaults.ray-lib-src-venv
 	. ${WORKFLOW_VENV_ACTIVATE};     \
 	pip install -e $(REPOROOT)/kfp/kfp_support_lib/shared_workflow_support; \
-	pip install -e $(REPOROOT)/kfp/kfp_support_lib/$(WORKFLOW_SUPPORT_LIB);
+	pip install -e $(REPOROOT)/kfp/kfp_support_lib/$(WORKFLOW_SUPPORT_LIB); \
+	$(MAKE) -C ${REPOROOT}/kfp/kfp_ray_components set-image
 	@# Help: Create the virtual environment common to all workflows
 
 .PHONY: .workflows.upload-pipeline


### PR DESCRIPTION
## Why are these changes needed?

Update the KFP publishing process. We have to publish 2 different images: one for KFPv1 and another for KFPv2.

Note: this PR is instead of https://github.com/IBM/data-prep-kit/pull/335


