### PR TITLE
Fix resize to not switch between schemas and add permissive_schema_merge option

### DIFF
--- a/transforms/universal/resize/python/README.md
+++ b/transforms/universal/resize/python/README.md
@@ -25,12 +25,16 @@ The set of dictionary keys holding [BlockListTransform](src/blocklist_transform.
 configuration for values are as follows:
 
 * _max_rows_per_table_ - specifies max documents per table
-* _max_mbytes_per_table - specifies max size of table, according to the _size_type_ value.
+* _max_mbytes_per_table_ - specifies max size of table, according to the _size_type_ value.
 * _size_type_ - indicates how table size is measured. Can be one of
     * memory - table size is measure by the in-process memory used by the table
     * disk - table size is estimated as the on-disk size of the parquet files.  This is an estimate only
         as files are generally compressed on disk and so may not be exact due varying compression ratios.
         This is the default.
+* _permissive_schema_merge_ - enables support for merging of tables with differing schemas according
+to PyArrow concat_table()'s 
+[unicode_promote_option='permissive'](*https://arrow.apache.org/docs/python/generated/pyarrow.concat_tables.html)
+option. Default is True to enable permissive merging.
 
 Only one of the _max_rows_per_table_ and _max_mbytes_per_table_ may be used.
 
@@ -54,6 +58,9 @@ the following command line arguments are available in addition to
                         Determines how memory is measured when using the --resize_max_mbytes_per_table option.
                         'memory' measures the in-process memory footprint and 
                         'disk' makes an estimate of the resulting parquet file size.
+  --resize_merge_schemas RESIZE_MERGE_SCHEMAS
+    Dis/allow permissivity when merging table schemas
+
 ```
 
 ### Transforming data using the transform image

--- a/transforms/universal/resize/python/README.md
+++ b/transforms/universal/resize/python/README.md
@@ -58,8 +58,8 @@ the following command line arguments are available in addition to
                         Determines how memory is measured when using the --resize_max_mbytes_per_table option.
                         'memory' measures the in-process memory footprint and 
                         'disk' makes an estimate of the resulting parquet file size.
-  --resize_merge_schemas RESIZE_MERGE_SCHEMAS
-    Dis/allow permissivity when merging table schemas
+  --resize_permissive_schema_merge RESIZE_PERMISSIVE_SCHEMA_MERGE
+    Dis/allow permissively merging table schemas, per pyarrow concat_table()
 
 ```
 

--- a/transforms/universal/resize/python/src/resize_transform.py
+++ b/transforms/universal/resize/python/src/resize_transform.py
@@ -15,13 +15,19 @@ from typing import Any
 
 import pyarrow as pa
 from data_processing.transform import AbstractTableTransform, TransformConfiguration
-from data_processing.utils import LOCAL_TO_DISK, MB, CLIArgumentProvider, get_logger
+from data_processing.utils import (
+    LOCAL_TO_DISK,
+    MB,
+    CLIArgumentProvider,
+    get_logger,
+    str2bool,
+)
 
 
 max_rows_per_table_key = "max_rows_per_table"
 max_mbytes_per_table_key = "max_mbytes_per_table"
 size_type_key = "size_type"
-permissive_schema_merge_key = "merge_schemas"
+permissive_schema_merge_key = "permissive_schema_merge"
 shortname = "resize"
 cli_prefix = f"{shortname}_"
 max_rows_per_table_cli_param = f"{cli_prefix}{max_rows_per_table_key}"
@@ -175,9 +181,9 @@ class ResizeTransformConfiguration(TransformConfiguration):
         )
         parser.add_argument(
             f"--{permissive_schema_merge_cli_param}",
-            type=bool,
+            type=lambda x: bool(str2bool(x)),
             default=permissive_schema_merge_default,
-            help=f"Dis/allow permissivity when merging table schemas",
+            help=f"Dis/allow permissively merging table schemas, per pyarrow concat_table()",
         )
 
     def apply_input_params(self, args: Namespace) -> bool:

--- a/transforms/universal/resize/python/test/test_resize_python.py
+++ b/transforms/universal/resize/python/test/test_resize_python.py
@@ -48,7 +48,7 @@ class TestRayResizeTransform(AbstractTransformLauncherTest):
         fixtures.append((launcher, config, basedir + "/input", basedir + "/expected-mbytes-0.05"))
 
         # Split into 4 or so files
-        config = {"resize_max_mbytes_per_table": 0.02}
+        config = {"resize_max_mbytes_per_table": 0.02, "resize_merge_schemas": True}
         fixtures.append((launcher, config, basedir + "/input", basedir + "/expected-mbytes-0.02"))
 
         return fixtures

--- a/transforms/universal/resize/python/test/test_resize_python.py
+++ b/transforms/universal/resize/python/test/test_resize_python.py
@@ -48,7 +48,7 @@ class TestRayResizeTransform(AbstractTransformLauncherTest):
         fixtures.append((launcher, config, basedir + "/input", basedir + "/expected-mbytes-0.05"))
 
         # Split into 4 or so files
-        config = {"resize_max_mbytes_per_table": 0.02, "resize_merge_schemas": True}
+        config = {"resize_max_mbytes_per_table": 0.02, "resize_permissive_schema_merge": True}
         fixtures.append((launcher, config, basedir + "/input", basedir + "/expected-mbytes-0.02"))
 
         return fixtures


### PR DESCRIPTION
## Why are these changes needed?
Fixes a problem in arising when there are lots of schema mismatches encountered.
Also adds `permissive_schema_merge` option and cli parameter

## Related issue number (if any).
Fixes #429 

