### PR TITLE
Try and make all transform Dockerfiles use a common set of first statements

### DIFF
--- a/transforms/code/code2parquet/python/Dockerfile
+++ b/transforms/code/code2parquet/python/Dockerfile
@@ -1,6 +1,6 @@
 FROM docker.io/python:3.10.14-slim-bullseye
 
-RUN pip install --upgrade pip 
+RUN pip install --upgrade --no-cache-dir pip 
 
 # install pytest
 RUN pip install --no-cache-dir pytest

--- a/transforms/code/code2parquet/ray/Dockerfile
+++ b/transforms/code/code2parquet/ray/Dockerfile
@@ -2,6 +2,8 @@ ARG BASE_IMAGE=docker.io/rayproject/ray:2.24.0-py310
 
 FROM ${BASE_IMAGE}
 
+RUN pip install --ugrade pip 
+
 # install pytest
 RUN pip install --no-cache-dir pytest
 

--- a/transforms/code/code2parquet/ray/Dockerfile
+++ b/transforms/code/code2parquet/ray/Dockerfile
@@ -2,7 +2,7 @@ ARG BASE_IMAGE=docker.io/rayproject/ray:2.24.0-py310
 
 FROM ${BASE_IMAGE}
 
-RUN pip install --ugrade pip 
+RUN pip install --upgrade --no-cache-dir pip 
 
 # install pytest
 RUN pip install --no-cache-dir pytest

--- a/transforms/code/code_quality/python/Dockerfile
+++ b/transforms/code/code_quality/python/Dockerfile
@@ -1,6 +1,6 @@
 FROM docker.io/python:3.10.14-slim-bullseye
 
-RUN pip install --upgrade pip 
+RUN pip install --upgrade --no-cache-dir pip 
 
 # install pytest
 RUN pip install --no-cache-dir pytest

--- a/transforms/code/code_quality/ray/Dockerfile
+++ b/transforms/code/code_quality/ray/Dockerfile
@@ -2,6 +2,8 @@ ARG BASE_IMAGE=docker.io/rayproject/ray:2.24.0-py310
 
 FROM ${BASE_IMAGE}
 
+RUN pip install --ugrade pip 
+
 # install pytest
 RUN pip install --no-cache-dir pytest
 

--- a/transforms/code/code_quality/ray/Dockerfile
+++ b/transforms/code/code_quality/ray/Dockerfile
@@ -2,7 +2,7 @@ ARG BASE_IMAGE=docker.io/rayproject/ray:2.24.0-py310
 
 FROM ${BASE_IMAGE}
 
-RUN pip install --ugrade pip 
+RUN pip install --upgrade --no-cache-dir pip 
 
 # install pytest
 RUN pip install --no-cache-dir pytest

--- a/transforms/code/malware/python/Dockerfile
+++ b/transforms/code/malware/python/Dockerfile
@@ -1,5 +1,10 @@
 FROM docker.io/python:3.10.14-slim-bullseye AS base
 
+RUN pip install --upgrade pip 
+
+# install pytest
+RUN pip install --no-cache-dir pytest
+
 RUN apt -y update \
     && apt install -y clamav-daemon \
     && apt-get clean \
@@ -27,8 +32,6 @@ COPY --chown=dpk:root --from=clamav-local /var/lib/clamav/ /var/lib/clamav/
 COPY --chown=dpk:root --from=clamav-local /etc/clamav/clamd.conf /etc/clamav/clamd.conf
 COPY --chown=dpk:root --from=clamav-local /var/log/clamav/clamav.log /var/log/clamav/clamav.log
 COPY --chown=dpk:root --from=clamav-local /var/run/clamav /var/run/clamav
-
-RUN pip install --no-cache-dir pytest
 
 # Copy and install data processing libraries 
 # These are expected to be placed in the docker context before this is run (see the make image).

--- a/transforms/code/malware/python/Dockerfile
+++ b/transforms/code/malware/python/Dockerfile
@@ -1,6 +1,6 @@
 FROM docker.io/python:3.10.14-slim-bullseye AS base
 
-RUN pip install --upgrade pip 
+RUN pip install --upgrade --no-cache-dir pip 
 
 # install pytest
 RUN pip install --no-cache-dir pytest
@@ -9,8 +9,6 @@ RUN apt -y update \
     && apt install -y clamav-daemon \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* \
-    && pip install --upgrade pip \
-    && pip install --no-cache-dir pytest \
     && useradd -ms /bin/bash dpk
 USER dpk
 WORKDIR /home/dpk

--- a/transforms/code/malware/ray/Dockerfile
+++ b/transforms/code/malware/ray/Dockerfile
@@ -2,6 +2,10 @@ ARG BASE_IMAGE=docker.io/rayproject/ray:2.24.0-py310
 
 FROM ${BASE_IMAGE} AS base
 
+RUN pip install --upgrade --no-cache-dir pip
+
+RUN pip install --no-cache-dir pytest
+
 USER root
 RUN apt -y update \
     && apt install -y clamav-daemon \
@@ -32,7 +36,6 @@ COPY --from=clamav-local --chown=ray:0 /etc/clamav/clamd.conf /etc/clamav/clamd.
 COPY --from=clamav-local --chown=ray:0 /var/log/clamav /var/log/clamav
 COPY --from=clamav-local --chown=ray:0 /var/run/clamav /var/run/clamav
 
-RUN pip install --no-cache-dir pytest
 
 # Copy in the data processing framework source/project and install it
 # This is expected to be placed in the docker context before this is run (see the make image).

--- a/transforms/code/proglang_select/python/Dockerfile
+++ b/transforms/code/proglang_select/python/Dockerfile
@@ -1,6 +1,6 @@
 FROM docker.io/python:3.10.14-slim-bullseye
 
-RUN pip install --upgrade pip 
+RUN pip install --upgrade --no-cache-dir pip 
 
 # install pytest
 RUN pip install --no-cache-dir pytest

--- a/transforms/code/proglang_select/ray/Dockerfile
+++ b/transforms/code/proglang_select/ray/Dockerfile
@@ -2,6 +2,8 @@ ARG BASE_IMAGE=docker.io/rayproject/ray:2.24.0-py310
 
 FROM ${BASE_IMAGE}
 
+RUN pip install --ugrade pip 
+
 # install pytest
 RUN pip install --no-cache-dir pytest
 

--- a/transforms/code/proglang_select/ray/Dockerfile
+++ b/transforms/code/proglang_select/ray/Dockerfile
@@ -2,7 +2,7 @@ ARG BASE_IMAGE=docker.io/rayproject/ray:2.24.0-py310
 
 FROM ${BASE_IMAGE}
 
-RUN pip install --ugrade pip 
+RUN pip install --upgrade --no-cache-dir pip 
 
 # install pytest
 RUN pip install --no-cache-dir pytest

--- a/transforms/code/repo_level_ordering/ray/Dockerfile
+++ b/transforms/code/repo_level_ordering/ray/Dockerfile
@@ -1,4 +1,8 @@
-FROM docker.io/rayproject/ray:2.24.0-py310
+ARG BASE_IMAGE=docker.io/rayproject/ray:2.24.0-py310
+
+FROM ${BASE_IMAGE}
+
+RUN pip install --ugrade pip 
 
 # install pytest
 RUN pip install --no-cache-dir pytest

--- a/transforms/code/repo_level_ordering/ray/Dockerfile
+++ b/transforms/code/repo_level_ordering/ray/Dockerfile
@@ -2,7 +2,7 @@ ARG BASE_IMAGE=docker.io/rayproject/ray:2.24.0-py310
 
 FROM ${BASE_IMAGE}
 
-RUN pip install --ugrade pip 
+RUN pip install --upgrade --no-cache-dir pip 
 
 # install pytest
 RUN pip install --no-cache-dir pytest

--- a/transforms/code/repo_level_ordering/ray/Makefile
+++ b/transforms/code/repo_level_ordering/ray/Makefile
@@ -7,8 +7,9 @@ REPOROOT=../../../..
 
 include $(REPOROOT)/transforms/.make.transforms
 
+BASE_IMAGE=$(RAY_BASE_IMAGE)
+
 TRANSFORM_NAME=repo_level_order
-DOCKER_IMAGE_VERSION=${REPO_LVL_ORDER_RAY_VERSION}
 
 venv::	.transforms.ray-venv
 

--- a/transforms/language/doc_quality/python/Dockerfile
+++ b/transforms/language/doc_quality/python/Dockerfile
@@ -1,6 +1,6 @@
 FROM docker.io/python:3.10.14-slim-bullseye
 
-RUN pip install --upgrade pip 
+RUN pip install --upgrade --no-cache-dir pip 
 
 # install pytest
 RUN pip install --no-cache-dir pytest

--- a/transforms/language/doc_quality/ray/Dockerfile
+++ b/transforms/language/doc_quality/ray/Dockerfile
@@ -2,6 +2,8 @@ ARG BASE_IMAGE=docker.io/rayproject/ray:2.24.0-py310
 
 FROM ${BASE_IMAGE}
 
+RUN pip install --ugrade pip 
+
 # install pytest
 RUN pip install --no-cache-dir pytest
 

--- a/transforms/language/doc_quality/ray/Dockerfile
+++ b/transforms/language/doc_quality/ray/Dockerfile
@@ -2,7 +2,7 @@ ARG BASE_IMAGE=docker.io/rayproject/ray:2.24.0-py310
 
 FROM ${BASE_IMAGE}
 
-RUN pip install --ugrade pip 
+RUN pip install --upgrade --no-cache-dir pip 
 
 # install pytest
 RUN pip install --no-cache-dir pytest

--- a/transforms/language/lang_id/python/Dockerfile
+++ b/transforms/language/lang_id/python/Dockerfile
@@ -1,6 +1,6 @@
 FROM docker.io/python:3.10.14-slim-bullseye
 
-RUN pip install --upgrade pip 
+RUN pip install --upgrade --no-cache-dir pip 
 
 # install pytest
 RUN pip install --no-cache-dir pytest

--- a/transforms/language/lang_id/ray/Dockerfile
+++ b/transforms/language/lang_id/ray/Dockerfile
@@ -2,6 +2,8 @@ ARG BASE_IMAGE=docker.io/rayproject/ray:2.24.0-py310
 
 FROM ${BASE_IMAGE}
 
+RUN pip install --ugrade pip 
+
 # install pytest
 RUN pip install --no-cache-dir pytest
 

--- a/transforms/language/lang_id/ray/Dockerfile
+++ b/transforms/language/lang_id/ray/Dockerfile
@@ -2,7 +2,7 @@ ARG BASE_IMAGE=docker.io/rayproject/ray:2.24.0-py310
 
 FROM ${BASE_IMAGE}
 
-RUN pip install --ugrade pip 
+RUN pip install --upgrade --no-cache-dir pip 
 
 # install pytest
 RUN pip install --no-cache-dir pytest

--- a/transforms/language/pdf2parquet/python/Dockerfile
+++ b/transforms/language/pdf2parquet/python/Dockerfile
@@ -1,6 +1,6 @@
 FROM docker.io/python:3.10.14-slim-bullseye
 
-RUN pip install --upgrade pip 
+RUN pip install --upgrade --no-cache-dir pip 
 
 # install pytest
 RUN pip install --no-cache-dir pytest

--- a/transforms/language/pdf2parquet/python/Dockerfile
+++ b/transforms/language/pdf2parquet/python/Dockerfile
@@ -5,16 +5,16 @@ RUN pip install --upgrade --no-cache-dir pip
 # install pytest
 RUN pip install --no-cache-dir pytest
 
-# Create a user and use it to run the transform
-RUN useradd -ms /bin/bash dpk
-USER dpk
-WORKDIR /home/dpk
-
 RUN \
     apt-get update \
     # for opencv, towhee
     && apt-get install -y libgl1 libglib2.0-0 curl wget \
     && apt-get clean
+
+# Create a user and use it to run the transform
+RUN useradd -ms /bin/bash dpk
+USER dpk
+WORKDIR /home/dpk
 
 # Copy and install data processing libraries 
 # These are expected to be placed in the docker context before this is run (see the make image).

--- a/transforms/language/pdf2parquet/python/Dockerfile
+++ b/transforms/language/pdf2parquet/python/Dockerfile
@@ -1,11 +1,5 @@
 FROM docker.io/python:3.10.14-slim-bullseye
 
-RUN \
-    apt-get update \
-    # for opencv, towhee
-    && apt-get install -y libgl1 libglib2.0-0 curl wget \
-    && apt-get clean
-
 RUN pip install --upgrade pip 
 
 # install pytest
@@ -15,6 +9,12 @@ RUN pip install --no-cache-dir pytest
 RUN useradd -ms /bin/bash dpk
 USER dpk
 WORKDIR /home/dpk
+
+RUN \
+    apt-get update \
+    # for opencv, towhee
+    && apt-get install -y libgl1 libglib2.0-0 curl wget \
+    && apt-get clean
 
 # Copy and install data processing libraries 
 # These are expected to be placed in the docker context before this is run (see the make image).

--- a/transforms/language/pdf2parquet/ray/Dockerfile
+++ b/transforms/language/pdf2parquet/ray/Dockerfile
@@ -2,14 +2,17 @@ ARG BASE_IMAGE=docker.io/rayproject/ray:2.24.0-py310
 
 FROM ${BASE_IMAGE}
 
+RUN pip install --ugrade pip 
+
+# install pytest
+RUN pip install --no-cache-dir pytest
+
 RUN \
     sudo apt-get update \
     # for opencv, towhee
     && sudo apt-get install -y libgl1 libglib2.0-0 curl wget \
     && sudo apt-get clean
 
-# install pytest
-RUN pip install --no-cache-dir pytest
 
 # Copy and install data processing libraries 
 # These are expected to be placed in the docker context before this is run (see the make image).

--- a/transforms/language/pdf2parquet/ray/Dockerfile
+++ b/transforms/language/pdf2parquet/ray/Dockerfile
@@ -2,7 +2,7 @@ ARG BASE_IMAGE=docker.io/rayproject/ray:2.24.0-py310
 
 FROM ${BASE_IMAGE}
 
-RUN pip install --ugrade pip 
+RUN pip install --upgrade --no-cache-dir pip 
 
 # install pytest
 RUN pip install --no-cache-dir pytest

--- a/transforms/universal/doc_id/ray/Dockerfile
+++ b/transforms/universal/doc_id/ray/Dockerfile
@@ -2,7 +2,7 @@ ARG BASE_IMAGE=docker.io/rayproject/ray:2.24.0-py310
 
 FROM ${BASE_IMAGE}
 
-RUN pip install --upgrade pip
+RUN pip install --upgrade --no-cache-dir pip
 
 # install pytest
 RUN pip install --no-cache-dir pytest

--- a/transforms/universal/doc_id/ray/Dockerfile
+++ b/transforms/universal/doc_id/ray/Dockerfile
@@ -2,6 +2,8 @@ ARG BASE_IMAGE=docker.io/rayproject/ray:2.24.0-py310
 
 FROM ${BASE_IMAGE}
 
+RUN pip install --upgrade pip
+
 # install pytest
 RUN pip install --no-cache-dir pytest
 

--- a/transforms/universal/ededup/python/Dockerfile
+++ b/transforms/universal/ededup/python/Dockerfile
@@ -1,6 +1,6 @@
 FROM docker.io/python:3.10.14-slim-bullseye
 
-RUN pip install --upgrade pip 
+RUN pip install --upgrade --no-cache-dir pip 
 
 # install pytest
 RUN pip install --no-cache-dir pytest

--- a/transforms/universal/ededup/ray/Dockerfile
+++ b/transforms/universal/ededup/ray/Dockerfile
@@ -2,7 +2,7 @@ ARG BASE_IMAGE=docker.io/rayproject/ray:2.24.0-py310
 
 FROM ${BASE_IMAGE}
 
-RUN pip install --upgrade pip
+RUN pip install --upgrade --no-cache-dir pip
 
 # install pytest
 RUN pip install --no-cache-dir pytest

--- a/transforms/universal/ededup/ray/Dockerfile
+++ b/transforms/universal/ededup/ray/Dockerfile
@@ -2,6 +2,8 @@ ARG BASE_IMAGE=docker.io/rayproject/ray:2.24.0-py310
 
 FROM ${BASE_IMAGE}
 
+RUN pip install --upgrade pip
+
 # install pytest
 RUN pip install --no-cache-dir pytest
 

--- a/transforms/universal/fdedup/ray/Dockerfile
+++ b/transforms/universal/fdedup/ray/Dockerfile
@@ -2,7 +2,7 @@ ARG BASE_IMAGE=docker.io/rayproject/ray:2.24.0-py310
 
 FROM ${BASE_IMAGE}
 
-RUN pip install --upgrade pip 
+RUN pip install --upgrade --no-cache-dir pip 
 
 # install pytest
 RUN pip install --no-cache-dir pytest

--- a/transforms/universal/fdedup/ray/Dockerfile
+++ b/transforms/universal/fdedup/ray/Dockerfile
@@ -2,6 +2,8 @@ ARG BASE_IMAGE=docker.io/rayproject/ray:2.24.0-py310
 
 FROM ${BASE_IMAGE}
 
+RUN pip install --upgrade pip 
+
 # install pytest
 RUN pip install --no-cache-dir pytest
 

--- a/transforms/universal/filter/python/Dockerfile
+++ b/transforms/universal/filter/python/Dockerfile
@@ -1,6 +1,6 @@
 FROM docker.io/python:3.10.14-slim-bullseye
 
-RUN pip install --upgrade pip 
+RUN pip install --upgrade --no-cache-dir pip 
 
 # install pytest
 RUN pip install --no-cache-dir pytest

--- a/transforms/universal/filter/ray/Dockerfile
+++ b/transforms/universal/filter/ray/Dockerfile
@@ -1,7 +1,7 @@
 ARG BASE_IMAGE=docker.io/rayproject/ray:2.24.0-py310
 FROM ${BASE_IMAGE}
 
-RUN pip install --upgrade pip 
+RUN pip install --upgrade --no-cache-dir pip 
 
 # install pytest
 RUN pip install --no-cache-dir pytest

--- a/transforms/universal/filter/ray/Dockerfile
+++ b/transforms/universal/filter/ray/Dockerfile
@@ -1,6 +1,8 @@
 ARG BASE_IMAGE=docker.io/rayproject/ray:2.24.0-py310
 FROM ${BASE_IMAGE}
 
+RUN pip install --upgrade pip 
+
 # install pytest
 RUN pip install --no-cache-dir pytest
 

--- a/transforms/universal/noop/python/Dockerfile
+++ b/transforms/universal/noop/python/Dockerfile
@@ -1,6 +1,6 @@
 FROM docker.io/python:3.10.14-slim-bullseye
 
-RUN pip install --upgrade pip 
+RUN pip install --upgrade --no-cache-dir pip 
 
 # install pytest
 RUN pip install --no-cache-dir pytest

--- a/transforms/universal/noop/ray/Dockerfile
+++ b/transforms/universal/noop/ray/Dockerfile
@@ -1,7 +1,7 @@
 ARG BASE_IMAGE=docker.io/rayproject/ray:2.24.0-py310
 FROM ${BASE_IMAGE}
 
-RUN pip install --upgrade pip 
+RUN pip install --upgrade --no-cache-dir pip 
 
 # install pytest
 RUN pip install --no-cache-dir pytest

--- a/transforms/universal/noop/ray/Dockerfile
+++ b/transforms/universal/noop/ray/Dockerfile
@@ -1,6 +1,8 @@
 ARG BASE_IMAGE=docker.io/rayproject/ray:2.24.0-py310
 FROM ${BASE_IMAGE}
 
+RUN pip install --upgrade pip 
+
 # install pytest
 RUN pip install --no-cache-dir pytest
 

--- a/transforms/universal/profiler/ray/Dockerfile
+++ b/transforms/universal/profiler/ray/Dockerfile
@@ -2,7 +2,7 @@ ARG BASE_IMAGE=docker.io/rayproject/ray:2.24.0-py310
 
 FROM ${BASE_IMAGE}
 
-RUN pip install --upgrade pip 
+RUN pip install --upgrade --no-cache-dir pip 
 
 # install pytest
 RUN pip install --no-cache-dir pytest

--- a/transforms/universal/profiler/ray/Dockerfile
+++ b/transforms/universal/profiler/ray/Dockerfile
@@ -2,6 +2,8 @@ ARG BASE_IMAGE=docker.io/rayproject/ray:2.24.0-py310
 
 FROM ${BASE_IMAGE}
 
+RUN pip install --upgrade pip 
+
 # install pytest
 RUN pip install --no-cache-dir pytest
 

--- a/transforms/universal/resize/python/Dockerfile
+++ b/transforms/universal/resize/python/Dockerfile
@@ -1,6 +1,6 @@
 FROM docker.io/python:3.10.14-slim-bullseye
 
-RUN pip install --upgrade pip 
+RUN pip install --upgrade --no-cache-dir pip 
 
 # install pytest
 RUN pip install --no-cache-dir pytest

--- a/transforms/universal/resize/ray/Dockerfile
+++ b/transforms/universal/resize/ray/Dockerfile
@@ -2,7 +2,7 @@ ARG BASE_IMAGE=docker.io/rayproject/ray:2.24.0-py310
 
 FROM ${BASE_IMAGE}
 
-RUN pip install --upgrade pip 
+RUN pip install --upgrade --no-cache-dir pip 
 
 # Install pytest so we can test the image later
 RUN pip install --no-cache-dir pytest

--- a/transforms/universal/resize/ray/Dockerfile
+++ b/transforms/universal/resize/ray/Dockerfile
@@ -2,7 +2,10 @@ ARG BASE_IMAGE=docker.io/rayproject/ray:2.24.0-py310
 
 FROM ${BASE_IMAGE}
 
-ARG EXTRA_ARTIFACTORY_URL
+RUN pip install --upgrade pip 
+
+# Install pytest so we can test the image later
+RUN pip install --no-cache-dir pytest
 
 # Copy and install data processing libraries
 # These are expected to be placed in the docker context before this is run (see the make image).
@@ -23,8 +26,6 @@ COPY ./src/resize_transform_ray.py ./
 # copy some of the samples in
 COPY ./src/resize_local_ray.py local/
 
-# Install pytest so we can test the image later
-RUN pip install --no-cache-dir pytest
 COPY test/ test/
 COPY test-data/ test-data/
 

--- a/transforms/universal/tokenization/python/Dockerfile
+++ b/transforms/universal/tokenization/python/Dockerfile
@@ -1,6 +1,6 @@
 FROM docker.io/python:3.10.14-slim-bullseye
 
-RUN pip install --upgrade pip 
+RUN pip install --upgrade --no-cache-dir pip 
 
 # install pytest
 RUN pip install --no-cache-dir pytest

--- a/transforms/universal/tokenization/ray/Dockerfile
+++ b/transforms/universal/tokenization/ray/Dockerfile
@@ -2,7 +2,7 @@ ARG BASE_IMAGE=docker.io/rayproject/ray:2.24.0-py310
 
 FROM ${BASE_IMAGE}
 
-RUN pip install --upgrade pip 
+RUN pip install --upgrade --no-cache-dir pip 
 
 # Install pytest so we can test the image later
 RUN pip install --no-cache-dir pytest

--- a/transforms/universal/tokenization/ray/Dockerfile
+++ b/transforms/universal/tokenization/ray/Dockerfile
@@ -2,7 +2,9 @@ ARG BASE_IMAGE=docker.io/rayproject/ray:2.24.0-py310
 
 FROM ${BASE_IMAGE}
 
-# install pytest
+RUN pip install --upgrade pip 
+
+# Install pytest so we can test the image later
 RUN pip install --no-cache-dir pytest
 
 # Copy and install data processing libraries 


### PR DESCRIPTION
## Why are these changes needed?
Should speed up ci/cd builds since we get better docker layer caching since all images use a common set of first steps.

## Related issue number (if any).


