### PR TITLE
Minor change to header_cleanser workflow

### DIFF
--- a/.github/workflows/workflow-manual-run.yml
+++ b/.github/workflows/workflow-manual-run.yml
@@ -52,9 +52,11 @@ jobs:
                   curl https://dl.min.io/client/mc/release/linux-amd64/mc --create-dirs -o /tmp/mc
                   chmod +x /tmp/mc
                   make -C $K8S_SETUP_SCRIPTS setup
-                  make -C $WORKFLOW_PATH workflow-test
                   debug_mode=$(echo "$DEBUG_MODE" | tr '[:upper:]' '[:lower:]')
                   if [ "$debug_mode" == "true" ]; then
+                     make -C $WORKFLOW_PATH workflow-test || true
                      kubectl describe pod -A
                      kubectl get pods -A
+                  else
+                     make -C $WORKFLOW_PATH workflow-test
                   fi

--- a/transforms/code/header_cleanser/kfp_ray/header_cleanser_wf.py
+++ b/transforms/code/header_cleanser/kfp_ray/header_cleanser_wf.py
@@ -106,7 +106,7 @@ def header_cleanser(
     # Ray cluster
     ray_name: str = "header_cleanser-kfp-ray",  # name of Ray cluster
     # Add image_pull_secret and image_pull_policy to ray workers if needed
-    ray_head_options: str = '{"cpu": 4, "memory": 4, "image": "' + task_image + '" }',
+    ray_head_options: str = '{"cpu": 1, "memory": 4, "image": "' + task_image + '" }',
     ray_worker_options: str = '{"replicas": 2, "max_replicas": 2, "min_replicas": 2, "cpu": 2, "memory": 4, \
             "image": "'
     + task_image


### PR DESCRIPTION
## Why are these changes needed?

header_cleanser workflow test fails when running in CI/CD. This is due to cpu requirement specified in ray_head_options. This PR reduces this requirement.


