### PR TITLE
prevent kfp test for transforms that do not support it

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -160,11 +160,17 @@ jobs:
                   make -C $K8S_SETUP_SCRIPTS setup
                   make -C kfp/kfp_support_lib test
                   make -C transforms workflow-build
-                  dir=("code"  "universal" "language") && index=$(($RANDOM % ${#dir[@]})) && subdirs=${dir[$index]} && transforms=($(find transforms/$subdirs/ -type d  -maxdepth 1 ))
-                  # First element is not really a subdir but rather the current dir so remove it and randomly choose a transform to run
-                  set -- "${transforms[@]}" && shift && transforms=("$@") && size=${#transforms[@]} && index=$(($RANDOM % $size))
                   source $K8S_SETUP_SCRIPTS/common.sh
-                  header_text "Running ${transforms[$index]} workflow test"
+                  while :
+                  do
+                    dir=("code"  "universal" "language") && index=$(($RANDOM % ${#dir[@]})) && subdirs=${dir[$index]} && transforms=($(find transforms/$subdirs -type d  -maxdepth 1 -mindepth 1 ))
+                    # First element is not really a subdir but rather the current dir so remove it and randomly choose a transform to run
+                    set -- "${transforms[@]}" && shift && transforms=("$@") && size=${#transforms[@]} && index=$(($RANDOM % $size))
+                    if [ -d ${transforms[$index]}/kfp_ray ]; then
+                      header_text "Running ${transforms[$index]} workflow test"
+                      break
+                    fi
+                  done  
                   make -C ${transforms[$index]} workflow-test
                   header_text "Run ${transforms[$index]} completed"
 
@@ -204,11 +210,17 @@ jobs:
                   make -C $K8S_SETUP_SCRIPTS setup
                   make -C kfp/kfp_support_lib test
                   make -C transforms workflow-build
-                  dir=("code"  "universal" "language") && index=$(($RANDOM % ${#dir[@]})) && subdirs=${dir[$index]} && transforms=($(find transforms/$subdirs/ -type d  -maxdepth 1 ))
-                  # First element is not really a subdir but rather the current dir so remove it and randomly choose a transform to run
-                  set -- "${transforms[@]}" && shift && transforms=("$@") && size=${#transforms[@]} && index=$(($RANDOM % $size))
                   source $K8S_SETUP_SCRIPTS/common.sh
-                  header_text "Running ${transforms[$index]} workflow test"
+                  while :
+                  do
+                    dir=("code"  "universal" "language") && index=$(($RANDOM % ${#dir[@]})) && subdirs=${dir[$index]} && transforms=($(find transforms/$subdirs -type d  -maxdepth 1 -mindepth 1 ))
+                    # First element is not really a subdir but rather the current dir so remove it and randomly choose a transform to run
+                    set -- "${transforms[@]}" && shift && transforms=("$@") && size=${#transforms[@]} && index=$(($RANDOM % $size))
+                    if [ -d ${transforms[$index]}/kfp_ray ]; then
+                      header_text "Running ${transforms[$index]} workflow test"
+                      break
+                    fi
+                  done 
                   make -C ${transforms[$index]} workflow-test
                   header_text "Run ${transforms[$index]} completed"
     test-data-processing-lib-images:


### PR DESCRIPTION
## Why are these changes needed?

Prevent cicd tests of transforms that do not support KFP automation.

## Related issue number (if any).

https://github.com/IBM/data-prep-kit/issues/514
