### PR TITLE
Add KFP prefix to DataAccess object created from kfp component. 

### DIFF
--- a/data-processing-lib/python/src/data_processing/utils/params_utils.py
+++ b/data-processing-lib/python/src/data_processing/utils/params_utils.py
@@ -92,7 +92,7 @@ class ParamsUtils:
         return all_text
 
     @staticmethod
-    def get_config_parameter(params: dict[str, Any]) -> str:
+    def get_config_parameter(params: dict[str, Any], cli_prefix: str = "data_") -> str:
         """
         Get the key name of the config parameter
         :param params: original parameters
@@ -100,8 +100,9 @@ class ParamsUtils:
         """
         # find config parameter
         config = None
+        print(params)
         for key in params.keys():
-            if key.startswith("data") and key.endswith("config"):
+            if key.startswith(cli_prefix) and key.endswith("config"):
                 if params[key] is not None and params[key] != "None" and len(params[key]) > 0:
                     config = key
                     break

--- a/kfp/kfp_support_lib/shared_workflow_support/src/runtime_utils/remote_jobs_utils.py
+++ b/kfp/kfp_support_lib/shared_workflow_support/src/runtime_utils/remote_jobs_utils.py
@@ -33,6 +33,8 @@ from python_apiserver_client.params import (
 from ray.job_submission import JobStatus
 from runtime_utils import KFPUtils
 
+short_name = "KFP"
+cli_prefix = f"{short_name}_"
 
 logger = get_logger(__name__)
 
@@ -437,7 +439,7 @@ def _execute_remote_job(
 
     logger.info(f"submitted job successfully, submission id {submission}")
     # create data access
-    data_factory = DataAccessFactory()
+    data_factory = DataAccessFactory(cli_arg_prefix=cli_prefix)
     data_factory.apply_input_params(args=data_access_params)
     data_access = data_factory.create_data_access()
     # print execution log
@@ -481,7 +483,7 @@ def execute_ray_jobs(
         wait_interval=additional_params.get("wait_interval", 2),
     )
     # find config parameter
-    config = ParamsUtils.get_config_parameter(e_params)
+    config = ParamsUtils.get_config_parameter(params=e_params)
     if config is None:
         exit(1)
     # get config value
@@ -493,7 +495,7 @@ def execute_ray_jobs(
             name=name,
             ns=ns,
             script=exec_script_name,
-            data_access_params={config: config_value, "data_s3_cred": s3_creds},
+            data_access_params={f"{cli_prefix}s3_config": config_value, f"{cli_prefix}s3_cred": s3_creds},
             params=e_params,
             additional_params=additional_params,
             remote_jobs=remote_jobs,
@@ -511,7 +513,7 @@ def execute_ray_jobs(
                 name=name,
                 ns=ns,
                 script=exec_script_name,
-                data_access_params={config: conf, "data_s3_cred": s3_creds},
+                data_access_params={f"{cli_prefix}s3_config": config_value, f"{cli_prefix}s3_cred": s3_creds},
                 params=launch_params,
                 additional_params=additional_params,
                 remote_jobs=remote_jobs,

--- a/kfp/kfp_support_lib/shared_workflow_support/src/runtime_utils/remote_jobs_utils.py
+++ b/kfp/kfp_support_lib/shared_workflow_support/src/runtime_utils/remote_jobs_utils.py
@@ -33,8 +33,7 @@ from python_apiserver_client.params import (
 from ray.job_submission import JobStatus
 from runtime_utils import KFPUtils
 
-short_name = "KFP"
-cli_prefix = f"{short_name}_"
+cli_prefix = "KFP"
 
 logger = get_logger(__name__)
 

--- a/kfp/kfp_support_lib/shared_workflow_support/src/runtime_utils/remote_jobs_utils.py
+++ b/kfp/kfp_support_lib/shared_workflow_support/src/runtime_utils/remote_jobs_utils.py
@@ -513,7 +513,7 @@ def execute_ray_jobs(
                 name=name,
                 ns=ns,
                 script=exec_script_name,
-                data_access_params={f"{cli_prefix}s3_config": config_value, f"{cli_prefix}s3_cred": s3_creds},
+                data_access_params={f"{cli_prefix}s3_config": conf, f"{cli_prefix}s3_cred": s3_creds},
                 params=launch_params,
                 additional_params=additional_params,
                 remote_jobs=remote_jobs,


### PR DESCRIPTION
## Why are these changes needed?


Add Add KFP prefix to DataAccess object created from kfp component. :
```bash
23:45:41 INFO - request to execute: python noop_transform_ray.py --data_max_files=-1 --data_num_samples=-1 --noop_sleep_sec=10 --runtime_code_location="{'github': 'github', 'commit_hash': '12345', 'path': 'path'}" --runtime_job_id="cc368a29-83f2-4171-833c-0c7b65701372" --runtime_num_workers="4" --runtime_pipeline_id="pipeline_id" --runtime_worker_options="{'num_cpus': 0.8}" --data_s3_cred="{'access_key': 'minio', 'secret_key': 'minio123', 'url': '
http://minio-service.kubeflow.svc.cluster.local:9000/
'}" --data_s3_config="{'input_folder': 'test/noop/input/', 'output_folder': 'test/noop/output/'}" 
23:45:42 INFO - submitted job successfully, submission id raysubmit_GSttvCxz3MY18YJJ
23:45:42 INFO - data factory KFP is using S3 data access: input path - test/noop/input/, output path - test/noop/output/
23:45:42 INFO - data factory KFP max_files -1, n_sample -1
23:45:42 INFO - data factory KFP Not using data sets, checkpointing False, max files -1, random samples -1, files to use ['.parquet'], files to checkpoint ['.parquet']
23:45:45 INFO - job status is RUNNING
23:45:45 INFO - Launching noop transform
23:45:45 INFO - connecting to existing cluster
```



