### PR TITLE
apply ZSTD compression

### DIFF
--- a/data-processing-lib/python/src/data_processing/utils/transform_utils.py
+++ b/data-processing-lib/python/src/data_processing/utils/transform_utils.py
@@ -160,7 +160,9 @@ class TransformUtils:
         try:
             # convert table to bytes
             writer = pa.BufferOutputStream()
-            pq.write_table(table=table, where=writer)
+            # Update default snappy compression to ZSTD.
+            # See https://arrow.apache.org/docs/python/generated/pyarrow.parquet.write_table.html
+            pq.write_table(table=table, where=writer, compression="ZSTD")
             return bytes(writer.getvalue())
         except Exception as e:
             logger.error(f"Failed to convert arrow table to byte array, exception {e}. Skipping it")

--- a/data-processing-lib/python/test/data_processing_tests/data_access/data_access_s3_test.py
+++ b/data-processing-lib/python/test/data_processing_tests/data_access/data_access_s3_test.py
@@ -66,7 +66,8 @@ def test_table_read_write():
         # save the table
         l, result, _ = d_a.save_table(path=output_location, table=r_table)
         print(f"length of saved table {l}, result {result}")
-        assert 36132 == l
+        # expected byte length changed due to compression option updated to ZSTD
+        assert 35419 == l
         table, _ = d_a.get_table(output_location)
         s_columns = table.column_names
         assert len(r_columns) == len(s_columns)


### PR DESCRIPTION
[Feature] pyarrow parquet write_table can save up to 30% storage with compression flag ‘ZSTD’ 

## Related issue number (if any).
#404 

