### PR TITLE
Fix Dockerfiles to doc the copied main() src file. remove RUNTIME from Makefiles

### DIFF
--- a/transforms/code/code2parquet/python/Dockerfile
+++ b/transforms/code/code2parquet/python/Dockerfile
@@ -21,12 +21,10 @@ COPY --chown=dpk:root src/ src/
 COPY --chown=dpk:root pyproject.toml pyproject.toml 
 RUN pip install --no-cache-dir -e .
 
-#COPY requirements.txt requirements.txt
-#RUN pip install --no-cache-dir -r  requirements.txt
-
-# copy source data
-COPY ./src/code2parquet_transform.py .
+# copy the main() entry point to the image 
 COPY ./src/code2parquet_transform_python.py .
+
+# copy some of the samples in
 COPY ./src/code2parquet_local.py local/
 
 # copy test

--- a/transforms/code/code2parquet/python/Makefile
+++ b/transforms/code/code2parquet/python/Makefile
@@ -7,7 +7,6 @@ REPOROOT=../../../..
 
 # $(REPOROOT)/.make.versions file contains the versions
 
-TRANSFORM_RUNTIME=python
 TRANSFORM_NAME=code2parquet
 
 include $(REPOROOT)/transforms/.make.transforms

--- a/transforms/code/code2parquet/ray/Dockerfile
+++ b/transforms/code/code2parquet/ray/Dockerfile
@@ -21,8 +21,10 @@ COPY --chown=ray:users src/ src/
 COPY --chown=ray:users pyproject.toml pyproject.toml 
 RUN pip install --no-cache-dir -e .
 
-# copy source 
+# copy the main() entry point to the image 
 COPY src/code2parquet_transform_ray.py .
+
+# copy some of the samples in
 COPY src/code2parquet_local_ray.py local/
 
 # copy test

--- a/transforms/code/code_quality/python/Dockerfile
+++ b/transforms/code/code_quality/python/Dockerfile
@@ -24,8 +24,10 @@ RUN pip install --no-cache-dir -e .
 #COPY requirements.txt requirements.txt
 #RUN pip install --no-cache-dir -r  requirements.txt
 
-# copy source data
+# copy the main() entry point to the image 
 COPY ./src/code_quality_transform_python.py .
+
+# copy some of the samples in
 COPY ./src/code_quality_local.py local/
 
 # copy test

--- a/transforms/code/code_quality/ray/Dockerfile
+++ b/transforms/code/code_quality/ray/Dockerfile
@@ -25,8 +25,10 @@ COPY --chown=ray:users src/ src/
 COPY --chown=ray:users pyproject.toml pyproject.toml 
 RUN pip install --no-cache-dir -e .
 
-# copy source data
+# copy the main() entry point to the image 
 COPY ./src/code_quality_transform_ray.py .
+
+# copy some of the samples in
 COPY ./src/code_quality_local_ray.py local/
 
 # copy test

--- a/transforms/code/malware/ray/Dockerfile
+++ b/transforms/code/malware/ray/Dockerfile
@@ -47,7 +47,10 @@ COPY --chown=ray:users src/ src/
 COPY --chown=ray:users pyproject.toml pyproject.toml
 RUN pip install --no-cache-dir -e .
 
+# copy the main() entry point to the image 
 COPY src/malware_transform_ray.py  ./
+
+# copy some of the samples in
 COPY src/malware_local_ray.py  local/
 
 COPY test/ test/

--- a/transforms/code/proglang_select/python/Dockerfile
+++ b/transforms/code/proglang_select/python/Dockerfile
@@ -21,9 +21,10 @@ COPY --chown=dpk:root src/ src/
 COPY --chown=dpk:root pyproject.toml pyproject.toml 
 RUN pip install --no-cache-dir -e .
 
-
-# copy source data
+# copy the main() entry point to the image 
 COPY ./src/proglang_select_transform_python.py .
+
+# copy some of the samples in
 COPY ./src/proglang_select_local.py local/
 
 # copy test

--- a/transforms/code/proglang_select/ray/Dockerfile
+++ b/transforms/code/proglang_select/ray/Dockerfile
@@ -21,8 +21,10 @@ COPY --chown=ray:users src/ src/
 COPY --chown=ray:users pyproject.toml pyproject.toml 
 RUN pip install --no-cache-dir -e .
 
-# copy source data
+# copy the main() entry point to the image 
 COPY ./src/proglang_select_transform_ray.py .
+
+# copy some of the samples in
 COPY ./src/proglang_select_local_ray.py local/
 
 # copy test

--- a/transforms/language/lang_id/python/Dockerfile
+++ b/transforms/language/lang_id/python/Dockerfile
@@ -37,8 +37,10 @@ USER dpk
 #COPY requirements.txt requirements.txt
 #RUN pip install --no-cache-dir -r  requirements.txt
 
-# copy source data
+# copy the main() entry point to the image 
 COPY ./src/lang_id_transform_python.py .
+
+# copy some of the samples in
 COPY ./src/lang_id_local.py local/
 
 # copy test

--- a/transforms/language/lang_id/python/Makefile
+++ b/transforms/language/lang_id/python/Makefile
@@ -7,7 +7,6 @@ REPOROOT=../../../..
 
 # $(REPOROOT)/.make.versions file contains the versions
 
-TRANSFORM_RUNTIME=python
 TRANSFORM_NAME=lang_id
 
 include $(REPOROOT)/transforms/.make.transforms

--- a/transforms/language/lang_id/ray/Dockerfile
+++ b/transforms/language/lang_id/ray/Dockerfile
@@ -31,8 +31,10 @@ RUN sudo apt remove gcc g++ -y \
     && sudo rm -rf /var/cache/apt/archives/* /var/lib/apt/lists/*
 USER ray
 
-# copy source data
+# copy the main() entry point to the image 
 COPY ./src/lang_id_transform_ray.py .
+
+# copy some of the samples in
 COPY ./src/lang_id_local_ray.py local/
 
 # copy test

--- a/transforms/universal/doc_id/ray/Dockerfile
+++ b/transforms/universal/doc_id/ray/Dockerfile
@@ -18,8 +18,10 @@ COPY --chown=ray:users pyproject.toml pyproject.toml
 COPY --chown=ray:users README.md README.md
 RUN pip install --no-cache-dir -e .
 
-# copy source data
+# copy the main() entry point to the image 
 COPY ./src/doc_id_transform_ray.py .
+
+# copy some of the samples in
 COPY src/doc_id_local_ray.py local/
 
 # copy test

--- a/transforms/universal/doc_id/spark/Dockerfile
+++ b/transforms/universal/doc_id/spark/Dockerfile
@@ -20,8 +20,10 @@ COPY --chown=spark:root src/ src/
 COPY --chown=spark:root pyproject.toml pyproject.toml 
 RUN pip install --no-cache-dir -e .
 
-# copy source main 
+# copy the main() entry point to the image 
 COPY ./src/doc_id_transform_spark.py .
+
+# copy some of the samples in
 COPY ./src/doc_id_local.py local/
 
 # copy test

--- a/transforms/universal/ededup/ray/Dockerfile
+++ b/transforms/universal/ededup/ray/Dockerfile
@@ -19,8 +19,10 @@ COPY --chown=ray:users README.md README.md
 COPY --chown=ray:users images/ images/
 RUN pip install --no-cache-dir -e .
 
-# copy source data
+# copy the main() entry point to the image 
 COPY ./src/ededup_transform_ray.py .
+
+# copy some of the samples in
 COPY src/ededup_local_ray.py local/
 
 # copy test

--- a/transforms/universal/fdedup/ray/Dockerfile
+++ b/transforms/universal/fdedup/ray/Dockerfile
@@ -19,8 +19,10 @@ COPY --chown=ray:users README.md README.md
 COPY --chown=ray:users images/ images/
 RUN pip install --no-cache-dir -e .
 
-# copy source data
+# copy the main() entry point to the image 
 COPY ./src/fdedup_transform_ray.py .
+
+# copy some of the samples in
 COPY src/fdedup_local_ray.py local/
 
 # copy test

--- a/transforms/universal/filter/python/Dockerfile
+++ b/transforms/universal/filter/python/Dockerfile
@@ -21,12 +21,10 @@ COPY --chown=dpk:root src/ src/
 COPY --chown=dpk:root pyproject.toml pyproject.toml 
 RUN pip install --no-cache-dir -e .
 
-#COPY requirements.txt requirements.txt
-#RUN pip install --no-cache-dir -r  requirements.txt
-
-# copy source data
-COPY ./src/filter_transform.py .
+# copy the main() entry point to the image 
 COPY ./src/filter_transform_python.py .
+
+# copy some of the samples in
 COPY ./src/filter_local.py local/
 
 # copy test

--- a/transforms/universal/filter/ray/Dockerfile
+++ b/transforms/universal/filter/ray/Dockerfile
@@ -20,8 +20,10 @@ COPY --chown=ray:users src/ src/
 COPY --chown=ray:users pyproject.toml pyproject.toml 
 RUN pip install --no-cache-dir -e .
 
-# copy source data
+# copy the main() entry point to the image 
 COPY ./src/filter_transform_ray.py .
+
+# copy some of the samples in
 COPY src/filter_local_ray.py local/
 
 # copy test

--- a/transforms/universal/filter/spark/Dockerfile
+++ b/transforms/universal/filter/spark/Dockerfile
@@ -19,9 +19,10 @@ COPY --chown=spark:root src/ src/
 COPY --chown=spark:root pyproject.toml pyproject.toml
 RUN pip install --no-cache-dir -e .
 
-# copy source main
-
+# copy the main() entry point to the image 
 COPY ./src/filter_transform_spark.py .
+
+# copy some of the samples in
 COPY ./src/filter_local.py local/
 
 # copy test

--- a/transforms/universal/noop/python/Dockerfile
+++ b/transforms/universal/noop/python/Dockerfile
@@ -21,12 +21,10 @@ COPY --chown=dpk:root src/ src/
 COPY --chown=dpk:root pyproject.toml pyproject.toml 
 RUN pip install --no-cache-dir -e .
 
-#COPY requirements.txt requirements.txt
-#RUN pip install --no-cache-dir -r  requirements.txt
-
-# copy source data
-COPY ./src/noop_transform.py .
+# copy transform main() entry point to the image 
 COPY ./src/noop_transform_python.py .
+
+# copy some of the samples in
 COPY ./src/noop_local.py local/
 
 # copy test

--- a/transforms/universal/noop/python/Makefile
+++ b/transforms/universal/noop/python/Makefile
@@ -7,7 +7,6 @@ REPOROOT=../../../..
 
 # $(REPOROOT)/.make.versions file contains the versions
 
-TRANSFORM_RUNTIME=python
 TRANSFORM_NAME=noop
 
 include $(REPOROOT)/transforms/.make.transforms

--- a/transforms/universal/noop/ray/Dockerfile
+++ b/transforms/universal/noop/ray/Dockerfile
@@ -20,8 +20,10 @@ COPY --chown=ray:users src/ src/
 COPY --chown=ray:users pyproject.toml pyproject.toml 
 RUN pip install --no-cache-dir -e .
 
-# copy source data
+# copy the main() entry point to the image 
 COPY ./src/noop_transform_ray.py .
+
+# copy some of the samples in
 COPY ./src/noop_local_ray.py local/
 
 # copy test

--- a/transforms/universal/noop/spark/Dockerfile
+++ b/transforms/universal/noop/spark/Dockerfile
@@ -20,8 +20,10 @@ COPY --chown=root:root src/ src/
 COPY --chown=root:root pyproject.toml pyproject.toml 
 RUN pip install --no-cache-dir -e .
 
-# copy source data
+# copy in the main() entry point to the image 
 COPY ./src/noop_transform_spark.py .
+
+# Copy in some samples
 COPY ./src/noop_local_spark.py local/
 
 # copy test

--- a/transforms/universal/profiler/ray/Dockerfile
+++ b/transforms/universal/profiler/ray/Dockerfile
@@ -18,8 +18,10 @@ COPY --chown=ray:users pyproject.toml pyproject.toml
 COPY --chown=ray:users README.md README.md
 RUN pip install --no-cache-dir -e .
 
-# copy source data
+# copy the main() entry point to the image 
 COPY src/profiler_transform_ray.py .
+
+# copy some of the samples in
 COPY src/profiler_local_ray.py local/
 
 # copy test

--- a/transforms/universal/resize/python/Dockerfile
+++ b/transforms/universal/resize/python/Dockerfile
@@ -21,8 +21,10 @@ COPY --chown=dpk:users pyproject.toml pyproject.toml
 COPY --chown=dpk:users README.md Readme.md
 RUN pip install --no-cache-dir -e .
 
-# copy source data
+# copy the main() entry point to the image 
 COPY ./src/resize_transform_python.py .
+
+# copy some of the samples in
 COPY ./src/resize_local.py local/
 
 # copy test

--- a/transforms/universal/resize/python/Makefile
+++ b/transforms/universal/resize/python/Makefile
@@ -7,7 +7,6 @@ REPOROOT=../../../..
 
 # $(REPOROOT)/.make.versions file contains the versions
 
-TRANSFORM_RUNTIME=python
 TRANSFORM_NAME=resize
 
 include $(REPOROOT)/transforms/.make.transforms

--- a/transforms/universal/resize/ray/Dockerfile
+++ b/transforms/universal/resize/ray/Dockerfile
@@ -17,7 +17,10 @@ COPY --chown=ray:users src/ src/
 COPY --chown=ray:users pyproject.toml pyproject.toml
 RUN pip install --no-cache-dir -e .
 
+# copy the main() entry point to the image 
 COPY ./src/resize_transform_ray.py ./
+
+# copy some of the samples in
 COPY ./src/resize_local_ray.py local/
 
 # Install pytest so we can test the image later

--- a/transforms/universal/tokenization/python/Dockerfile
+++ b/transforms/universal/tokenization/python/Dockerfile
@@ -24,10 +24,10 @@ RUN pip install --no-cache-dir -e .
 #COPY requirements.txt requirements.txt
 #RUN pip install --no-cache-dir -r  requirements.txt
 
-# copy source data
-COPY ./src/tokenization_transform.py . 
+# copy the main() entry point to the image 
 COPY ./src/tokenization_transform_python.py .
-COPY ./src/tokenization_utils.py .
+
+# copy some of the samples in
 COPY src/tokenization_local_python.py local/
 
 # copy test

--- a/transforms/universal/tokenization/ray/Dockerfile
+++ b/transforms/universal/tokenization/ray/Dockerfile
@@ -21,8 +21,10 @@ COPY --chown=ray:users src/ src/
 COPY --chown=ray:users pyproject.toml pyproject.toml 
 RUN pip install --no-cache-dir -e .
 
-# copy source data
+# copy the main() entry point to the image 
 COPY ./src/tokenization_transform_ray.py .
+
+# copy some of the samples in
 COPY src/tokenization_local_ray.py local/
 
 # copy test


### PR DESCRIPTION

## Why are these changes needed?
More clarity for developers using existing transforms as template.
Removed unneeded TRANSFORM_RUNTIME macro in transform Makefiles

## Related issue number (if any).


