### PR TITLE
fix release script to not modify main branch and add better logging

### DIFF
--- a/scripts/release-branch.sh
+++ b/scripts/release-branch.sh
@@ -4,7 +4,11 @@ dbg_suffix=.dev7
 reporoot=$(dirname $0)/..
 cd $reporoot
 
-DEFAULT_BRANCH=dev
+if [ -z "$debug" ]; then
+    DEFAULT_BRANCH=dev
+else
+    DEFAULT_BRANCH=releasing
+fi
 
 # Make sure we're starting from the base branch
 git fetch
@@ -19,9 +23,10 @@ if [ -z "$debug" ]; then
 else
     tag=test$version
 fi
+release_branch=releases/$tag
+release_branch_pr=$tag
 
 # Create a new branch for this version and switch to it
-release_branch=releases/$tag
 if [ ! -z "$debug" ]; then
     # delete local tag and branch
     git tag --delete $tag
@@ -30,8 +35,15 @@ if [ ! -z "$debug" ]; then
     git push --delete origin $tag
     git push --delete origin $release_branch
 fi
-echo Creating $release_branch branch
+echo Creating and pushing $release_branch branch to receive PR of version changes
 git checkout -b $release_branch 
+git push --set-upstream origin $release_branch 
+git commit --no-verify -s -a -m "Target branch to receive PR for version $version"
+git push 
+
+echo Creating $release_branch_pr branch to hold version changes as the source of PR into $release_banch branch
+git checkout -b $release_branch_pr
+git push --set-upstream origin $release_branch_pr
 
 # Remove the release suffix in this branch
 # Apply the unsuffixed version to the repo and check it into this release branch
@@ -43,24 +55,23 @@ else
     mv tt .make.versions
 fi
 # Apply the version change to all files in the repo 
-echo Applying $version to $release_branch branch 
+echo Applying $version to $release_branch_pr branch 
 make set-versions > /dev/null
 
-# Commit the changes to the release branch and tag it
+# Commit the changes to the release pr branch 
 git status
-echo Committing and pushing version changes in $release_branch branch. 
-git commit --no-verify -s -a -m "Cut release $version"
-git push --set-upstream origin $release_branch 
-echo Committing and pushing tag $tag in $release_branch branch
-git tag -a -s -m "Cut release $version" $tag 
-git push origin $tag 
+echo Committing and pushing version changes in $release_branch_pr branch. 
+git commit --no-verify -s -a -m "Pull request source branch to cut release $version"
+git push 
 
 # Now create and push a new branch from which we will PR into main to update the version 
-next_version_branch=release_next_pending
-echo Creating $next_version_branch branch for PR request back to main for version upgrade
+this_version=$(make show-version)
+next_version_branch=pending-version-change/$this_version
+echo Creating $next_version_branch branch for PR request back to $DEFAULT_BRANCH for version upgrade
 git checkout -b $next_version_branch 
-git commit --no-verify -s -a -m "Branch to PR back into $DEFAULT_BRANCH holding the next version"
 git push --set-upstream origin $next_version_branch
+git commit --no-verify -s -a -m "Initializing branch to PR back into $DEFAULT_BRANCH holding the next development version"
+git push 
 
 # Change to the next development version (bumped minor version with suffix).
 micro=$(cat .make.versions | grep '^DPK_MICRO_VERSION=' | sed -e 's/DPK_MICRO_VERSION=\([0-9]*\).*/\1/') 
@@ -68,20 +79,33 @@ micro=$(($micro + 1))
 cat .make.versions | sed -e "s/^DPK_MICRO_VERSION=.*/DPK_MICRO_VERSION=$micro/"  \
  			 -e "s/^DPK_VERSION_SUFFIX=.*/DPK_VERSION_SUFFIX=.dev0/"  > tt
 mv tt .make.versions
-# Apply the version change to all files in the repo 
 next_version=$(make show-version)
+
+# Apply the version change to all files in the repo 
 echo Applying updated version $next_version to $next_version_branch branch
 make set-versions > /dev/null
 
 # Push the version change back to the origin
 if [ -z "$debug" ]; then
     echo Committing and pushing version $next_version to $next_version_branch branch.
-    git commit --no-verify -s -a -m "Bump micro version to $next_version after cutting release $version into branch $release_branch"
+    git commit --no-verify -s -a -m "Bump micro version to $next_version" 
     #git diff origin/$next_version_branch $next_version_branch 
-    git push origin
-    echo Please go to https://github.com/IBM/data-prep-kit/pulls and 
-    echo create a new pull request from the $next_version_branch branch back into $DEFAULT_BRANCH branch. 
+    git push 
 else
     git status
     echo In non-debug mode, the above diffs would have been committed to the $next_version_branch branch
 fi
+cat << EOM
+
+Summary of changes:
+   1. Pushed $release_branch_pr branch holding version $version of the repository. 
+   2. Pushed $release_branch branch to receive PR from the $release_branch_pr branch.
+   3. Pushed $next_version_branch branch to hold updated version $next_version of the repository on the main branch. 
+   No modifications made to the $DEFAULT_BRANCH branch.
+
+To complete this process, please go to https://github.com/IBM/data-prep-kit and ...
+   1. Create a new pull request from the $next_version_branch branch back into $DEFAULT_BRANCH branch. 
+   2. Create a pull request from $release_branch_pr branch into $release_branch branch.
+   3. After the PR into $release_branch is merged, create a new tag $tag on $release_branch branch.
+   4. Create a release from the $tag tag
+EOM


### PR DESCRIPTION
## Why are these changes needed?
Move to a PR based changing of versions - no direct pushes to the dev branch.

## Related issue number (if any).

#361
