### PR TITLE
adding unrecoverable exception

### DIFF
--- a/.make.defaults
+++ b/.make.defaults
@@ -295,7 +295,7 @@ endif
 	if [ ! -z "$(EXTRA_INDEX_URL)" ]; then				\
 		extra_url='--extra-index-url $(EXTRA_INDEX_URL)';	\
 	fi;								\
-	pip install --force-reinstall $${extra_url}  -e $(PYTHON_PROJECT_DIR);		
+	pip install $${extra_url}  -e $(PYTHON_PROJECT_DIR);
 	@echo Done installing source from $(PYTHON_PROJECT_DIR) into venv
 
 # Install local requirements last as it generally includes our lib source

--- a/data-processing-lib/python/src/data_processing/runtime/transform_file_processor.py
+++ b/data-processing-lib/python/src/data_processing/runtime/transform_file_processor.py
@@ -9,12 +9,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 ################################################################################
-
 import time
 import traceback
 from typing import Any
 
-from data_processing.utils import TransformUtils, get_logger
+from data_processing.utils import TransformUtils, UnrecoverableException, get_logger
 
 
 class AbstractTransformFileProcessor:
@@ -66,6 +65,11 @@ class AbstractTransformFileProcessor:
             self.last_extension = name_extension[1]
             # save results
             self._submit_file(t_start=t_start, out_files=out_files, stats=stats)
+        # Process unrecoverable exceptions
+        except UnrecoverableException as _:
+            self.logger.warning(f"Transform has thrown unrecoverable exception processing file {f_name}. Exiting...")
+            raise UnrecoverableException
+        # Process other exceptions
         except Exception as e:
             self.logger.warning(f"Exception {e} processing file {f_name}: {traceback.format_exc()}")
             self._publish_stats({"transform execution exception": 1})

--- a/data-processing-lib/python/src/data_processing/utils/__init__.py
+++ b/data-processing-lib/python/src/data_processing/utils/__init__.py
@@ -1,3 +1,4 @@
+from data_processing.utils.unrecoverable import UnrecoverableException
 from data_processing.utils.config import DPKConfig, add_if_missing
 from data_processing.utils.cli_utils import GB, KB, MB, CLIArgumentProvider, str2bool
 from data_processing.utils.log import get_logger

--- a/data-processing-lib/python/src/data_processing/utils/unrecoverable.py
+++ b/data-processing-lib/python/src/data_processing/utils/unrecoverable.py
@@ -1,0 +1,6 @@
+class UnrecoverableException(Exception):
+    """
+    Raised when a transform wants to cancel overall execution
+    Default - skip this file and continue
+    """
+    pass

--- a/data-processing-lib/ray/src/data_processing_ray/runtime/ray/ray_utils.py
+++ b/data-processing-lib/ray/src/data_processing_ray/runtime/ray/ray_utils.py
@@ -11,14 +11,15 @@
 ################################################################################
 
 import logging
+import sys
 import time
 from typing import Any
 
 import ray
-from data_processing.utils import GB
+from data_processing.utils import GB, UnrecoverableException
 from ray.actor import ActorHandle
 from ray.util.actor_pool import ActorPool
-
+from ray.exceptions import RayError
 
 class RayUtils:
     """
@@ -71,6 +72,22 @@ class RayUtils:
             "memory": resources.get("memory", 0.0) / GB,
             "object_store": resources.get("object_store_memory", 0.0) / GB,
         }
+
+    @staticmethod
+    def get_available_nodes(available_nodes_gauge: Gauge = None) -> int:
+        """
+        Get the list of the alive Ray nodes and optionally expose it to prometheus
+        :param available_nodes_gauge: the gauge used to publish number of available node
+        :return: number of available nodes
+        """
+        # get nodes from Ray
+        nodes = ray.nodes()
+        # filer out available ones
+        nnodes = 0
+        for node in nodes:
+            if node['Alive']:
+                nnodes += 1
+        return nnodes
 
     @staticmethod
     def create_actors(
@@ -128,6 +145,7 @@ class RayUtils:
             available_memory_gauge=available_memory_gauge,
             object_memory_gauge=object_memory_gauge,
         )
+        terminate = False
         running = 0
         t_start = time.time()
         completed = 0
@@ -140,13 +158,22 @@ class RayUtils:
                 while True:
                     # we can have several workers fail here
                     try:
-                        executors.get_next_unordered()
+                        res = executors.get_next_unordered()
                         break
                     except Exception as e:
+                        if isinstance(e, RayError):
+                            # Ray exception - terminate
+                            logger.error(f"Got Ray worker exception {e}, terminating")
+                            terminate = True
+                            break
                         logger.error(f"Failed to process request worker exception {e}")
                         actor_failures += 1
                         completed += 1
+                        break
+                if terminate:
+                    raise UnrecoverableException
                 executors.submit(lambda a, v: a.process_file.remote(v), path)
+
                 completed += 1
                 files_completed_gauge.set(completed)
                 RayUtils.get_available_resources(
@@ -203,5 +230,6 @@ class RayUtils:
             except Exception as e:
                 logger.error(f"Failed to process request worker exception {e}")
                 actor_failures += 1
+                not_ready = replies - 1
             replies = not_ready
         return actor_failures

--- a/data-processing-lib/ray/src/data_processing_ray/runtime/ray/transform_orchestrator.py
+++ b/data-processing-lib/ray/src/data_processing_ray/runtime/ray/transform_orchestrator.py
@@ -131,7 +131,6 @@ def orchestrate(
         logger.error(f"Exception during execution {e}: {traceback.print_exc()}")
         status = "failure"
         return_code = 1
-
     try:
         # Compute execution statistics
         logger.debug("Computing execution stats")

--- a/transforms/universal/resize/python/src/resize_local_python.py
+++ b/transforms/universal/resize/python/src/resize_local_python.py
@@ -38,7 +38,7 @@ params = {
     "runtime_code_location": ParamsUtils.convert_to_ast(code_location),
     # resize configuration
     # "resize_max_mbytes_per_table":  0.02,
-    "resize_max_rows_per_table": 125,
+    "resize_max_rows_per_table": 300,
 }
 sys.argv = ParamsUtils.dict_to_req(d=params)
 

--- a/transforms/universal/resize/python/src/resize_transform.py
+++ b/transforms/universal/resize/python/src/resize_transform.py
@@ -15,7 +15,7 @@ from typing import Any
 
 import pyarrow as pa
 from data_processing.transform import AbstractTableTransform, TransformConfiguration
-from data_processing.utils import LOCAL_TO_DISK, MB, CLIArgumentProvider, get_logger
+from data_processing.utils import LOCAL_TO_DISK, MB, CLIArgumentProvider, UnrecoverableException, get_logger
 
 
 max_rows_per_table_key = "max_rows_per_table"
@@ -42,9 +42,7 @@ class ResizeTransform(AbstractTableTransform):
         Initialize based on the dictionary of configuration information.
         """
         super().__init__(config)
-        self.logger = get_logger(__name__)
         self.max_rows_per_table = config.get(max_rows_per_table_key, 0)
-
         self.max_bytes_per_table = MB * config.get(max_mbytes_per_table_key, 0)
         disk_memory = config.get(size_type_key, size_type_default)
         if size_type_default in disk_memory:
@@ -71,15 +69,15 @@ class ResizeTransform(AbstractTableTransform):
                 self.logger.debug(
                     f"concatenating buffer with {self.buffer.num_rows} rows to table with {table.num_rows} rows"
                 )
-                table = pa.concat_tables([self.buffer, table], unicode_promote_options="permissive")
+                #table = pa.concat_tables([self.buffer, table], unicode_promote_options="permissive")
+                table = pa.concat_tables([self.buffer, table])
                 self.logger.debug(f"concatenated table has {table.num_rows} rows")
-                self.buffer = None
-            except Exception as e:  # Can happen if schemas are different
-                # Throw away the buffer and try and keep the current table by placing it in the buffer.
-                self.buffer = table
-                raise ValueError(
-                    "Can not concatenate buffered table with input table. Dropping buffer and proceeding."
-                ) from e
+            except Exception as _:  # Can happen if schemas are different
+                # Raise unrecoverable error to stop the execution
+                self.logger.warning(f"table in {file_name} can't be merged with the buffer")
+                self.logger.warning(f"incoming table columns {table.schema.names} ")
+                self.logger.warning(f"buffer columns {self.buffer.schema.names}")
+                raise UnrecoverableException()
 
         result = []
         start_row = 0

--- a/transforms/universal/resize/python/src/resize_transform.py
+++ b/transforms/universal/resize/python/src/resize_transform.py
@@ -71,6 +71,7 @@ class ResizeTransform(AbstractTableTransform):
                 )
                 #table = pa.concat_tables([self.buffer, table], unicode_promote_options="permissive")
                 table = pa.concat_tables([self.buffer, table])
+                self.buffer = None
                 self.logger.debug(f"concatenated table has {table.num_rows} rows")
             except Exception as _:  # Can happen if schemas are different
                 # Raise unrecoverable error to stop the execution

--- a/transforms/universal/resize/python/test/test_resize.py
+++ b/transforms/universal/resize/python/test/test_resize.py
@@ -32,12 +32,12 @@ class TestResizeTransform(AbstractTableTransformTest):
         input_tables = get_tables_in_folder(input_dir)
         expected_metadata_list = [{}] * (1 + len(input_tables))
 
-        config = {"max_rows_per_table": 125}
-        expected_tables = get_tables_in_folder(os.path.join(basedir, "expected-rows-125"))
-        fixtures.append((ResizeTransform(config), input_tables, expected_tables, expected_metadata_list))
-
         config = {"max_rows_per_table": 300}
         expected_tables = get_tables_in_folder(os.path.join(basedir, "expected-rows-300"))
+        fixtures.append((ResizeTransform(config), input_tables, expected_tables, expected_metadata_list))
+
+        config = {"max_rows_per_table": 125}
+        expected_tables = get_tables_in_folder(os.path.join(basedir, "expected-rows-125"))
         fixtures.append((ResizeTransform(config), input_tables, expected_tables, expected_metadata_list))
 
         config = {"max_mbytes_per_table": 0.05}


### PR DESCRIPTION
## Why are these changes needed?

Current implementation was designed so that if there is an error processing the file, it is skipped and processing continues. Althought for the most transforms this is a good strategy, for some of them (for example resize), the execution need to be camceled.
To achieve this, current PR defines a new Exception - `UnrecoverableException`. When a transformer throws this one, execution is killed. An example of using such exception is in Resize transform

## Related issue number (if any).

https://github.com/IBM/data-prep-kit/issues/437

