### PR TITLE
Update release-branch script to not verify commits to avoid failures

### DIFF
--- a/.make.versions
+++ b/.make.versions
@@ -16,10 +16,10 @@ DPK_MAJOR_VERSION=0
 # The minor version is incremented manually when significant features have been added that are backward compatible with the previous major.minor release.
 DPK_MINOR_VERSION=2
 # The minor version is incremented AUTOMATICALLY by the release.sh script when a new release is set.
-DPK_MICRO_VERSION=1
+DPK_MICRO_VERSION=0
 # The suffix is generally always set in the main/development branch and only nulled out when creating release branches.
 # It can be manually incremented, for example, to allow publishing a new intermediate version wheel to pypi. 
-DPK_VERSION_SUFFIX=.dev0
+DPK_VERSION_SUFFIX=.dev6
 
 DPK_VERSION=$(DPK_MAJOR_VERSION).$(DPK_MINOR_VERSION).$(DPK_MICRO_VERSION)$(DPK_VERSION_SUFFIX)
 

--- a/data-processing-lib/python/pyproject.toml
+++ b/data-processing-lib/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "data_prep_toolkit"
-version = "0.2.1.dev0"
+version = "0.2.0.dev6"
 requires-python = ">=3.10"
 keywords = ["data", "data preprocessing", "data preparation", "llm", "generative", "ai", "fine-tuning", "llmapps" ]
 description = "Data Preparation Toolkit Library"

--- a/data-processing-lib/ray/pyproject.toml
+++ b/data-processing-lib/ray/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "data_prep_toolkit_ray"
-version = "0.2.1.dev0"
+version = "0.2.0.dev6"
 keywords = ["data", "data preprocessing", "data preparation", "llm", "generative", "ai", "fine-tuning", "llmapps" ]
 requires-python = ">=3.10"
 description = "Data Preparation Toolkit Library for Ray"
@@ -11,7 +11,7 @@ authors = [
     { name = "Boris Lublinsky", email = "blublinsky@ibm.com" },
 ]
 dependencies = [
-    "data-prep-toolkit==0.2.1.dev0",
+    "data-prep-toolkit==0.2.0.dev6",
     "ray[default]==2.24.0",
     # These two are to fix security issues identified by quay.io
     "fastapi>=0.110.2",

--- a/data-processing-lib/spark/pyproject.toml
+++ b/data-processing-lib/spark/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "data_prep_toolkit_spark"
-version = "0.2.1.dev0"
+version = "0.2.0.dev6"
 keywords = ["data", "data preprocessing", "data preparation", "llm", "generative", "ai", "fine-tuning", "llmapps" ]
 requires-python = ">=3.10"
 description = "Data Preparation Toolkit Library for Spark"
@@ -11,7 +11,7 @@ authors = [
     { name = "Constantin Adam", email = "cmadam@us.ibm.com" },
 ]
 dependencies = [
-    "data-prep-toolkit==0.2.1.dev0",	
+    "data-prep-toolkit==0.2.0.dev6",	
     "pyspark>=3.5.1",
     "pyyaml>=6.0.1",
 ]

--- a/kfp/kfp_support_lib/kfp_v1_workflow_support/pyproject.toml
+++ b/kfp/kfp_support_lib/kfp_v1_workflow_support/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "data_prep_toolkit_kfp_v1"
-version = "0.2.1.dev0"
+version = "0.2.0.dev6"
 requires-python = ">=3.10,<3.12"
 description = "Data Preparation Kit Library. KFP support"
 license = {text = "Apache-2.0"}
@@ -13,7 +13,7 @@ authors = [
 ]
 dependencies = [
     "kfp==1.8.22",
-    "data-prep-toolkit-kfp-shared==0.2.1.dev0",
+    "data-prep-toolkit-kfp-shared==0.2.0.dev6",
 ]
 
 [build-system]

--- a/kfp/kfp_support_lib/kfp_v2_workflow_support/pyproject.toml
+++ b/kfp/kfp_support_lib/kfp_v2_workflow_support/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "data_prep_toolkit_kfp_v2"
-version = "0.2.1.dev0"
+version = "0.2.0.dev6"
 requires-python = ">=3.10,<3.12"
 description = "Data Preparation Kit Library. KFP support"
 license = {text = "Apache-2.0"}
@@ -14,7 +14,7 @@ authors = [
 dependencies = [
     "kfp==2.7.0",
     "kfp-kubernetes==1.2.0",
-    "data-prep-toolkit-kfp-shared==0.2.1.dev0",
+    "data-prep-toolkit-kfp-shared==0.2.0.dev6",
 ]
 
 [build-system]

--- a/kfp/kfp_support_lib/shared_workflow_support/pyproject.toml
+++ b/kfp/kfp_support_lib/shared_workflow_support/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "data_prep_toolkit_kfp_shared"
-version = "0.2.1.dev0"
+version = "0.2.0.dev6"
 requires-python = ">=3.10,<3.12"
 description = "Data Preparation Kit Library. KFP support"
 license = {text = "Apache-2.0"}
@@ -14,7 +14,7 @@ authors = [
 dependencies = [
     "requests",
     "kubernetes",
-    "data-prep-toolkit-ray==0.2.1.dev0",
+    "data-prep-toolkit-ray==0.2.0.dev6",
 ]
 
 [build-system]

--- a/kfp/superworkflows/ray/kfp_v1/superworkflow_code_sample_wf.py
+++ b/kfp/superworkflows/ray/kfp_v1/superworkflow_code_sample_wf.py
@@ -4,6 +4,7 @@ import kfp.dsl as dsl
 from workflow_support.compile_utils import ONE_WEEK_SEC
 
 
+# empty comment to triigger pre-commit
 # Components
 # For every sub workflow we need a separate components, that knows about this subworkflow.
 component_spec_path = "../../../kfp_ray_components/"

--- a/kfp/superworkflows/ray/kfp_v1/superworkflow_code_sample_wf.py
+++ b/kfp/superworkflows/ray/kfp_v1/superworkflow_code_sample_wf.py
@@ -16,14 +16,14 @@ run_exact_dedup_op = comp.load_component_from_file(component_spec_path + "execut
 run_fuzzy_dedup_op = comp.load_component_from_file(component_spec_path + "executeSubWorkflowComponent.yaml")
 run_tokenization_op = comp.load_component_from_file(component_spec_path + "executeSubWorkflowComponent.yaml")
 
-code_to_parquet_image = "quay.io/dataprep1/data-prep-kit/code2parquet-ray:0.2.1.dev0"
-proglang_select_image = "quay.io/dataprep1/data-prep-kit/proglang_select-ray:0.2.1.dev0"
-code_quality_image = "quay.io/dataprep1/data-prep-kit/code_quality-ray:0.2.1.dev0"
-malware_image = "quay.io/dataprep1/data-prep-kit/malware-ray:0.2.1.dev0"
-doc_id_image = "quay.io/dataprep1/data-prep-kit/doc_id-ray:0.2.1.dev0"
-ededup_image = "quay.io/dataprep1/data-prep-kit/ededup-ray:0.2.1.dev0"
-fdedup_image = "quay.io/dataprep1/data-prep-kit/fdedup-ray:0.2.1.dev0"
-tokenizer_image = "quay.io/dataprep1/data-prep-kit/tokenization-ray:0.2.1.dev0"
+code_to_parquet_image = "quay.io/dataprep1/data-prep-kit/code2parquet-ray:0.2.0.dev6"
+proglang_select_image = "quay.io/dataprep1/data-prep-kit/proglang_select-ray:0.2.0.dev6"
+code_quality_image = "quay.io/dataprep1/data-prep-kit/code_quality-ray:0.2.0.dev6"
+malware_image = "quay.io/dataprep1/data-prep-kit/malware-ray:0.2.0.dev6"
+doc_id_image = "quay.io/dataprep1/data-prep-kit/doc_id-ray:0.2.0.dev6"
+ededup_image = "quay.io/dataprep1/data-prep-kit/ededup-ray:0.2.0.dev6"
+fdedup_image = "quay.io/dataprep1/data-prep-kit/fdedup-ray:0.2.0.dev6"
+tokenizer_image = "quay.io/dataprep1/data-prep-kit/tokenization-ray:0.2.0.dev6"
 
 
 # Pipeline to invoke execution on remote resource

--- a/kfp/superworkflows/ray/kfp_v1/superworkflow_dedups_sample_wf.py
+++ b/kfp/superworkflows/ray/kfp_v1/superworkflow_dedups_sample_wf.py
@@ -12,9 +12,9 @@ run_doc_id_op = comp.load_component_from_file(component_spec_path + "executeSubW
 run_exact_dedup_op = comp.load_component_from_file(component_spec_path + "executeSubWorkflowComponent.yaml")
 run_fuzzy_dedup_op = comp.load_component_from_file(component_spec_path + "executeSubWorkflowComponent.yaml")
 
-doc_id_image = "quay.io/dataprep1/data-prep-kit/doc_id-ray:0.2.1.dev0"
-ededup_image = "quay.io/dataprep1/data-prep-kit/ededup-ray:0.2.1.dev0"
-fdedup_image = "quay.io/dataprep1/data-prep-kit/fdedup-ray:0.2.1.dev0"
+doc_id_image = "quay.io/dataprep1/data-prep-kit/doc_id-ray:0.2.0.dev6"
+ededup_image = "quay.io/dataprep1/data-prep-kit/ededup-ray:0.2.0.dev6"
+fdedup_image = "quay.io/dataprep1/data-prep-kit/fdedup-ray:0.2.0.dev6"
 
 # Pipeline to invoke execution on remote resource
 @dsl.pipeline(

--- a/scripts/release-branch.sh
+++ b/scripts/release-branch.sh
@@ -49,7 +49,7 @@ make set-versions > /dev/null
 # Commit the changes to the release branch and tag it
 git status
 echo Committing and pushing version changes in $release_branch branch. 
-git commit -s -a -m "Cut release $version"
+git commit --no-verify -s -a -m "Cut release $version"
 git push --set-upstream origin $release_branch 
 echo Committing and pushing tag $tag in $release_branch branch
 git tag -a -s -m "Cut release $version" $tag 
@@ -72,7 +72,7 @@ make set-versions > /dev/null
 # Push the version change back to the origin
 if [ -z "$debug" ]; then
     echo Committing and pushing version $next_version to $DEFAULT_BRANCH branch.
-    git commit -s -a -m "Bump micro version to $next_version after cutting release $version into branch $release_branch"
+    git commit --no-verify -s -a -m "Bump micro version to $next_version after cutting release $version into branch $release_branch"
     git diff origin/$DEFAULT_BRANCH $DEFAULT_BRANCH
     git push origin
 else

--- a/transforms/code/code2parquet/kfp_ray/code2parquet_wf.py
+++ b/transforms/code/code2parquet/kfp_ray/code2parquet_wf.py
@@ -21,11 +21,11 @@ from workflow_support.compile_utils import ONE_HOUR_SEC, ONE_WEEK_SEC, Component
 # the name of the job script
 EXEC_SCRIPT_NAME: str = "code2parquet_transform_ray.py"
 
-task_image = "quay.io/dataprep1/data-prep-kit/code2parquet-ray:0.2.1.dev0"
+task_image = "quay.io/dataprep1/data-prep-kit/code2parquet-ray:0.2.0.dev6"
 
 
 # components
-base_kfp_image = "quay.io/dataprep1/data-prep-kit/kfp-data-processing:0.2.1.dev0"
+base_kfp_image = "quay.io/dataprep1/data-prep-kit/kfp-data-processing:0.2.0.dev6"
 
 # path to kfp component specifications files
 component_spec_path = "../../../../kfp/kfp_ray_components/"

--- a/transforms/code/code2parquet/python/pyproject.toml
+++ b/transforms/code/code2parquet/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "dpk_code2parquet_transform_python"
-version = "0.2.1.dev0"
+version = "0.2.0.dev6"
 requires-python = ">=3.10"
 description = "code2parquet Python Transform"
 license = {text = "Apache-2.0"}
@@ -10,7 +10,7 @@ authors = [
     { name = "Boris Lublinsky", email = "blublinsky@ibm.com" },
 ]
 dependencies = [
-    "data-prep-toolkit==0.2.1.dev0",
+    "data-prep-toolkit==0.2.0.dev6",
     "parameterized",
     "pandas",
 ]

--- a/transforms/code/code2parquet/ray/pyproject.toml
+++ b/transforms/code/code2parquet/ray/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "dpk_code2parquet_transform_ray"
-version = "0.2.1.dev0"
+version = "0.2.0.dev6"
 requires-python = ">=3.10"
 description = "code2parquet Ray Transform"
 license = {text = "Apache-2.0"}
@@ -10,8 +10,8 @@ authors = [
     { name = "Boris Lublinsky", email = "blublinsky@ibm.com" },
 ]
 dependencies = [
-    "data-prep-toolkit-ray==0.2.1.dev0",
-    "dpk-code2parquet-transform-python==0.2.1.dev0",
+    "data-prep-toolkit-ray==0.2.0.dev6",
+    "dpk-code2parquet-transform-python==0.2.0.dev6",
     "parameterized",
     "pandas",
 ]

--- a/transforms/code/code_quality/kfp_ray/code_quality_wf.py
+++ b/transforms/code/code_quality/kfp_ray/code_quality_wf.py
@@ -21,10 +21,10 @@ from workflow_support.compile_utils import ONE_HOUR_SEC, ONE_WEEK_SEC, Component
 EXEC_SCRIPT_NAME: str = "code_quality_transform_ray.py"
 PREFIX: str = ""
 
-task_image = "quay.io/dataprep1/data-prep-kit/code_quality-ray:0.2.1.dev0"
+task_image = "quay.io/dataprep1/data-prep-kit/code_quality-ray:0.2.0.dev6"
 
 # components
-base_kfp_image = "quay.io/dataprep1/data-prep-kit/kfp-data-processing:0.2.1.dev0"
+base_kfp_image = "quay.io/dataprep1/data-prep-kit/kfp-data-processing:0.2.0.dev6"
 
 # path to kfp component specifications files
 component_spec_path = "../../../../kfp/kfp_ray_components/"

--- a/transforms/code/code_quality/python/pyproject.toml
+++ b/transforms/code/code_quality/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "dpk_code_quality_transform_python"
-version = "0.2.1.dev0"
+version = "0.2.0.dev6"
 requires-python = ">=3.10"
 description = "Code Quality Python Transform"
 license = {text = "Apache-2.0"}
@@ -9,7 +9,7 @@ authors = [
     { name = "Shivdeep Singh", email = "shivdeep.singh@ibm.com" },
 ]
 dependencies = [
-    "data-prep-toolkit==0.2.1.dev0",
+    "data-prep-toolkit==0.2.0.dev6",
     "bs4==0.0.2",
     "transformers==4.38.2",
 ]

--- a/transforms/code/code_quality/ray/pyproject.toml
+++ b/transforms/code/code_quality/ray/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "dpk_code_quality_transform_ray"
-version = "0.2.1.dev0"
+version = "0.2.0.dev6"
 requires-python = ">=3.10"
 description = "Code Quality Ray Transform"
 license = {text = "Apache-2.0"}
@@ -9,8 +9,8 @@ authors = [
     { name = "Shivdeep Singh", email = "shivdeep.singh@ibm.com" },
 ]
 dependencies = [
-    "dpk-code-quality-transform-python==0.2.1.dev0",
-    "data-prep-toolkit-ray==0.2.1.dev0",
+    "dpk-code-quality-transform-python==0.2.0.dev6",
+    "data-prep-toolkit-ray==0.2.0.dev6",
 ]
 
 [build-system]

--- a/transforms/code/malware/kfp_ray/malware_wf.py
+++ b/transforms/code/malware/kfp_ray/malware_wf.py
@@ -21,10 +21,10 @@ from workflow_support.compile_utils import ONE_HOUR_SEC, ONE_WEEK_SEC, Component
 # the name of the job script
 EXEC_SCRIPT_NAME: str = "malware_transform_ray.py"
 
-task_image = "quay.io/dataprep1/data-prep-kit/malware-ray:0.2.1.dev0"
+task_image = "quay.io/dataprep1/data-prep-kit/malware-ray:0.2.0.dev6"
 
 # components
-base_kfp_image = "quay.io/dataprep1/data-prep-kit/kfp-data-processing:0.2.1.dev0"
+base_kfp_image = "quay.io/dataprep1/data-prep-kit/kfp-data-processing:0.2.0.dev6"
 
 # path to kfp component specifications files
 component_spec_path = "../../../../kfp/kfp_ray_components/"

--- a/transforms/code/malware/python/pyproject.toml
+++ b/transforms/code/malware/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "dpk_malware_transform_python"
-version = "0.2.1.dev0"
+version = "0.2.0.dev6"
 requires-python = ">=3.10"
 description = "Malware Python Transform"
 license = {text = "Apache-2.0"}
@@ -9,7 +9,7 @@ authors = [
     { name = "Takuya Goto", email = "tkyg@jp.ibm.com" },
 ]
 dependencies = [
-    "data-prep-toolkit==0.2.1.dev0",
+    "data-prep-toolkit==0.2.0.dev6",
     "clamd==1.0.2",
 ]
 

--- a/transforms/code/malware/ray/pyproject.toml
+++ b/transforms/code/malware/ray/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "dpk_malware_transform_ray"
-version = "0.2.1.dev0"
+version = "0.2.0.dev6"
 requires-python = ">=3.10"
 description = "Malware Ray Transform"
 license = {text = "Apache-2.0"}
@@ -9,8 +9,8 @@ authors = [
     { name = "Takuya Goto", email = "tkyg@jp.ibm.com" },
 ]
 dependencies = [
-    "dpk-malware-transform-python==0.2.1.dev0",
-    "data-prep-toolkit-ray==0.2.1.dev0",
+    "dpk-malware-transform-python==0.2.0.dev6",
+    "data-prep-toolkit-ray==0.2.0.dev6",
 ]
 
 [build-system]

--- a/transforms/code/proglang_select/kfp_ray/proglang_select_wf.py
+++ b/transforms/code/proglang_select/kfp_ray/proglang_select_wf.py
@@ -21,10 +21,10 @@ from workflow_support.compile_utils import ONE_HOUR_SEC, ONE_WEEK_SEC, Component
 # the name of the job script
 EXEC_SCRIPT_NAME: str = "proglang_select_transform_ray.py"
 
-task_image = "quay.io/dataprep1/data-prep-kit/proglang_select-ray:0.2.1.dev0"
+task_image = "quay.io/dataprep1/data-prep-kit/proglang_select-ray:0.2.0.dev6"
 
 # components
-base_kfp_image = "quay.io/dataprep1/data-prep-kit/kfp-data-processing:0.2.1.dev0"
+base_kfp_image = "quay.io/dataprep1/data-prep-kit/kfp-data-processing:0.2.0.dev6"
 
 # path to kfp component specifications files
 component_spec_path = "../../../../kfp/kfp_ray_components/"

--- a/transforms/code/proglang_select/python/pyproject.toml
+++ b/transforms/code/proglang_select/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "dpk_proglang_select_transform_python"
-version = "0.2.1.dev0"
+version = "0.2.0.dev6"
 requires-python = ">=3.10"
 description = "Programming Language Selection Python Transform"
 license = {text = "Apache-2.0"}
@@ -9,7 +9,7 @@ authors = [
     { name = "Shivdeep Singh", email = "shivdeep.singh@ibm.com" },
 ]
 dependencies = [
-    "data-prep-toolkit==0.2.1.dev0",
+    "data-prep-toolkit==0.2.0.dev6",
 ]
 
 [build-system]

--- a/transforms/code/proglang_select/ray/pyproject.toml
+++ b/transforms/code/proglang_select/ray/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "dpk_proglang_select_transform_ray"
-version = "0.2.1.dev0"
+version = "0.2.0.dev6"
 requires-python = ">=3.10"
 description = "Programming Language Selection Ray Transform"
 license = {text = "Apache-2.0"}
@@ -9,8 +9,8 @@ authors = [
     { name = "Shivdeep Singh", email = "shivdeep.singh@ibm.com" },
 ]
 dependencies = [
-    "dpk-proglang-select-transform-python==0.2.1.dev0",
-    "data-prep-toolkit-ray==0.2.1.dev0",
+    "dpk-proglang-select-transform-python==0.2.0.dev6",
+    "data-prep-toolkit-ray==0.2.0.dev6",
 ]
 
 [build-system]

--- a/transforms/language/lang_id/kfp_ray/lang_id_multiple_wf.py
+++ b/transforms/language/lang_id/kfp_ray/lang_id_multiple_wf.py
@@ -17,13 +17,13 @@ import kfp.dsl as dsl
 from workflow_support.compile_utils import ONE_HOUR_SEC, ONE_WEEK_SEC, ComponentUtils
 
 
-task_image = "quay.io/dataprep1/data-prep-kit/lang_id-ray:0.2.1.dev0"
+task_image = "quay.io/dataprep1/data-prep-kit/lang_id-ray:0.2.0.dev6"
 
 # the name of the job script
 EXEC_SCRIPT_NAME: str = "lang_id_transform_ray.py"
 
 # components
-base_kfp_image = "quay.io/dataprep1/data-prep-kit/kfp-data-processing:0.2.1.dev0"
+base_kfp_image = "quay.io/dataprep1/data-prep-kit/kfp-data-processing:0.2.0.dev6"
 
 # path to kfp component specifications files
 component_spec_path = "../../../../kfp/kfp_ray_components/"

--- a/transforms/language/lang_id/kfp_ray/lang_id_wf.py
+++ b/transforms/language/lang_id/kfp_ray/lang_id_wf.py
@@ -17,13 +17,13 @@ import kfp.dsl as dsl
 from workflow_support.compile_utils import ONE_HOUR_SEC, ONE_WEEK_SEC, ComponentUtils
 
 
-task_image = "quay.io/dataprep1/data-prep-kit/lang_id-ray:0.2.1.dev0"
+task_image = "quay.io/dataprep1/data-prep-kit/lang_id-ray:0.2.0.dev6"
 
 # the name of the job script
 EXEC_SCRIPT_NAME: str = "lang_id_transform_ray.py"
 
 # components
-base_kfp_image = "quay.io/dataprep1/data-prep-kit/kfp-data-processing:0.2.1.dev0"
+base_kfp_image = "quay.io/dataprep1/data-prep-kit/kfp-data-processing:0.2.0.dev6"
 
 # path to kfp component specifications files
 component_spec_path = "../../../../kfp/kfp_ray_components/"

--- a/transforms/language/lang_id/python/pyproject.toml
+++ b/transforms/language/lang_id/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "dpk_lang_id_transform_python"
-version = "0.2.1.dev0"
+version = "0.2.0.dev6"
 requires-python = ">=3.10"
 description = "Language Identification Python Transform"
 license = {text = "Apache-2.0"}
@@ -9,7 +9,7 @@ authors = [
     { name = "Daiki Tsuzuku", email = "dtsuzuku@jp.ibm.com" }
 ]
 dependencies = [
-    "data-prep-toolkit==0.2.1.dev0",
+    "data-prep-toolkit==0.2.0.dev6",
     "fasttext==0.9.2",
     "langcodes==3.3.0",
     "huggingface-hub==0.21.4",

--- a/transforms/language/lang_id/ray/pyproject.toml
+++ b/transforms/language/lang_id/ray/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "dpk_lang_id_transform_ray"
-version = "0.2.1.dev0"
+version = "0.2.0.dev6"
 requires-python = ">=3.10"
 description = "Language Identification Ray Transform"
 license = {text = "Apache-2.0"}
@@ -9,8 +9,8 @@ authors = [
     { name = "Daiki Tsuzuku", email = "dtsuzuku@jp.ibm.com" }
 ]
 dependencies = [
-    "dpk-lang_id-transform-python==0.2.1.dev0",
-    "data-prep-toolkit-ray==0.2.1.dev0",
+    "dpk-lang_id-transform-python==0.2.0.dev6",
+    "data-prep-toolkit-ray==0.2.0.dev6",
 ]
 
 [build-system]

--- a/transforms/universal/doc_id/kfp_ray/doc_id_wf.py
+++ b/transforms/universal/doc_id/kfp_ray/doc_id_wf.py
@@ -17,12 +17,12 @@ import kfp.dsl as dsl
 from workflow_support.compile_utils import ONE_HOUR_SEC, ONE_WEEK_SEC, ComponentUtils
 
 
-task_image = "quay.io/dataprep1/data-prep-kit/doc_id-ray:0.2.1.dev0"
+task_image = "quay.io/dataprep1/data-prep-kit/doc_id-ray:0.2.0.dev6"
 
 # the name of the job script
 EXEC_SCRIPT_NAME: str = "doc_id_transform_ray.py"
 # components
-base_kfp_image = "quay.io/dataprep1/data-prep-kit/kfp-data-processing:0.2.1.dev0"
+base_kfp_image = "quay.io/dataprep1/data-prep-kit/kfp-data-processing:0.2.0.dev6"
 
 # path to kfp component specifications files
 component_spec_path = "../../../../kfp/kfp_ray_components/"

--- a/transforms/universal/ededup/kfp_ray/ededup_wf.py
+++ b/transforms/universal/ededup/kfp_ray/ededup_wf.py
@@ -18,13 +18,13 @@ from src.ededup_compute_execution_params import ededup_compute_execution_params
 from workflow_support.compile_utils import ONE_HOUR_SEC, ONE_WEEK_SEC, ComponentUtils
 
 
-task_image = "quay.io/dataprep1/data-prep-kit/ededup-ray:0.2.1.dev0"
+task_image = "quay.io/dataprep1/data-prep-kit/ededup-ray:0.2.0.dev6"
 
 # the name of the job script
 EXEC_SCRIPT_NAME: str = "ededup_transform_ray.py"
 
 # components
-base_kfp_image = "quay.io/dataprep1/data-prep-kit/kfp-data-processing:0.2.1.dev0"
+base_kfp_image = "quay.io/dataprep1/data-prep-kit/kfp-data-processing:0.2.0.dev6"
 
 # path to kfp component specifications files
 component_spec_path = "../../../../kfp/kfp_ray_components/"

--- a/transforms/universal/fdedup/kfp_ray/fdedup_wf.py
+++ b/transforms/universal/fdedup/kfp_ray/fdedup_wf.py
@@ -18,13 +18,13 @@ from src.fdedup_compute_execution_params import fdedup_compute_execution_params
 from workflow_support.compile_utils import ONE_HOUR_SEC, ONE_WEEK_SEC, ComponentUtils
 
 
-task_image = "quay.io/dataprep1/data-prep-kit/fdedup-ray:0.2.1.dev0"
+task_image = "quay.io/dataprep1/data-prep-kit/fdedup-ray:0.2.0.dev6"
 
 # the name of the job script
 EXEC_SCRIPT_NAME: str = "fdedup_transform_ray.py"
 
 # components
-base_kfp_image = "quay.io/dataprep1/data-prep-kit/kfp-data-processing:0.2.1.dev0"
+base_kfp_image = "quay.io/dataprep1/data-prep-kit/kfp-data-processing:0.2.0.dev6"
 
 # path to kfp component specifications files
 component_spec_path = "../../../../kfp/kfp_ray_components/"

--- a/transforms/universal/filter/kfp_ray/filter_wf.py
+++ b/transforms/universal/filter/kfp_ray/filter_wf.py
@@ -21,10 +21,10 @@ from workflow_support.compile_utils import ONE_HOUR_SEC, ONE_WEEK_SEC, Component
 EXEC_SCRIPT_NAME: str = "filter_transform_ray.py"
 PREFIX: str = ""
 
-task_image = "quay.io/dataprep1/data-prep-kit/filter-ray:0.2.1.dev0"
+task_image = "quay.io/dataprep1/data-prep-kit/filter-ray:0.2.0.dev6"
 
 # components
-base_kfp_image = "quay.io/dataprep1/data-prep-kit/kfp-data-processing:0.2.1.dev0"
+base_kfp_image = "quay.io/dataprep1/data-prep-kit/kfp-data-processing:0.2.0.dev6"
 
 # path to kfp component specifications files
 component_spec_path = "../../../../kfp/kfp_ray_components/"

--- a/transforms/universal/filter/python/pyproject.toml
+++ b/transforms/universal/filter/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "dpk_filter_transform_python"
-version = "0.2.1.dev0"
+version = "0.2.0.dev6"
 requires-python = ">=3.10"
 description = "Filter Transform for Python"
 license = {text = "Apache-2.0"}
@@ -9,7 +9,7 @@ authors = [
     { name = "Constantin Adam", email = "cmadam@us.ibm.com" },
 ]
 dependencies = [
-    "data-prep-toolkit==0.2.1.dev0",
+    "data-prep-toolkit==0.2.0.dev6",
     "duckdb==0.10.1",
 ]
 

--- a/transforms/universal/filter/ray/pyproject.toml
+++ b/transforms/universal/filter/ray/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "dpk_filter_transform_ray"
-version = "0.2.1.dev0"
+version = "0.2.0.dev6"
 requires-python = ">=3.10"
 description = "Filter Transform for Ray"
 license = {text = "Apache-2.0"}
@@ -9,8 +9,8 @@ authors = [
     { name = "Constantin Adam", email = "cmadam@us.ibm.com" },
 ]
 dependencies = [
-    "dpk-filter-transform-python==0.2.1.dev0",
-    "data-prep-toolkit-ray==0.2.1.dev0",
+    "dpk-filter-transform-python==0.2.0.dev6",
+    "data-prep-toolkit-ray==0.2.0.dev6",
 ]
 
 [build-system]

--- a/transforms/universal/noop/kfp_ray/noop_multiple_wf.py
+++ b/transforms/universal/noop/kfp_ray/noop_multiple_wf.py
@@ -17,13 +17,13 @@ import kfp.dsl as dsl
 from workflow_support.compile_utils import ONE_HOUR_SEC, ONE_WEEK_SEC, ComponentUtils
 
 
-task_image = "quay.io/dataprep1/data-prep-kit/noop-ray:0.2.1.dev0"
+task_image = "quay.io/dataprep1/data-prep-kit/noop-ray:0.2.0.dev6"
 
 # the name of the job script
 EXEC_SCRIPT_NAME: str = "noop_transform_ray.py"
 
 # components
-base_kfp_image = "quay.io/dataprep1/data-prep-kit/kfp-data-processing:0.2.1.dev0"
+base_kfp_image = "quay.io/dataprep1/data-prep-kit/kfp-data-processing:0.2.0.dev6"
 
 # path to kfp component specifications files
 component_spec_path = "../../../../kfp/kfp_ray_components/"

--- a/transforms/universal/noop/kfp_ray/noop_wf.py
+++ b/transforms/universal/noop/kfp_ray/noop_wf.py
@@ -17,13 +17,13 @@ import kfp.dsl as dsl
 from workflow_support.compile_utils import ONE_HOUR_SEC, ONE_WEEK_SEC, ComponentUtils
 
 
-task_image = "quay.io/dataprep1/data-prep-kit/noop-ray:0.2.1.dev0"
+task_image = "quay.io/dataprep1/data-prep-kit/noop-ray:0.2.0.dev6"
 
 # the name of the job script
 EXEC_SCRIPT_NAME: str = "noop_transform_ray.py"
 
 # components
-base_kfp_image = "quay.io/dataprep1/data-prep-kit/kfp-data-processing:0.2.1.dev0"
+base_kfp_image = "quay.io/dataprep1/data-prep-kit/kfp-data-processing:0.2.0.dev6"
 
 # path to kfp component specifications files
 component_spec_path = "../../../../kfp/kfp_ray_components/"

--- a/transforms/universal/noop/python/pyproject.toml
+++ b/transforms/universal/noop/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "dpk_noop_transform_python"
-version = "0.2.1.dev0"
+version = "0.2.0.dev6"
 requires-python = ">=3.10"
 description = "NOOP Python Transform"
 license = {text = "Apache-2.0"}
@@ -10,7 +10,7 @@ authors = [
     { name = "Boris Lublinsky", email = "blublinsky@ibm.com" },
 ]
 dependencies = [
-    "data-prep-toolkit==0.2.1.dev0",
+    "data-prep-toolkit==0.2.0.dev6",
 ]
 
 [build-system]

--- a/transforms/universal/noop/ray/pyproject.toml
+++ b/transforms/universal/noop/ray/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "dpk_noop_transform_ray"
-version = "0.2.1.dev0"
+version = "0.2.0.dev6"
 requires-python = ">=3.10"
 description = "NOOP Ray Transform"
 license = {text = "Apache-2.0"}
@@ -10,8 +10,8 @@ authors = [
     { name = "Boris Lublinsky", email = "blublinsky@ibm.com" },
 ]
 dependencies = [
-    "dpk-noop-transform-python==0.2.1.dev0",
-    "data-prep-toolkit-ray==0.2.1.dev0",
+    "dpk-noop-transform-python==0.2.0.dev6",
+    "data-prep-toolkit-ray==0.2.0.dev6",
 ]
 
 [build-system]

--- a/transforms/universal/noop/spark/pyproject.toml
+++ b/transforms/universal/noop/spark/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "dpk_noop_transform_spark"
-version = "0.2.1.dev0"
+version = "0.2.0.dev6"
 requires-python = ">=3.10"
 description = "NOOP Spark Transform"
 license = {text = "Apache-2.0"}
@@ -10,8 +10,8 @@ authors = [
     { name = "Boris Lublinsky", email = "blublinsky@ibm.com" },
 ]
 dependencies = [
-    "dpk-noop-transform-python==0.2.1.dev0",
-    "data-prep-toolkit-spark==0.2.1.dev0",
+    "dpk-noop-transform-python==0.2.0.dev6",
+    "data-prep-toolkit-spark==0.2.0.dev6",
 ]
 
 [build-system]

--- a/transforms/universal/profiler/kfp_ray/profiler_wf.py
+++ b/transforms/universal/profiler/kfp_ray/profiler_wf.py
@@ -18,13 +18,13 @@ from src.profiler_compute_execution_params import profiler_compute_execution_par
 from workflow_support.compile_utils import ONE_HOUR_SEC, ONE_WEEK_SEC, ComponentUtils
 
 
-task_image = "quay.io/dataprep1/data-prep-kit/profiler-ray:0.2.1.dev0"
+task_image = "quay.io/dataprep1/data-prep-kit/profiler-ray:0.2.0.dev6"
 
 # the name of the job script
 EXEC_SCRIPT_NAME: str = "profiler_transform_ray.py"
 
 # components
-base_kfp_image = "quay.io/dataprep1/data-prep-kit/kfp-data-processing:0.2.1.dev0"
+base_kfp_image = "quay.io/dataprep1/data-prep-kit/kfp-data-processing:0.2.0.dev6"
 
 # path to kfp component specifications files
 component_spec_path = "../../../../kfp/kfp_ray_components/"

--- a/transforms/universal/tokenization/kfp_ray/tokenization_wf.py
+++ b/transforms/universal/tokenization/kfp_ray/tokenization_wf.py
@@ -20,10 +20,10 @@ from workflow_support.compile_utils import ONE_HOUR_SEC, ONE_WEEK_SEC, Component
 # the name of the job script
 EXEC_SCRIPT_NAME: str = "tokenization_transform_ray.py"
 
-task_image = "quay.io/dataprep1/data-prep-kit/tokenization-ray:0.2.1.dev0"
+task_image = "quay.io/dataprep1/data-prep-kit/tokenization-ray:0.2.0.dev6"
 
 # components
-base_kfp_image = "quay.io/dataprep1/data-prep-kit/kfp-data-processing:0.2.1.dev0"
+base_kfp_image = "quay.io/dataprep1/data-prep-kit/kfp-data-processing:0.2.0.dev6"
 # path to kfp component specifications files
 
 # path to kfp component specifications files

--- a/transforms/universal/tokenization/python/pyproject.toml
+++ b/transforms/universal/tokenization/python/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "dpk_tokenization_transform_python"
 keywords = ["tokenizer", "data", "data preprocessing", "data preparation", "llm", "generative", "ai", "fine-tuning", "llmapps" ]
-version = "0.2.1.dev0"
+version = "0.2.0.dev6"
 requires-python = ">=3.10"
 description = "Tokenization Transform for Python"
 license = {text = "Apache-2.0"}
@@ -10,7 +10,7 @@ authors = [
     { name = "Xuan-Hong Dang", email = "xuan-hong.dang@ibm.com"},
 ]
 dependencies = [
-    "data-prep-toolkit==0.2.1.dev0",
+    "data-prep-toolkit==0.2.0.dev6",
     "transformers==4.38.0",
 ]
 

--- a/transforms/universal/tokenization/ray/pyproject.toml
+++ b/transforms/universal/tokenization/ray/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "dpk_tokenization_transform_ray"
-version = "0.2.1.dev0"
+version = "0.2.0.dev6"
 requires-python = ">=3.10"
 description = "Tokenization Transform for Ray"
 license = {text = "Apache-2.0"}
@@ -9,8 +9,8 @@ authors = [
     { name = "Xuan-Hong Dang", email = "xuan-hong.dang@ibm.com"},
 ]
 dependencies = [
-    "dpk-tokenization-transform-python==0.2.1.dev0",
-    "data-prep-toolkit-ray==0.2.1.dev0",
+    "dpk-tokenization-transform-python==0.2.0.dev6",
+    "data-prep-toolkit-ray==0.2.0.dev6",
 ]
 
 [build-system]


### PR DESCRIPTION
## Why are these changes needed?
Reverting versions to 0.2.0.dev6 which was set to 0.2.1.dev0 on the last run of the release-branch.sh script
Fix release-branch-script.sh to not verify commits in case someone checked in one of the files with version changes, w/o pre-commit checks.

## Related issue number (if any).


