### PR TITLE
Add workflow-build target

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -107,7 +107,7 @@ jobs:
                   export DEPLOY_KUBEFLOW=1
                   make -C $K8S_SETUP_SCRIPTS setup
                   make -C kfp/kfp_support_lib test
-                  make -C transforms setup
+                  make -C transforms workflow-build
                   dir=("code"  "universal") && index=$(($RANDOM % 2)) && subdirs=${dir[$index]} && transforms=($(find transforms/$subdirs/ -type d  -maxdepth 1 ))
                   # First element is not really a subdir but rather the current dir so remove it and randomly choose a transform to run
                   set -- "${transforms[@]}" && shift && transforms=("$@") && size=${#transforms[@]} && index=$(($RANDOM % $size))
@@ -151,7 +151,7 @@ jobs:
                   export KFPv2=1
                   make -C $K8S_SETUP_SCRIPTS setup
                   make -C kfp/kfp_support_lib test
-                  make -C transforms setup
+                  make -C transforms workflow-build
                   dir=("code"  "universal") && index=$(($RANDOM % 2)) && subdirs=${dir[$index]} && transforms=($(find transforms/$subdirs/ -type d  -maxdepth 1 ))
                   # First element is not really a subdir but rather the current dir so remove it and randomly choose a transform to run
                   set -- "${transforms[@]}" && shift && transforms=("$@") && size=${#transforms[@]} && index=$(($RANDOM % $size))

--- a/kfp/superworkflows/Makefile
+++ b/kfp/superworkflows/Makefile
@@ -15,7 +15,7 @@ else
 	$(MAKE) -C ray/kfp_v1 workflow-venv
 endif
 
-.PHONY: setup
+.PHONY: workflow-build
 setup:
 ifeq ($(KFPv2), 1)
 	echo "Skipping build as KFPv2 is defined"

--- a/kfp/superworkflows/ray/kfp_v1/Makefile
+++ b/kfp/superworkflows/ray/kfp_v1/Makefile
@@ -9,8 +9,8 @@ workflow-venv:: .check_python_version ${WORKFLOW_VENV_ACTIVATE}
 
 worflow-clean:: .workflows.clean
 
-.PHONY: setup
-setup: workflow-venv
+.PHONY: workflow-build
+workflow-build: workflow-venv
 	@for file in $(YAML_WF); do \
 		$(MAKE) $$file;       \
 	done
@@ -18,7 +18,7 @@ setup: workflow-venv
 workflow-test::
 
 .PHONY: workflow-upload
-workflow-upload: setup
+workflow-upload: workflow-build
 	@for file in $(YAML_WF); do \
                 $(MAKE) .workflows.upload-pipeline PIPELINE_FILE=$$file; \
         done

--- a/transforms/.make.workflows
+++ b/transforms/.make.workflows
@@ -27,7 +27,9 @@ set-versions:
 .workflows.compile-pipeline:
 	. ${WORKFLOW_VENV_ACTIVATE} && ${PYTHON} ${WF_NAME}.py
 
-KFP_LIB_SRC_FILES := $(shell find ${REPOROOT}/kfp/kfp_support_lib/${WORKFLOW_SUPPORT_LIB}/src/ -name '*.py')
+KFP_SHARED_LIB_SRC_FILES := $(shell find ${REPOROOT}/kfp/kfp_support_lib/shared_workflow_support/ \( -name '*.py' -o -name '*.toml' \))
+
+KFP_LIB_SRC_FILES := $(shell find ${REPOROOT}/kfp/kfp_support_lib/${WORKFLOW_SUPPORT_LIB}/ \( -name '*.py' -o -name '*.toml' \))
 
 KFP_LIB_CONFIG_FILE := ${REPOROOT}/kfp/kfp_support_lib/${WORKFLOW_SUPPORT_LIB}/pyproject.toml
 
@@ -51,7 +53,7 @@ endif
 	. ${WORKFLOW_VENV_ACTIVATE}  && ${PYTHON} -m workflow_support.pipeline_utils.pipelines_tests_utils -c "sanity-test" -p ${CURDIR}/${PIPELINE_FILE} -e ${KFP_ENDPOINT}
 
 
-${WORKFLOW_VENV_ACTIVATE}: ${REPOROOT}/.make.versions ${REPOROOT}/kfp/kfp_ray_components/requirements.txt ${DPK_RAY_LIB_DIR} ${KFP_LIB_SRC_FILES} ${KFP_LIB_CONFIG_FILE}
+${WORKFLOW_VENV_ACTIVATE}: ${REPOROOT}/.make.versions ${REPOROOT}/kfp/kfp_ray_components/requirements.txt ${DPK_RAY_LIB_DIR} ${KFP_LIB_SRC_FILES} ${KFP_LIB_CONFIG_FILE} ${KFP_SHARED_LIB_SRC_FILES}
 	rm -rf ${REPOROOT}/transforms/venv
 	$(MAKE) -C ${REPOROOT}/transforms .defaults.ray-lib-src-venv
 	. ${WORKFLOW_VENV_ACTIVATE};     \

--- a/transforms/Makefile
+++ b/transforms/Makefile
@@ -56,6 +56,10 @@ workflow-test::
 	@# Help: Recursively make $@ in subdirs
 	$(MAKE) RULE=$@ .recurse
 
+workflow-build::
+	@# Help: Recursively make $@ in subdirs
+	$(MAKE) RULE=$@ .recurse
+
 workflow-upload::
 	@# Help: Recursively make $@ in subdirs
 	$(MAKE) RULE=$@ .recurse

--- a/transforms/Makefile
+++ b/transforms/Makefile
@@ -13,6 +13,10 @@ clean::
 	@# Help: Recursively make $@ all subdirs 
 	$(MAKE) RULE=$@ .recurse
 
+setup::
+	@# Help: Recursively make $@ in subdirs 
+	$(MAKE) RULE=$@ .recurse
+
 build::
 	@# Help: Recursively make $@ in subdirs 
 	$(MAKE) RULE=$@ .recurse

--- a/transforms/code/Makefile
+++ b/transforms/code/Makefile
@@ -14,6 +14,7 @@ venv::
 test:: 
 	@# Help: Recursively test in all subdirs 
 	@$(MAKE) RULE=test .recurse
+
 setup:: 
 	@# Help: Recursively $@ in all subdirs 
 	@$(MAKE) RULE=$@ .recurse

--- a/transforms/code/Makefile
+++ b/transforms/code/Makefile
@@ -47,14 +47,14 @@ workflow-venv::
 	@# Help: Recursively make $@ in subdirs
 	$(MAKE) RULE=$@ .recurse	
 
-setup::
-	@# Help: Recursively make $@ in subdirs
-	$(MAKE) RULE=$@ .recurse
-
 workflow-test::
 	@# Help: Recursively make $@ in subdirs
 	$(MAKE) RULE=$@ .recurse
 
 workflow-upload::
+	@# Help: Recursively make $@ in subdirs
+	$(MAKE) RULE=$@ .recurse
+
+workflow-build::
 	@# Help: Recursively make $@ in subdirs
 	$(MAKE) RULE=$@ .recurse

--- a/transforms/code/code2parquet/Makefile
+++ b/transforms/code/code2parquet/Makefile
@@ -57,3 +57,6 @@ workflow-test:
 workflow-upload:
 	$(MAKE) -C kfp_ray workflow-upload
 
+.PHONY: workflow-build
+workflow-build:
+	$(MAKE) -C  kfp_ray workflow-build

--- a/transforms/code/code2parquet/kfp_ray/Makefile
+++ b/transforms/code/code2parquet/kfp_ray/Makefile
@@ -31,16 +31,16 @@ test-image::
 load-image::
 
 
-.PHONY: setup
-setup: workflow-venv
+.PHONY: workflow-build
+workflow-build: workflow-venv
 	$(MAKE) $(YAML_WF)
 
 .PHONY: workflow-test
-workflow-test: setup
+workflow-test: workflow-build
 	$(MAKE) .workflows.test-pipeline TRANSFORM_SRC=${SRC_DIR} PIPELINE_FILE=code2parquet_wf.yaml
 
 .PHONY: workflow-upload
-workflow-upload: setup
+workflow-upload: workflow-build
 	@for file in $(YAML_WF); do \
 		$(MAKE) .workflows.upload-pipeline PIPELINE_FILE=$$file; \
 	done

--- a/transforms/code/code2parquet/kfp_ray/Makefile
+++ b/transforms/code/code2parquet/kfp_ray/Makefile
@@ -18,6 +18,8 @@ venv::
 
 build::
 
+setup::
+
 test::
 
 test-src::

--- a/transforms/code/code_quality/Makefile
+++ b/transforms/code/code_quality/Makefile
@@ -57,3 +57,6 @@ workflow-test:
 workflow-upload:
 	$(MAKE) -C  kfp_ray workflow-upload
 
+.PHONY: workflow-build
+workflow-build:
+	$(MAKE) -C  kfp_ray workflow-build

--- a/transforms/code/code_quality/kfp_ray/Makefile
+++ b/transforms/code/code_quality/kfp_ray/Makefile
@@ -18,6 +18,8 @@ venv::
 
 build::
 
+setup::
+
 test::
 
 test-src::

--- a/transforms/code/code_quality/kfp_ray/Makefile
+++ b/transforms/code/code_quality/kfp_ray/Makefile
@@ -31,16 +31,16 @@ image::
 load-image::
 
 
-.PHONY: setup
-setup: workflow-venv
+.PHONY: workflow-build
+workflow-build: workflow-venv
 	$(MAKE) $(YAML_WF)
 
 .PHONY: workflow-test
-workflow-test: setup
+workflow-test: workflow-build
 	$(MAKE) .workflows.test-pipeline TRANSFORM_SRC=${SRC_DIR} PIPELINE_FILE=code_quality_wf.yaml
 
 .PHONY: workflow-upload
-workflow-upload: setup
+workflow-upload: workflow-build
 	@for file in $(YAML_WF); do \
 		$(MAKE) .workflows.upload-pipeline PIPELINE_FILE=$$file; \
 	done

--- a/transforms/code/malware/Makefile
+++ b/transforms/code/malware/Makefile
@@ -56,3 +56,7 @@ workflow-test:
 .PHONY: workflow-upload
 workflow-upload:
 	$(MAKE) -C kfp_ray workflow-upload
+
+.PHONY: workflow-build
+workflow-build:
+	$(MAKE) -C  kfp_ray workflow-build

--- a/transforms/code/malware/kfp_ray/Makefile
+++ b/transforms/code/malware/kfp_ray/Makefile
@@ -18,6 +18,8 @@ venv::
 
 build::
 
+setup::
+
 test::
 
 test-src::

--- a/transforms/code/malware/kfp_ray/Makefile
+++ b/transforms/code/malware/kfp_ray/Makefile
@@ -30,16 +30,16 @@ image::
 
 load-image::
 
-.PHONY: setup
-setup: workflow-venv
+.PHONY: workflow-build
+workflow-build: workflow-venv
 	$(MAKE) $(YAML_WF)
 
 .PHONY: workflow-test
-workflow-test: setup
+workflow-test: workflow-build
 	$(MAKE) .workflows.test-pipeline TRANSFORM_SRC=${SRC_DIR} PIPELINE_FILE=malware_wf.yaml
 
 .PHONY: workflow-upload
-workflow-upload: setup
+workflow-upload: workflow-build
 	@for file in $(YAML_WF); do \
 		$(MAKE) .workflows.upload-pipeline PIPELINE_FILE=$$file; \
 	done

--- a/transforms/code/proglang_select/Makefile
+++ b/transforms/code/proglang_select/Makefile
@@ -57,3 +57,6 @@ workflow-test:
 workflow-upload:
 	$(MAKE) -C kfp_ray workflow-upload
 
+.PHONY: workflow-build
+workflow-build:
+	$(MAKE) -C  kfp_ray workflow-build

--- a/transforms/code/proglang_select/kfp_ray/Makefile
+++ b/transforms/code/proglang_select/kfp_ray/Makefile
@@ -18,6 +18,8 @@ venv::
 
 build::
 
+setup::
+
 test::
 
 test-src::

--- a/transforms/code/proglang_select/kfp_ray/Makefile
+++ b/transforms/code/proglang_select/kfp_ray/Makefile
@@ -30,16 +30,16 @@ image::
 
 load-image::
 
-.PHONY: setup
-setup: workflow-venv
+.PHONY: workflow-build
+workflow-build: workflow-venv
 	$(MAKE) $(YAML_WF)
 
 .PHONY: workflow-test
-workflow-test: setup
+workflow-test: workflow-build
 	$(MAKE) .workflows.test-pipeline TRANSFORM_SRC=${SRC_DIR} PIPELINE_FILE=proglang_select_wf.yaml
 
 .PHONY: workflow-upload
-workflow-upload: setup
+workflow-upload: workflow-build
 	@for file in $(YAML_WF); do \
 		$(MAKE) .workflows.upload-pipeline PIPELINE_FILE=$$file; \
 	done

--- a/transforms/language/Makefile
+++ b/transforms/language/Makefile
@@ -58,3 +58,6 @@ workflow-upload::
 	@# Help: Recursively make $@ in subdirs
 	$(MAKE) RULE=$@ .recurse
 
+workflow-build::
+	@# Help: Recursively make $@ in subdirs
+	$(MAKE) RULE=$@ .recurse

--- a/transforms/language/lang_id/Makefile
+++ b/transforms/language/lang_id/Makefile
@@ -56,3 +56,7 @@ workflow-test:
 .PHONY: workflow-upload
 workflow-upload:
 	$(MAKE) -C kfp_ray workflow-upload
+
+.PHONY: workflow-build
+workflow-build:
+	$(MAKE) -C  kfp_ray workflow-build

--- a/transforms/language/lang_id/Makefile
+++ b/transforms/language/lang_id/Makefile
@@ -13,6 +13,11 @@ clean::
 build::
 	@# Help: Recursively make $@ in subdirs 
 	$(MAKE) RULE=$@ .recurse
+	
+setup::
+	@# Help: Recursively make $@ in subdirs 
+	$(MAKE) RULE=$@ .recurse
+
 venv::
 	@# Help: Recursively make $@ in subdirs 
 	$(MAKE) RULE=$@ .recurse

--- a/transforms/language/lang_id/kfp_ray/Makefile
+++ b/transforms/language/lang_id/kfp_ray/Makefile
@@ -18,6 +18,8 @@ venv::
 
 build::
 
+setup::
+
 test::
 
 test-src::

--- a/transforms/language/lang_id/kfp_ray/Makefile
+++ b/transforms/language/lang_id/kfp_ray/Makefile
@@ -30,16 +30,16 @@ image::
 
 load-image::
 
-.PHONY: setup
-setup: workflow-venv
+.PHONY: workflow-build
+workflow-build: workflow-venv
 	$(MAKE) $(YAML_WF)
 
 .PHONY: workflow-test
-workflow-test: setup
+workflow-test: workflow-build
 	$(MAKE) .workflows.test-pipeline TRANSFORM_SRC=${SRC_DIR} PIPELINE_FILE=lang_id_wf.yaml
 
 .PHONY: workflow-upload
-workflow-upload: setup
+workflow-upload: workflow-build
 	@for file in $(YAML_WF); do \
 		$(MAKE) .workflows.upload-pipeline PIPELINE_FILE=$$file; \
 	done

--- a/transforms/universal/Makefile
+++ b/transforms/universal/Makefile
@@ -61,3 +61,7 @@ workflow-test::
 workflow-upload::
 	@# Help: Recursively make $@ in subdirs
 	$(MAKE) RULE=$@ .recurse
+
+workflow-build::
+	@# Help: Recursively make $@ in subdirs
+	$(MAKE) RULE=$@ .recurse

--- a/transforms/universal/Makefile
+++ b/transforms/universal/Makefile
@@ -8,6 +8,9 @@ clean::
 build::
 	@# Help: Recursively make $@ all subdirs 
 	$(MAKE) RULE=$@ .recurse
+setup::
+	@# Help: Recursively make $@ in subdirs 
+	$(MAKE) RULE=$@ .recurse
 venv::
 	@# Help: Recursively make $@ in all subdirs 
 	$(MAKE) RULE=$@ .recurse

--- a/transforms/universal/doc_id/Makefile
+++ b/transforms/universal/doc_id/Makefile
@@ -56,3 +56,7 @@ workflow-test:
 .PHONY: workflow-upload
 workflow-upload:
 	$(MAKE) -C kfp_ray workflow-upload
+
+.PHONY: workflow-build
+workflow-build:
+	$(MAKE) -C  kfp_ray workflow-build

--- a/transforms/universal/doc_id/kfp_ray/Makefile
+++ b/transforms/universal/doc_id/kfp_ray/Makefile
@@ -18,6 +18,8 @@ venv::
 
 build::
 
+setup::
+
 test::
 
 test-src::

--- a/transforms/universal/doc_id/kfp_ray/Makefile
+++ b/transforms/universal/doc_id/kfp_ray/Makefile
@@ -30,16 +30,16 @@ image::
 
 load-image::
 
-.PHONY: setup
-setup: workflow-venv
+.PHONY: workflow-build
+workflow-build: workflow-venv
 	$(MAKE) $(YAML_WF)
 
 .PHONY: workflow-test
-workflow-test: setup
+workflow-test: workflow-build
 	$(MAKE) .workflows.test-pipeline TRANSFORM_SRC=${SRC_DIR} PIPELINE_FILE=doc_id_wf.yaml
 
 .PHONY: workflow-upload
-workflow-upload: setup
+workflow-upload: workflow-build
 	@for file in $(YAML_WF); do \
 		$(MAKE) .workflows.upload-pipeline PIPELINE_FILE=$$file; \
 	done

--- a/transforms/universal/ededup/Makefile
+++ b/transforms/universal/ededup/Makefile
@@ -57,3 +57,6 @@ workflow-test:
 workflow-upload:
 	$(MAKE) -C kfp_ray workflow-upload
 
+.PHONY: workflow-build
+workflow-build:
+	$(MAKE) -C  kfp_ray workflow-build

--- a/transforms/universal/ededup/kfp_ray/Makefile
+++ b/transforms/universal/ededup/kfp_ray/Makefile
@@ -29,16 +29,16 @@ image::
 
 load-image::
 
-.PHONY: setup
-setup: workflow-venv
+.PHONY: workflow-build
+workflow-build: workflow-venv
 	$(MAKE) $(YAML_WF)
 
 .PHONY: workflow-test
-workflow-test: setup
+workflow-test: workflow-build
 	$(MAKE) .workflows.test-pipeline TRANSFORM_SRC=${SRC_DIR} PIPELINE_FILE=ededup_wf.yaml
 
 .PHONY: workflow-upload
-workflow-upload: setup
+workflow-upload: workflow-build
 	@for file in $(YAML_WF); do \
 		$(MAKE) .workflows.upload-pipeline PIPELINE_FILE=$$file; \
 	done

--- a/transforms/universal/ededup/kfp_ray/Makefile
+++ b/transforms/universal/ededup/kfp_ray/Makefile
@@ -17,6 +17,8 @@ venv::
 
 build::
 
+setup::
+
 test::
 
 test-src::

--- a/transforms/universal/fdedup/Makefile
+++ b/transforms/universal/fdedup/Makefile
@@ -56,3 +56,7 @@ workflow-test:
 .PHONY: workflow-upload
 workflow-upload:
 	$(MAKE) -C kfp_ray workflow-upload
+
+.PHONY: workflow-build
+workflow-build:
+	$(MAKE) -C  kfp_ray workflow-build

--- a/transforms/universal/fdedup/kfp_ray/Makefile
+++ b/transforms/universal/fdedup/kfp_ray/Makefile
@@ -18,6 +18,8 @@ venv::
 
 build::
 
+setup::
+
 test::
 
 test-src::

--- a/transforms/universal/fdedup/kfp_ray/Makefile
+++ b/transforms/universal/fdedup/kfp_ray/Makefile
@@ -30,16 +30,16 @@ test-image::
 
 load-image::
 
-.PHONY: setup
-setup: workflow-venv
+.PHONY: workflow-build
+workflow-build: workflow-venv
 	$(MAKE) $(YAML_WF)
 
 .PHONY: workflow-test
-workflow-test: setup
+workflow-test: workflow-build
 	$(MAKE) .workflows.test-pipeline TRANSFORM_SRC=${SRC_DIR} PIPELINE_FILE=fdedup_wf.yaml
 
 .PHONY: workflow-upload
-workflow-upload: setup
+workflow-upload: workflow-build
 	@for file in $(YAML_WF); do \
 		$(MAKE) .workflows.upload-pipeline PIPELINE_FILE=$$file; \
 	done

--- a/transforms/universal/filter/Makefile
+++ b/transforms/universal/filter/Makefile
@@ -56,3 +56,7 @@ workflow-test:
 .PHONY: workflow-upload
 workflow-upload:
 	$(MAKE) -C kfp_ray workflow-upload
+
+.PHONY: workflow-build
+workflow-build:
+	$(MAKE) -C  kfp_ray workflow-build

--- a/transforms/universal/filter/kfp_ray/Makefile
+++ b/transforms/universal/filter/kfp_ray/Makefile
@@ -18,6 +18,8 @@ venv::
 
 build::
 
+setup::
+
 test::
 
 test-src::

--- a/transforms/universal/filter/kfp_ray/Makefile
+++ b/transforms/universal/filter/kfp_ray/Makefile
@@ -30,16 +30,16 @@ image::
 
 load-image::
 
-.PHONY: setup
-setup: workflow-venv
+.PHONY: workflow-build
+workflow-build: workflow-venv
 	$(MAKE) $(YAML_WF)
 
 .PHONY: workflow-test
-workflow-test: setup
+workflow-test: workflow-build
 	$(MAKE) .workflows.test-pipeline TRANSFORM_SRC=${SRC_DIR} PIPELINE_FILE=filter_wf.yaml
 
 .PHONY: workflow-upload
-workflow-upload: setup
+workflow-upload: workflow-build
 	@for file in $(YAML_WF); do \
 		$(MAKE) .workflows.upload-pipeline PIPELINE_FILE=$$file; \
 	done

--- a/transforms/universal/noop/Makefile
+++ b/transforms/universal/noop/Makefile
@@ -56,3 +56,7 @@ workflow-test:
 .PHONY: workflow-upload
 workflow-upload:
 	$(MAKE) -C kfp_ray workflow-upload
+
+.PHONY: workflow-build
+workflow-build:
+	$(MAKE) -C  kfp_ray workflow-build

--- a/transforms/universal/noop/kfp_ray/Makefile
+++ b/transforms/universal/noop/kfp_ray/Makefile
@@ -18,6 +18,8 @@ venv::
 
 build::
 
+setup::
+
 test::
 
 test-src::

--- a/transforms/universal/noop/kfp_ray/Makefile
+++ b/transforms/universal/noop/kfp_ray/Makefile
@@ -30,16 +30,16 @@ image::
 
 load-image::
 
-.PHONY: setup
-setup: workflow-venv
+.PHONY: workflow-build
+workflow-build: workflow-venv
 	$(MAKE) $(YAML_WF)
 
 .PHONY: workflow-test
-workflow-test: setup
+workflow-test: workflow-build
 	$(MAKE) .workflows.test-pipeline TRANSFORM_SRC=${SRC_DIR} PIPELINE_FILE=noop_wf.yaml
 
 .PHONY: workflow-upload
-workflow-upload: setup
+workflow-upload: workflow-build
 	@for file in $(YAML_WF); do \
 		$(MAKE) .workflows.upload-pipeline PIPELINE_FILE=$$file; \
 	done

--- a/transforms/universal/profiler/Makefile
+++ b/transforms/universal/profiler/Makefile
@@ -57,5 +57,6 @@ workflow-test:
 workflow-upload:
 	$(MAKE) -C kfp_ray workflow-upload
 
-.PHONY: workflow-reconcile-requirements
-	$(MAKE) -C kfp_ray workflow-reconcile-requirements
+.PHONY: workflow-build
+workflow-build:
+	$(MAKE) -C  kfp_ray workflow-build

--- a/transforms/universal/profiler/kfp_ray/Makefile
+++ b/transforms/universal/profiler/kfp_ray/Makefile
@@ -18,6 +18,8 @@ venv::
 
 build::
 
+setup::
+
 test::
 
 test-src::

--- a/transforms/universal/profiler/kfp_ray/Makefile
+++ b/transforms/universal/profiler/kfp_ray/Makefile
@@ -30,16 +30,16 @@ image::
 
 load-image::
 
-.PHONY: setup
-setup: workflow-venv
+.PHONY: workflow-build
+workflow-build: workflow-venv
 	$(MAKE) $(YAML_WF)
 
 .PHONY: workflow-test
-workflow-test: setup
+workflow-test: workflow-build
 	$(MAKE) .workflows.test-pipeline TRANSFORM_SRC=${SRC_DIR} PIPELINE_FILE=profiler_wf.yaml
 
 .PHONY: workflow-upload
-workflow-upload: setup
+workflow-upload: workflow-build
 	@for file in $(YAML_WF); do \
 		$(MAKE) .workflows.upload-pipeline PIPELINE_FILE=$$file; \
 	done

--- a/transforms/universal/tokenization/Makefile
+++ b/transforms/universal/tokenization/Makefile
@@ -56,3 +56,7 @@ workflow-test:
 .PHONY: workflow-upload
 workflow-upload:
 	$(MAKE) -C kfp_ray workflow-upload
+
+.PHONY: workflow-build
+workflow-build:
+	$(MAKE) -C  kfp_ray workflow-build

--- a/transforms/universal/tokenization/kfp_ray/Makefile
+++ b/transforms/universal/tokenization/kfp_ray/Makefile
@@ -18,6 +18,8 @@ venv::
 
 build::
 
+setup::
+
 test::
 
 test-src::

--- a/transforms/universal/tokenization/kfp_ray/Makefile
+++ b/transforms/universal/tokenization/kfp_ray/Makefile
@@ -30,16 +30,16 @@ image::
 
 load-image::
 
-.PHONY: setup
-setup: workflow-venv
+.PHONY: workflow-build
+workflow-build: workflow-venv
 	$(MAKE) $(YAML_WF)
 
 .PHONY: workflow-test
-workflow-test: setup
+workflow-test: workflow-build
 	$(MAKE) .workflows.test-pipeline TRANSFORM_SRC=${SRC_DIR} PIPELINE_FILE=tokenization_wf.yaml
 
 .PHONY: workflow-upload
-workflow-upload: setup
+workflow-upload: workflow-build
 	@for file in $(YAML_WF); do \
 		$(MAKE) .workflows.upload-pipeline PIPELINE_FILE=$$file; \
 	done


### PR DESCRIPTION
## Why are these changes needed?

This PR adds workflow-build target in transforms directory.
The `setup` target which is now used to build the workflows is left empty.

## Related issue number (if any).
#345 


