### PR TITLE
do not publish-dist in make publish

### DIFF
--- a/transforms/code/repo_level_ordering/ray/Makefile
+++ b/transforms/code/repo_level_ordering/ray/Makefile
@@ -26,7 +26,7 @@ test-image:: .transforms.ray-test-image
 
 build:: build-dist image
 
-publish:: publish-dist publish-image
+publish:: publish-image
 
 publish-image:: .transforms.publish-image-ray
 


### PR DESCRIPTION
## Why are these changes needed?

It prevents publishing ray image for code modules.

## Related issue number (if any).

https://github.com/IBM/data-prep-kit/issues/450
