### PR TITLE
Fix local run of noop

### DIFF
--- a/transforms/language/doc_quality/python/src/doc_quality_local.py
+++ b/transforms/language/doc_quality/python/src/doc_quality_local.py
@@ -34,7 +34,7 @@ if __name__ == "__main__":
     transform = DocQualityTransform(doc_quality_params)
     # Use the local data access to read a parquet table.
     data_access = DataAccessLocal()
-    table = data_access.get_table(os.path.join(input_folder, "test1.parquet"))
+    table, _ = data_access.get_table(os.path.join(input_folder, "test1.parquet"))
     print(f"input table: {table}")
     # Transform the table
     table_list, metadata = transform.transform(table[0])

--- a/transforms/language/doc_quality/python/src/doc_quality_local.py
+++ b/transforms/language/doc_quality/python/src/doc_quality_local.py
@@ -15,10 +15,11 @@ import os
 from data_processing.data_access import DataAccessLocal
 from doc_quality_transform import (
     DocQualityTransform,
-    text_lang_key,
-    doc_content_column_key,
     bad_word_filepath_key,
+    doc_content_column_key,
+    text_lang_key,
 )
+
 
 # create parameters
 basedir = os.path.abspath(os.path.join(os.path.dirname(__file__), "../"))
@@ -37,6 +38,6 @@ if __name__ == "__main__":
     table, _ = data_access.get_table(os.path.join(input_folder, "test1.parquet"))
     print(f"input table: {table}")
     # Transform the table
-    table_list, metadata = transform.transform(table[0])
+    table_list, metadata = transform.transform(table)
     print(f"\noutput table: {table_list}")
     print(f"output metadata : {metadata}")

--- a/transforms/language/lang_id/python/src/lang_id_local.py
+++ b/transforms/language/lang_id/python/src/lang_id_local.py
@@ -42,7 +42,7 @@ if __name__ == "__main__":
     print(f"input table: {table}")
     # Transform the table
     try:
-        table_list, metadata = transform.transform(table[0])
+        table_list, metadata = transform.transform(table)
         print(f"\noutput table: {table_list}")
         print(f"output metadata : {metadata}")
     except Exception as e:

--- a/transforms/language/lang_id/python/src/lang_id_local.py
+++ b/transforms/language/lang_id/python/src/lang_id_local.py
@@ -38,7 +38,7 @@ if __name__ == "__main__":
     transform = LangIdentificationTransform(lang_id_params)
     # Use the local data access to read a parquet table.
     data_access = DataAccessLocal()
-    table = data_access.get_table(os.path.join(input_folder, "test_01.parquet"))
+    table, _ = data_access.get_table(os.path.join(input_folder, "test_01.parquet"))
     print(f"input table: {table}")
     # Transform the table
     try:

--- a/transforms/universal/noop/python/src/noop_local.py
+++ b/transforms/universal/noop/python/src/noop_local.py
@@ -26,7 +26,7 @@ if __name__ == "__main__":
     transform = NOOPTransform(noop_params)
     # Use the local data access to read a parquet table.
     data_access = DataAccessLocal()
-    table = data_access.get_table(os.path.join(input_folder, "test1.parquet"))
+    table, _ = data_access.get_table(os.path.join(input_folder, "test1.parquet"))
     print(f"input table: {table}")
     # Transform the table
     table_list, metadata = transform.transform(table)


### PR DESCRIPTION
## Why are these changes needed?

The noop is using an old interface for getting the table and fails by launching the transform with a tuple instead of a `pa.Table`.


