### PR TITLE
fix relative input path

### DIFF
--- a/data-processing-lib/python/Makefile
+++ b/data-processing-lib/python/Makefile
@@ -46,6 +46,7 @@ image::
 # it seems when running multiple ray launch tests in a single pytest run there is some sort of ray.init() duplication.
 # pytest-forked was tried, but then we get SIGABRT in pytest when running the s3 tests, some of which are skipped.. 
 # TODO: the following fails.  Why?  source venv/bin/activate; export PYTHONPATH=../src; cd test; $(PYTEST)  . 
+.PHONY: test
 test::   venv
 	@# Help: Use the already-built virtual environment to run pytest on the test directory. 
 	source venv/bin/activate; export PYTHONPATH=../src; cd test; $(PYTEST)  data_processing_tests/data_access;

--- a/data-processing-lib/python/src/data_processing/data_access/data_access_local.py
+++ b/data-processing-lib/python/src/data_processing/data_access/data_access_local.py
@@ -54,8 +54,8 @@ class DataAccessLocal(DataAccess):
             self.input_folder = None
             self.output_folder = None
         else:
-            self.input_folder = local_config["input_folder"]
-            self.output_folder = local_config["output_folder"]
+            self.input_folder = os.path.abspath(local_config["input_folder"])
+            self.output_folder = os.path.abspath(local_config["output_folder"])
         self.d_sets = d_sets
         self.checkpoint = checkpoint
         self.m_files = m_files

--- a/data-processing-lib/python/test/data_processing_tests/data_access/data_access_local_test.py
+++ b/data-processing-lib/python/test/data_processing_tests/data_access/data_access_local_test.py
@@ -441,6 +441,15 @@ class TestGetOutputLocation(TestInit):
         out_path = self.dal.get_output_location(in_path)
         assert out_path == os.path.join(self.dal.output_folder, "path", "to", "f.parquet")
 
+        path_dict = {
+            "input_folder": os.path.join("..", "input_guf"),
+            "output_folder": os.path.join(os.sep, "tmp", "output_guf"),
+        }
+        dal = DataAccessLocal(path_dict)
+        in_path = os.path.abspath(os.path.join("..", "input_guf", "path", "to", "f.parquet"))
+        out_path = dal.get_output_location(in_path)
+        assert out_path == os.path.join(dal.output_folder, "path", "to", "f.parquet")
+
 
 class TestSavePyarrowTable(TestInit):
 


### PR DESCRIPTION
## Why are these changes needed?

Fixes situations when one of DataAccess local input or output folders is relative and another is absolute.  
## Related issue number (if any).
 #386

