### PR TITLE
Add PII to the root README

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Matrix below shows the the combination of modules and supported runtimes. All th
 | [Document quality](transforms/language/doc_quality/python/README.md)                 | :white_check_mark: |:white_check_mark:|                  |:white_check_mark:      |
 | [Document chunking for RAG](transforms/language/doc_chunk/python/README.md)         | :white_check_mark: |:white_check_mark:|                  |:white_check_mark:      |
 | [Text encoder](transforms/language/text_encoder/python/README.md)                     | :white_check_mark: |:white_check_mark:|                  |:white_check_mark:      |
-| [PII Annotator/Redactor](transforms/universal/pii_redactor/python/README.md)| :white_check_mark:| :white_check_mark: | | :white_check_mark: |
+| [PII Annotator/Redactor](transforms/language/pii_redactor/python/README.md)| :white_check_mark:| :white_check_mark: | | :white_check_mark: |
 | **Code-only**                    |                    |                  |                  |                        |
 | [Programming language annnotation](transforms/code/proglang_select/python/README.md) | :white_check_mark: |:white_check_mark:|                  |:white_check_mark:      |
 | [Code quality annotation](transforms/code/code_quality/python/README.md)          | :white_check_mark: |:white_check_mark:|                  |:white_check_mark:      |

--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ Matrix below shows the the combination of modules and supported runtimes. All th
 | [Document quality](transforms/language/doc_quality/python/README.md)                 | :white_check_mark: |:white_check_mark:|                  |:white_check_mark:      |
 | [Document chunking for RAG](transforms/language/doc_chunk/python/README.md)         | :white_check_mark: |:white_check_mark:|                  |:white_check_mark:      |
 | [Text encoder](transforms/language/text_encoder/python/README.md)                     | :white_check_mark: |:white_check_mark:|                  |:white_check_mark:      |
+| [PII Annotator/Redactor](transforms/universal/pii_redactor/python/README.md)| :white_check_mark:| :white_check_mark: | | :white_check_mark: |
 | **Code-only**                    |                    |                  |                  |                        |
 | [Programming language annnotation](transforms/code/proglang_select/python/README.md) | :white_check_mark: |:white_check_mark:|                  |:white_check_mark:      |
 | [Code quality annotation](transforms/code/code_quality/python/README.md)          | :white_check_mark: |:white_check_mark:|                  |:white_check_mark:      |


### PR DESCRIPTION
PII transform is now added to the table in the root README file. 





