### PR TITLE
Suppot Multi-platform images.

### DIFF
--- a/.github/workflows/test-image-multiarch.yml
+++ b/.github/workflows/test-image-multiarch.yml
@@ -1,0 +1,49 @@
+name: Multi-arch image build
+
+on:
+    workflow_dispatch:
+    push:
+        branches:
+            - "dev"
+            - "releases/**"
+        tags:
+            - '*'
+    pull_request:
+        branches:
+            - "dev"
+            - "releases/**"
+jobs:
+    build-and-test-multi-arch-images-on-ubuntu:
+        runs-on: ubuntu-22.04
+        timeout-minutes: 120
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v4
+            - name: Set up QEMU
+              uses: docker/setup-qemu-action@v3
+            - name: Set up Docker Buildx
+              uses: docker/setup-buildx-action@v3
+            - name: Free up space in github runner
+              run: |
+                  df -h
+                  sudo rm -rf /opt/ghc
+                  sudo rm -rf "/usr/local/share/boost"
+                  sudo rm -rf "$AGENT_TOOLSDIRECTORY"
+                  sudo rm -rf /usr/share/dotnet /opt/ghc /usr/local/lib/android /usr/local/share/powershell /usr/share/swift /usr/lib/jvm /usr/local/.ghcup
+                  sudo docker rmi $(docker image ls -aq) >/dev/null 2>&1 || true
+                  df -h
+            - name: build multi arch image
+              run: |
+                  cd transforms/universal/noop/ray
+                  make multiarch_image 
+                  docker buildx build -t noop-ray:latest-multiarch --load .
+                  docker ps
+                  docker run -t --rm noop-ray:latest-multiarch pytest -s test
+                  docker buildx build --platform=linux/amd64,linux/arm64 -t noop-ray:latest-multiarch .
+                  docker ps
+            - name:  Run pre-created multi-arch image
+              run: |
+                   docker pull quay.io/dataprep1/data-prep-kit/noop-ray:latest-multiarch
+                   docker run -t --rm quay.io/dataprep1/data-prep-kit/noop-ray:latest-multiarch pytest -s test 
+
+

--- a/.github/workflows/test-image-multiarch.yml
+++ b/.github/workflows/test-image-multiarch.yml
@@ -16,6 +16,9 @@ jobs:
     build-and-test-multi-arch-images-on-ubuntu:
         runs-on: ubuntu-22.04
         timeout-minutes: 120
+        env:
+           DOCKER_REGISTRY_USER: ${{ secrets.DOCKER_REGISTRY_USER }}
+           DOCKER_REGISTRY_KEY: ${{ secrets.DOCKER_REGISTRY_KEY }}
         steps:
             - name: Checkout
               uses: actions/checkout@v4
@@ -39,11 +42,15 @@ jobs:
                   docker buildx build -t noop-ray:latest-multiarch --load .
                   docker ps
                   docker run -t --rm noop-ray:latest-multiarch pytest -s test
-                  docker buildx build --platform=linux/amd64,linux/arm64 -t noop-ray:latest-multiarch .
+                  docker login quay.io -u $DOCKER_REGISTRY_USER -p $DOCKER_REGISTRY_KEY
+                  docker buildx build --platform=linux/amd64,linux/arm64 -t quay.io/dataprep1/data-prep-kit/noop-ray:latest-multiarch --push . 
                   docker ps
-            - name:  Run pre-created multi-arch image
+    test-multi-arch-images-on-ubuntu:
+        runs-on: ubuntu-22.04
+        timeout-minutes: 120
+            - name: Test multi-arch image
+              needs: [build-and-test-multi-arch-images-on-ubuntu]
               run: |
                    docker pull quay.io/dataprep1/data-prep-kit/noop-ray:latest-multiarch
                    docker run -t --rm quay.io/dataprep1/data-prep-kit/noop-ray:latest-multiarch pytest -s test 
-
 

--- a/.github/workflows/test-image-multiarch.yml
+++ b/.github/workflows/test-image-multiarch.yml
@@ -48,9 +48,9 @@ jobs:
     test-multi-arch-images-on-ubuntu:
         runs-on: ubuntu-22.04
         timeout-minutes: 120
+        needs: [build-and-test-multi-arch-images-on-ubuntu]
         steps:
             - name: Test multi-arch image
-              needs: [build-and-test-multi-arch-images-on-ubuntu]
               run: |
                    docker pull quay.io/dataprep1/data-prep-kit/noop-ray:latest-multiarch
                    docker run -t --rm quay.io/dataprep1/data-prep-kit/noop-ray:latest-multiarch pytest -s test 

--- a/.github/workflows/test-image-multiarch.yml
+++ b/.github/workflows/test-image-multiarch.yml
@@ -37,12 +37,12 @@ jobs:
                   df -h
             - name: build multi arch image
               run: |
-                  #cd transforms/universal/noop/ray
-                  #make multiarch_image 
-                  #docker buildx build -t noop-ray:latest-multiarch --load .
-                  #docker ps
-                  #docker run -t --rm noop-ray:latest-multiarch pytest -s test
-                  docker login quay.io -u "$(DOCKER_REGISTRY_USER)" -p "$(DOCKER_REGISTRY_KEY)"
+                  cd transforms/universal/noop/ray
+                  make multiarch_image 
+                  docker buildx build -t noop-ray:latest-multiarch --load .
+                  docker ps
+                  docker run -t --rm noop-ray:latest-multiarch pytest -s test
+                  make defaults.login
                   docker buildx build --platform=linux/amd64,linux/arm64 -t quay.io/dataprep1/data-prep-kit/noop-ray:latest-multiarch --push . 
                   docker ps
     test-multi-arch-images-on-ubuntu:

--- a/.github/workflows/test-image-multiarch.yml
+++ b/.github/workflows/test-image-multiarch.yml
@@ -42,7 +42,7 @@ jobs:
                   #docker buildx build -t noop-ray:latest-multiarch --load .
                   #docker ps
                   #docker run -t --rm noop-ray:latest-multiarch pytest -s test
-                  docker login quay.io -u "$DOCKER_REGISTRY_USER" -p "$DOCKER_REGISTRY_KEY"
+                  docker login quay.io -u "$(DOCKER_REGISTRY_USER)" -p "$(DOCKER_REGISTRY_KEY)"
                   docker buildx build --platform=linux/amd64,linux/arm64 -t quay.io/dataprep1/data-prep-kit/noop-ray:latest-multiarch --push . 
                   docker ps
     test-multi-arch-images-on-ubuntu:

--- a/.github/workflows/test-image-multiarch.yml
+++ b/.github/workflows/test-image-multiarch.yml
@@ -37,12 +37,12 @@ jobs:
                   df -h
             - name: build multi arch image
               run: |
-                  cd transforms/universal/noop/ray
-                  make multiarch_image 
-                  docker buildx build -t noop-ray:latest-multiarch --load .
-                  docker ps
-                  docker run -t --rm noop-ray:latest-multiarch pytest -s test
-                  docker login quay.io -u $DOCKER_REGISTRY_USER -p $DOCKER_REGISTRY_KEY
+                  #cd transforms/universal/noop/ray
+                  #make multiarch_image 
+                  #docker buildx build -t noop-ray:latest-multiarch --load .
+                  #docker ps
+                  #docker run -t --rm noop-ray:latest-multiarch pytest -s test
+                  docker login quay.io -u "$DOCKER_REGISTRY_USER" -p "$DOCKER_REGISTRY_KEY"
                   docker buildx build --platform=linux/amd64,linux/arm64 -t quay.io/dataprep1/data-prep-kit/noop-ray:latest-multiarch --push . 
                   docker ps
     test-multi-arch-images-on-ubuntu:

--- a/.github/workflows/test-image-multiarch.yml
+++ b/.github/workflows/test-image-multiarch.yml
@@ -42,8 +42,8 @@ jobs:
                   docker buildx build -t noop-ray:latest-multiarch --load .
                   docker ps
                   docker run -t --rm noop-ray:latest-multiarch pytest -s test
-                  make defaults.login
-                  docker buildx build --platform=linux/amd64,linux/arm64 -t quay.io/dataprep1/data-prep-kit/noop-ray:latest-multiarch --push . 
+                  #make defaults.login
+                  docker buildx build --platform=linux/amd64,linux/arm64 -t quay.io/dataprep1/data-prep-kit/noop-ray:latest-multiarch  . 
                   docker ps
     test-multi-arch-images-on-ubuntu:
         runs-on: ubuntu-22.04

--- a/.github/workflows/test-image-multiarch.yml
+++ b/.github/workflows/test-image-multiarch.yml
@@ -48,6 +48,7 @@ jobs:
     test-multi-arch-images-on-ubuntu:
         runs-on: ubuntu-22.04
         timeout-minutes: 120
+        steps:
             - name: Test multi-arch image
               needs: [build-and-test-multi-arch-images-on-ubuntu]
               run: |

--- a/.make.defaults
+++ b/.make.defaults
@@ -452,6 +452,10 @@ endif
 	$(DOCKER) login $(DOCKER_HOSTNAME) -u '$(DOCKER_REGISTRY_USER)' -p '$(DOCKER_REGISTRY_KEY)'
 	$(DOCKER) push $(DOCKER_REMOTE_IMAGE)
 
+.PHONY: defaults.login
+defaults.login:
+	$(DOCKER) login $(DOCKER_HOSTNAME) -u '$(DOCKER_REGISTRY_USER)' -p '$(DOCKER_REGISTRY_KEY)'
+
 # Create the local virtual environment, assuming python is already installed and available
 # We upgrade pip as that seems to be required by watson_nlp
 # We install wheel, because it seems to be required for fasttext install on redhat.

--- a/.make.defaults
+++ b/.make.defaults
@@ -267,9 +267,7 @@ ifeq ($(USE_REPO_LIB_SRC), 1)
 	$(MAKE) LIB_PATH=$(DPK_PYTHON_LIB_DIR) LIB_NAME=data-processing-lib-python .defaults.copy-lib
 	$(MAKE) LIB_PATH=$(DPK_RAY_LIB_DIR) LIB_NAME=data-processing-lib-ray .defaults.copy-lib
 endif
-	if [ -e ../python ]; then                                                               \	
-		$(MAKE) LIB_PATH=../python LIB_NAME=python-transform .defaults.copy-lib;        \	
-	fi
+	$(MAKE) LIB_PATH=../python LIB_NAME=python-transform .defaults.copy-lib
 
 # Build the base spark image used by spark-based transforms
 .PHONY: .defaults.spark-lib-base-image

--- a/.make.defaults
+++ b/.make.defaults
@@ -260,6 +260,17 @@ endif
 	-rm -rf data-processing-lib-ray
 	-rm -rf python-transform 
 
+.PHONY: .defaults._ray-lib-src-image
+.defaults._ray-lib-src-image:
+	@# Help: Build the Ray $(DOCKER_LOCAL_IMAGE) using the $(DOCKER_FILE), requirements.txt and data-processing-libs source
+ifeq ($(USE_REPO_LIB_SRC), 1)
+	$(MAKE) LIB_PATH=$(DPK_PYTHON_LIB_DIR) LIB_NAME=data-processing-lib-python .defaults.copy-lib
+	$(MAKE) LIB_PATH=$(DPK_RAY_LIB_DIR) LIB_NAME=data-processing-lib-ray .defaults.copy-lib
+endif
+	if [ -e ../python ]; then                                                               \	
+		$(MAKE) LIB_PATH=../python LIB_NAME=python-transform .defaults.copy-lib;        \	
+	fi
+
 # Build the base spark image used by spark-based transforms
 .PHONY: .defaults.spark-lib-base-image
 .defaults.spark-lib-base-image-spark: 

--- a/transforms/.make.transforms
+++ b/transforms/.make.transforms
@@ -117,6 +117,9 @@ extra-help:
 .PHONY: .transforms.ray-image
 .transforms.ray-image:: .defaults.ray-lib-src-image
 
+.PHONY: .transforms._ray-image
+.transforms._ray-image: .defaults._ray-lib-src-image
+
 .PHONY: .transforms.spark-image
 .transforms.spark-image:: .defaults.spark-lib-src-image
 

--- a/transforms/universal/noop/ray/Dockerfile
+++ b/transforms/universal/noop/ray/Dockerfile
@@ -1,6 +1,20 @@
 ARG BASE_IMAGE=docker.io/rayproject/ray:2.24.0-py310
-FROM ${BASE_IMAGE}
 
+# Declare stage using linux/amd64 base image
+FROM --platform=linux/amd64 ${BASE_IMAGE} AS stage-amd64
+RUN echo "I am running on $BUILDPLATFORM, building for $TARGETPLATFORM"
+
+# Declare stage using linux/arm64 base image
+FROM --platform=linux/arm64 ${BASE_IMAGE}-aarch64 AS stage-arm64
+RUN echo "I am running on $BUILDPLATFORM, building for $TARGETPLATFORM"
+
+# Declare TARGETARCH to make it available
+ARG TARGETARCH
+
+# Select final stage based on TARGETARCH ARG
+FROM stage-${TARGETARCH} AS final
+
+RUN echo "I am running on $BUILDPLATFORM, building for $TARGETPLATFORM"
 # install pytest
 RUN pip install --no-cache-dir pytest
 
@@ -29,7 +43,7 @@ COPY test/ test/
 COPY test-data/ test-data/
 
 # Set environment
-ENV PYTHONPATH /home/ray
+ENV PYTHONPATH=/home/ray
 
 # Put these at the end since they seem to upset the docker cache.
 ARG BUILD_DATE

--- a/transforms/universal/noop/ray/Makefile
+++ b/transforms/universal/noop/ray/Makefile
@@ -18,6 +18,8 @@ clean:: .transforms.clean
 
 image:: .transforms.ray-image
 
+multiarch_image:: .transforms._ray-image
+
 test-src:: .transforms.test-src
 
 setup:: .transforms.setup


### PR DESCRIPTION
## Why are these changes needed?

This PR add support for [Multi-platform images](https://docs.docker.com/build/building/multi-platform/)

It build the images for platforms linux/amd64 and linux/arm64
## Related issue number (if any).


