### PR TITLE
Don't use pip cache in Dockerfile and fix exception reporting msg

### DIFF
--- a/data-processing-lib/python/src/data_processing/runtime/transform_file_processor.py
+++ b/data-processing-lib/python/src/data_processing/runtime/transform_file_processor.py
@@ -85,7 +85,7 @@ class AbstractTransformFileProcessor:
             raise UnrecoverableException
         # Process other exceptions
         except Exception as e:
-            self.logger.warning(f"Exception {e} processing file {f_name}: {traceback.format_exc()}")
+            self.logger.warning(f"Exception processing file {f_name}: {traceback.format_exc()}")
             self._publish_stats({"transform execution exception": 1})
 
     def flush(self) -> None:

--- a/transforms/code/header_cleanser/python/Dockerfile
+++ b/transforms/code/header_cleanser/python/Dockerfile
@@ -1,6 +1,6 @@
 FROM docker.io/python:3.11.9-slim-bullseye
 
-RUN pip install --upgrade pip 
+RUN pip install --upgrade --no-cache-dir pip 
 
 # install pytest
 RUN pip install --no-cache-dir pytest

--- a/transforms/language/doc_chunk/python/Dockerfile
+++ b/transforms/language/doc_chunk/python/Dockerfile
@@ -1,6 +1,6 @@
 FROM docker.io/python:3.10.14-slim-bullseye
 
-RUN pip install --upgrade pip 
+RUN pip install --upgrade --no-cache-dir pip 
 
 # install pytest
 RUN pip install --no-cache-dir pytest

--- a/transforms/language/pii_redactor/python/Dockerfile
+++ b/transforms/language/pii_redactor/python/Dockerfile
@@ -1,6 +1,6 @@
 FROM docker.io/python:3.10.14-slim-bullseye
 
-RUN pip install --upgrade pip 
+RUN pip install --upgrade --no-cache-dir pip 
 
 # install pytest
 RUN pip install --no-cache-dir pytest

--- a/transforms/language/text_encoder/python/Dockerfile
+++ b/transforms/language/text_encoder/python/Dockerfile
@@ -1,6 +1,6 @@
 FROM docker.io/python:3.10.14-slim-bullseye
 
-RUN pip install --upgrade pip 
+RUN pip install --upgrade --no-cache-dir pip 
 
 # install pytest
 RUN pip install --no-cache-dir pytest

--- a/transforms/universal/html2parquet/python/Dockerfile
+++ b/transforms/universal/html2parquet/python/Dockerfile
@@ -1,6 +1,6 @@
 FROM docker.io/python:3.10.14-slim-bullseye
 
-RUN pip install --upgrade pip 
+RUN pip install --upgrade --no-cache-dir pip 
 
 # install pytest
 RUN pip install --no-cache-dir pytest


### PR DESCRIPTION
## Why are these changes needed?
This should make python images smaller, but more importantly MAY fix `PACKAGES DO NOT MATCH THE HASHES` errors we're seeing in some image builds during ci/cd.

## Related issue number (if any).


