### PR TITLE
fix 'make set-versions' for doc_id, e/fdedup transforms

### DIFF
--- a/transforms/universal/doc_id/ray/Makefile
+++ b/transforms/universal/doc_id/ray/Makefile
@@ -32,7 +32,7 @@ publish-image:: .transforms.publish-image-ray
 
 setup:: .transforms.setup
 
-# TRANSFORM_PYTHON_VERSION has no effect since requirements to specify a python transform implementation
+# TRANSFORM_PYTHON_VERSION has no effect since requirements do not specify a python transform implementation
 set-versions:
 	$(MAKE) TRANSFORM_PYTHON_VERSION=${DOCKER_IMAGE_VERSION} .transforms.set-versions 
 

--- a/transforms/universal/doc_id/ray/Makefile
+++ b/transforms/universal/doc_id/ray/Makefile
@@ -32,7 +32,9 @@ publish-image:: .transforms.publish-image-ray
 
 setup:: .transforms.setup
 
-set-versions::
+# TRANSFORM_PYTHON_VERSION has no effect since requirements to specify a python transform implementation
+set-versions:
+	$(MAKE) TRANSFORM_PYTHON_VERSION=${DOCKER_IMAGE_VERSION} .transforms.set-versions 
 
 build-dist:: .defaults.build-dist
 

--- a/transforms/universal/doc_id/ray/pyproject.toml
+++ b/transforms/universal/doc_id/ray/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "dpk_docid_transform_ray"
-version = "0.4.0.dev6"
+version = "0.2.1.dev0"
 requires-python = ">=3.10"
 description = "docid Ray Transform"
 license = {text = "Apache-2.0"}
@@ -10,7 +10,7 @@ authors = [
     { name = "Boris Lublinsky", email = "blublinsky@ibm.com" },
 ]
 dependencies = [
-    "data-prep-toolkit-ray==0.2.0.dev6",
+    "data-prep-toolkit-ray==0.2.1.dev0",
 ]
 
 [build-system]

--- a/transforms/universal/ededup/ray/Makefile
+++ b/transforms/universal/ededup/ray/Makefile
@@ -32,7 +32,7 @@ publish-image:: .transforms.publish-image-ray
 
 setup:: .transforms.setup
 
-# TRANSFORM_PYTHON_VERSION has no effect since requirements to specify a python transform implementation
+# TRANSFORM_PYTHON_VERSION has no effect since requirements do not specify a python transform implementation
 set-versions:
 	$(MAKE) TRANSFORM_PYTHON_VERSION=${DOCKER_IMAGE_VERSION} .transforms.set-versions 
 

--- a/transforms/universal/ededup/ray/Makefile
+++ b/transforms/universal/ededup/ray/Makefile
@@ -32,7 +32,9 @@ publish-image:: .transforms.publish-image-ray
 
 setup:: .transforms.setup
 
-set-versions::
+# TRANSFORM_PYTHON_VERSION has no effect since requirements to specify a python transform implementation
+set-versions:
+	$(MAKE) TRANSFORM_PYTHON_VERSION=${DOCKER_IMAGE_VERSION} .transforms.set-versions 
 
 build-dist:: .defaults.build-dist
 

--- a/transforms/universal/ededup/ray/pyproject.toml
+++ b/transforms/universal/ededup/ray/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "dpk_ededup_transform_ray"
-version = "0.4.0.dev6"
+version = "0.2.1.dev0"
 requires-python = ">=3.10"
 description = "ededup Ray Transform"
 license = {text = "Apache-2.0"}
@@ -10,7 +10,7 @@ authors = [
     { name = "Boris Lublinsky", email = "blublinsky@ibm.com" },
 ]
 dependencies = [
-    "data-prep-toolkit-ray==0.2.0.dev6",
+    "data-prep-toolkit-ray==0.2.1.dev0",
     "mmh3==4.1.0",
     "xxhash==3.4.1",
     "tqdm==4.66.3",

--- a/transforms/universal/fdedup/ray/Makefile
+++ b/transforms/universal/fdedup/ray/Makefile
@@ -32,7 +32,7 @@ publish-image:: .transforms.publish-image-ray
 
 setup:: .transforms.setup
 
-# TRANSFORM_PYTHON_VERSION has no effect since requirements to specify a python transform implementation
+# TRANSFORM_PYTHON_VERSION has no effect since requirements do not specify a python transform implementation
 set-versions:
 	$(MAKE) TRANSFORM_PYTHON_VERSION=${DOCKER_IMAGE_VERSION} .transforms.set-versions 
 

--- a/transforms/universal/fdedup/ray/Makefile
+++ b/transforms/universal/fdedup/ray/Makefile
@@ -32,7 +32,9 @@ publish-image:: .transforms.publish-image-ray
 
 setup:: .transforms.setup
 
-set-versions::
+# TRANSFORM_PYTHON_VERSION has no effect since requirements to specify a python transform implementation
+set-versions:
+	$(MAKE) TRANSFORM_PYTHON_VERSION=${DOCKER_IMAGE_VERSION} .transforms.set-versions 
 
 build-dist:: .defaults.build-dist
 

--- a/transforms/universal/fdedup/ray/pyproject.toml
+++ b/transforms/universal/fdedup/ray/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "dpk_fdedup_transform_ray"
-version = "0.4.0.dev6"
+version = "0.2.1.dev0"
 requires-python = ">=3.10"
 description = "fdedup Ray Transform"
 license = {text = "Apache-2.0"}
@@ -10,7 +10,7 @@ authors = [
     { name = "Boris Lublinsky", email = "blublinsky@ibm.com" },
 ]
 dependencies = [
-    "data-prep-toolkit-ray==0.2.0.dev6",
+    "data-prep-toolkit-ray==0.2.1.dev0",
     "mmh3==4.1.0",
     "xxhash==3.4.1",
     "tqdm==4.66.3",

--- a/transforms/universal/profiler/ray/Makefile
+++ b/transforms/universal/profiler/ray/Makefile
@@ -23,9 +23,9 @@ test-src:: .transforms.test-src
 setup:: .transforms.setup
 
 
-# set the version of python transform that this depends on.
+# TRANSFORM_PYTHON_VERSION has no effect since requirements do not specify a python transform implementation
 set-versions: 
-	$(MAKE) TRANSFORM_PYTHON_VERSION=${NOOP_PYTHON_VERSION} TOML_VERSION=$(NOOP_RAY_VERSION) .transforms.set-versions 
+	$(MAKE) TRANSFORM_PYTHON_VERSION=${DOCKER_IMAGE_VERSION} .transforms.set-versions 
 
 test-image:: .transforms.ray-test-image
 

--- a/transforms/universal/profiler/ray/Makefile
+++ b/transforms/universal/profiler/ray/Makefile
@@ -22,7 +22,10 @@ test-src:: .transforms.test-src
 
 setup:: .transforms.setup
 
-set-versions::
+
+# set the version of python transform that this depends on.
+set-versions: 
+	$(MAKE) TRANSFORM_PYTHON_VERSION=${NOOP_PYTHON_VERSION} TOML_VERSION=$(NOOP_RAY_VERSION) .transforms.set-versions 
 
 test-image:: .transforms.ray-test-image
 

--- a/transforms/universal/profiler/ray/pyproject.toml
+++ b/transforms/universal/profiler/ray/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "dpk_profiler_transform_ray"
-version = "0.4.0.dev6"
+version = "0.2.1.dev0"
 requires-python = ">=3.10"
 description = "profiler Ray Transform"
 license = {text = "Apache-2.0"}
@@ -10,7 +10,7 @@ authors = [
     { name = "Boris Lublinsky", email = "blublinsky@ibm.com" },
 ]
 dependencies = [
-    "data-prep-toolkit-ray==0.2.0.dev6",
+    "data-prep-toolkit-ray==0.2.1.dev0",
     "mmh3==4.1.0",
     "xxhash==3.4.1",
     "tqdm==4.66.3",


### PR DESCRIPTION
## Why are these changes needed?
`make set-versions` was not working in profiler, doc_id, e/fdedup ray transform directories.

## Related issue number (if any).

Fixes issue #355 
