### PR TITLE
stop installing extra dependencies in building doc quality python image

### DIFF
--- a/transforms/language/doc_quality/python/Dockerfile
+++ b/transforms/language/doc_quality/python/Dockerfile
@@ -19,7 +19,7 @@ RUN cd data-processing-lib-python && pip install --no-cache-dir -e .
 
 COPY --chown=dpk:root src/ src/
 COPY --chown=dpk:root pyproject.toml pyproject.toml 
-RUN pip install --no-cache-dir -e .[dev]
+RUN pip install --no-cache-dir -e .
 
  # copy transform main() entry point to the image
 COPY ./src/doc_quality_transform_python.py .


### PR DESCRIPTION
## Why are these changes needed?

Follow up for this commit. I failed to save the change I made locally...
https://github.com/IBM/data-prep-kit/pull/282/commits/6ff248fb7a898c864bf2885ab05366629f72e4ea

## Related issue number (if any).

https://github.com/IBM/data-prep-kit/pull/282

