### PR TITLE
Mods to github workflows/actions

### DIFF
--- a/.github/workflows/build-library.yml
+++ b/.github/workflows/build-library.yml
@@ -12,7 +12,7 @@ on:
             - "releases/**"
 jobs:
     build-python-lib:
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-22.04
         strategy:
             matrix:
                 python:
@@ -24,7 +24,7 @@ jobs:
               run: |
                   make -C data-processing-lib/python DOCKER=docker venv build
     build-ray-lib:
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-22.04
         strategy:
             matrix:
                 python:
@@ -36,7 +36,7 @@ jobs:
               run: |
                   make -C data-processing-lib/ray DOCKER=docker venv build
     build-spark-lib:
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-22.04
         strategy:
             matrix:
                 python:

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -8,7 +8,7 @@ on:
             - "releases/**"
 jobs:
     deploy:
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-22.04
         env:
             REPO_URL: "https://github.com/${{ github.repository }}"
             REPO_BRANCH: "dev"

--- a/.github/workflows/deploy-library.yml
+++ b/.github/workflows/deploy-library.yml
@@ -14,7 +14,7 @@ permissions:
 jobs:
     build-package:
         name: Build Ray data processing libraries
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-22.04
         steps:
             - name: Checkout
               uses: actions/checkout@v4
@@ -30,7 +30,7 @@ jobs:
         name: Publish packages to test.pypi.org
         # disabled
         if: false
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-22.04
         needs: build-package
 
         steps:
@@ -47,7 +47,7 @@ jobs:
 
     publish-pypi:
         name: Publish release to pypi.org
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-22.04
         needs: build-package
         # disabled as of now
         if: false

--- a/.github/workflows/deploy-transforms.yml
+++ b/.github/workflows/deploy-transforms.yml
@@ -9,7 +9,7 @@ on:
 jobs:
     build-images:
         name: Build and check images
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-22.04
         steps:
             - name: Checkout
               uses: actions/checkout@v4
@@ -23,7 +23,7 @@ jobs:
         name: Publish packages to quay.io
         # disabled
         if: false
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-22.04
         needs: build-images
 
         steps:

--- a/.github/workflows/test-images.yml
+++ b/.github/workflows/test-images.yml
@@ -1,4 +1,4 @@
-name: Build Transform Images
+name: Test Transform Images
 
 on:
     workflow_dispatch:
@@ -11,42 +11,42 @@ on:
             - "dev"
             - "releases/**"
 jobs:
-    build-code:
-        runs-on: ubuntu-latest
+    test-code-images:
+        runs-on: ubuntu-22.04
         timeout-minutes: 30
         steps:
             - name: Checkout
               uses: actions/checkout@v4
-            - name: Build and Test Code Transforms
+            - name: Test Code Transform Images
               run: |
                   make -C data-processing-lib DOCKER=docker image 
                   make -C transforms/code DOCKER=docker test-image
-    build-language:
-        runs-on: ubuntu-latest
+    test-language-images:
+        runs-on: ubuntu-22.04
         timeout-minutes: 30
         steps:
             - name: Checkout
               uses: actions/checkout@v4
-            - name: Build and Test Language Transforms
+            - name: Test Language Transform Images
               run: |
                   make -C data-processing-lib DOCKER=docker image
                   make -C transforms/language DOCKER=docker test-image
-    build-universal:
-        runs-on: ubuntu-latest
+    test-universal-images:
+        runs-on: ubuntu-22.04
         timeout-minutes: 30
         steps:
             - name: Checkout
               uses: actions/checkout@v4
-            - name: Build and Test Universal Transforms
+            - name: Test Universal Transform Images
               run: |
                   make -C data-processing-lib DOCKER=docker image 
                   make -C transforms/universal DOCKER=docker test-image
-    build-tools:
-        runs-on: ubuntu-latest
+    test-tool-images:
+        runs-on: ubuntu-22.04
         timeout-minutes: 30
         steps:
             - name: Checkout
               uses: actions/checkout@v4
-            - name: Build and Test Tool images
+            - name: Test Tool images
               run: |
                   make -C tools/ingest2parquet DOCKER=docker test-image

--- a/.github/workflows/test-src.yml
+++ b/.github/workflows/test-src.yml
@@ -1,4 +1,4 @@
-name: Test CI
+name: Test Code
 
 on:
     workflow_dispatch:
@@ -12,7 +12,7 @@ on:
             - "releases/**"
 jobs:
     test-make:
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-22.04
         steps:
             - name: Checkout
               uses: actions/checkout@v4
@@ -20,7 +20,7 @@ jobs:
               run: |
                   make -n clean test build publish set-versions
     test-python-lib:
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-22.04
         steps:
             - name: Checkout
               uses: actions/checkout@v4
@@ -28,7 +28,7 @@ jobs:
               run: |
                   make -C data-processing-lib/python DOCKER=docker venv test
     test-ray-lib:
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-22.04
         steps:
             - name: Checkout
               uses: actions/checkout@v4
@@ -36,7 +36,7 @@ jobs:
               run: |
                   make -C data-processing-lib/ray DOCKER=docker venv test
     test-spark-lib:
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-22.04
         steps:
             - name: Checkout
               uses: actions/checkout@v4
@@ -44,7 +44,7 @@ jobs:
               run: |
                   make -C data-processing-lib/spark DOCKER=docker venv test
     test-code:
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-22.04
         steps:
             - name: Checkout
               uses: actions/checkout@v4
@@ -52,7 +52,7 @@ jobs:
               run: |
                   make -C transforms/code DOCKER=docker venv test-src
     test-language:
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-22.04
         steps:
             - name: Checkout
               uses: actions/checkout@v4
@@ -60,7 +60,7 @@ jobs:
               run: |
                   make -C transforms/language DOCKER=docker venv test-src
     test-universal:
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-22.04
         steps:
             - name: Checkout
               uses: actions/checkout@v4
@@ -68,7 +68,7 @@ jobs:
               run: |
                   make -C transforms/universal DOCKER=docker venv test-src
     test-tools:
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-22.04
         steps:
             - name: Checkout
               uses: actions/checkout@v4
@@ -76,7 +76,7 @@ jobs:
               run: |
                   make -C tools DOCKER=docker venv test
     test-kfp-v1:
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-22.04
         steps:
             - name: Checkout
               uses: actions/checkout@v4
@@ -119,7 +119,7 @@ jobs:
                   header_text "Run ${transforms[$index]} completed"
 
     test-kfp-v2:
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-22.04
         steps:
             - name: Checkout
               uses: actions/checkout@v4

--- a/.github/workflows/workflow-manual-run.yml
+++ b/.github/workflows/workflow-manual-run.yml
@@ -22,7 +22,7 @@ jobs:
             KFPv2: ${{ github.event.inputs.kfp_v1 }}
             WORKFLOW_PATH: ${{ github.event.inputs.workflow-path }}
             DEBUG_MODE: ${{ github.event.inputs.debug }}
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-22.04
         steps:
             - name: Checkout
               uses: actions/checkout@v4


### PR DESCRIPTION
Renamed some of the yml files and names of flows.
Instead of ubuntu-latest use current equivalent of ubuntu-22.04 (see https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources)
This so github does not change things underneath us and start causing us unknown problems.

## Why are these changes needed?
Cleanups/clarity

## Related issue number (if any).


