### PR TITLE
Use cpu-only version of torch on linux builds

### DIFF
--- a/.make.defaults
+++ b/.make.defaults
@@ -39,9 +39,9 @@ DOCKER_FILE?=Dockerfile
 DOCKER?=docker
 DOCKER_PLATFORM?=linux/amd64
 # Can be used by transforms or others to add args to the "docker build" command in .defaults.image target
-DOCKER_BUILD_EXTRA_ARGS=
+DOCKER_BUILD_EXTRA_ARGS?=
 # Can be used by transforms or others to add args to the "pip install" commands referencing toml or requirements.txt files
-PIP_INSTALL_EXTRA_ARGS=
+PIP_INSTALL_EXTRA_ARGS?=
 DOCKER_HOSTNAME?=quay.io
 DOCKER_NAMESPACE ?= dataprep1/data-prep-kit
 DOCKER_REGISTRY_USER?=$(DPK_DOCKER_REGISTRY_USER)

--- a/transforms/language/doc_chunk/python/Dockerfile
+++ b/transforms/language/doc_chunk/python/Dockerfile
@@ -10,6 +10,8 @@ RUN useradd -ms /bin/bash dpk
 USER dpk
 WORKDIR /home/dpk
 
+ARG PIP_INSTALL_EXTRA_ARGS
+
 # Copy and install data processing libraries 
 # These are expected to be placed in the docker context before this is run (see the make image).
 COPY --chown=dpk:root data-processing-lib-python/ data-processing-lib-python/

--- a/transforms/language/doc_chunk/python/Dockerfile
+++ b/transforms/language/doc_chunk/python/Dockerfile
@@ -19,7 +19,7 @@ RUN cd data-processing-lib-python && pip install --no-cache-dir -e .
 
 COPY --chown=dpk:root src/ src/
 COPY --chown=dpk:root pyproject.toml pyproject.toml 
-RUN pip install --no-cache-dir -e .
+RUN pip install ${PIP_INSTALL_EXTRA_ARGS} --no-cache-dir -e .
 
 # copy transform main() entry point to the image 
 COPY ./src/doc_chunk_transform_python.py .

--- a/transforms/language/doc_chunk/python/Makefile
+++ b/transforms/language/doc_chunk/python/Makefile
@@ -6,6 +6,7 @@ REPOROOT=../../../..
 # to override/redefine the rules below. 
 
 # $(REPOROOT)/.make.versions file contains the versions
+include $(REPOROOT)/transforms/.make.transforms
 
 TRANSFORM_NAME=doc_chunk
 
@@ -18,7 +19,6 @@ ifeq ($(OS),Linux)
 	endif
 endif
 
-include $(REPOROOT)/transforms/.make.transforms
 
 venv::	.transforms.python-venv
 

--- a/transforms/language/doc_chunk/python/Makefile
+++ b/transforms/language/doc_chunk/python/Makefile
@@ -9,6 +9,15 @@ REPOROOT=../../../..
 
 TRANSFORM_NAME=doc_chunk
 
+LINUX_WITH_CPU_TORCH?=true
+OS := $(shell uname -s)
+ifeq ($(OS),Linux)
+	ifeq ($(LINUX_WITH_CPU_TORCH),true)
+	PIP_INSTALL_EXTRA_ARGS=--extra-index-url=https://download.pytorch.org/whl/cpu
+	DOCKER_BUILD_EXTRA_ARGS=--build-arg PIP_INSTALL_EXTRA_ARGS=${PIP_INSTALL_EXTRA_ARGS}
+	endif
+endif
+
 include $(REPOROOT)/transforms/.make.transforms
 
 venv::	.transforms.python-venv

--- a/transforms/language/doc_chunk/python/pyproject.toml
+++ b/transforms/language/doc_chunk/python/pyproject.toml
@@ -12,7 +12,13 @@ authors = [
 ]
 dependencies = [
     "data-prep-toolkit==0.2.1.dev0",
-    "quackling==0.1.0",
+    # replicating here the quackling deps
+    # for some reason this is needed, otherwise one gets into
+    # conflicts with ray
+    "docling>=1.8.2,<2.0.0",
+    "llama-index-core>=0.11.1,<0.12.0",
+    "docling-core>=1.1.2,<2.0.0",
+    "quackling==0.1.1",
 ]
 
 [build-system]

--- a/transforms/language/doc_chunk/ray/Dockerfile
+++ b/transforms/language/doc_chunk/ray/Dockerfile
@@ -11,14 +11,14 @@ RUN cd data-processing-lib-python && pip install --no-cache-dir -e .
 COPY --chown=ray:users data-processing-lib-ray/ data-processing-lib-ray/ 
 RUN cd data-processing-lib-ray    && pip install --no-cache-dir -e .
 COPY --chown=ray:users python-transform/  python-transform/
-RUN cd python-transform && pip install --no-cache-dir -e .
+RUN cd python-transform && pip install ${PIP_INSTALL_EXTRA_ARGS} --no-cache-dir -e .
 
 #COPY requirements.txt requirements.txt
 #RUN pip install --no-cache-dir -r  requirements.txt
 
 COPY --chown=ray:users src/ src/
 COPY --chown=ray:users pyproject.toml pyproject.toml 
-RUN pip install --no-cache-dir -e .
+RUN pip install ${PIP_INSTALL_EXTRA_ARGS} --no-cache-dir -e .
 
 # copy the main() entry point to the image 
 COPY ./src/doc_chunk_transform_ray.py .

--- a/transforms/language/doc_chunk/ray/Dockerfile
+++ b/transforms/language/doc_chunk/ray/Dockerfile
@@ -4,6 +4,8 @@ FROM ${BASE_IMAGE}
 # install pytest
 RUN pip install --no-cache-dir pytest
 
+ARG PIP_INSTALL_EXTRA_ARGS
+
 # Copy and install data processing libraries 
 # These are expected to be placed in the docker context before this is run (see the make image).
 COPY --chown=ray:users data-processing-lib-python/ data-processing-lib-python/

--- a/transforms/language/doc_chunk/ray/Makefile
+++ b/transforms/language/doc_chunk/ray/Makefile
@@ -9,6 +9,15 @@ include $(REPOROOT)/transforms/.make.transforms
 
 TRANSFORM_NAME=doc_chunk
 
+LINUX_WITH_CPU_TORCH?=true
+OS := $(shell uname -s)
+ifeq ($(OS),Linux)
+	ifeq ($(LINUX_WITH_CPU_TORCH),true)
+	PIP_INSTALL_EXTRA_ARGS=--extra-index-url=https://download.pytorch.org/whl/cpu
+	DOCKER_BUILD_EXTRA_ARGS=--build-arg PIP_INSTALL_EXTRA_ARGS=${PIP_INSTALL_EXTRA_ARGS}
+	endif
+endif
+
 BASE_IMAGE=${RAY_BASE_IMAGE}
 venv::	.transforms.ray-venv
 

--- a/transforms/language/pdf2parquet/python/Dockerfile
+++ b/transforms/language/pdf2parquet/python/Dockerfile
@@ -16,6 +16,8 @@ RUN useradd -ms /bin/bash dpk
 USER dpk
 WORKDIR /home/dpk
 
+ARG PIP_INSTALL_EXTRA_ARGS
+
 # Copy and install data processing libraries 
 # These are expected to be placed in the docker context before this is run (see the make image).
 COPY --chown=dpk:root data-processing-lib-python/ data-processing-lib-python/

--- a/transforms/language/pdf2parquet/python/Dockerfile
+++ b/transforms/language/pdf2parquet/python/Dockerfile
@@ -24,7 +24,7 @@ RUN cd data-processing-lib-python && pip install --no-cache-dir -e .
 # END OF STEPS destined for a data-prep-kit base image 
 
 COPY --chown=dpk:root pyproject.toml pyproject.toml 
-RUN pip install --no-cache-dir -e .
+RUN pip install ${PIP_INSTALL_EXTRA_ARGS} --no-cache-dir -e .
 
 # Download models
 RUN python -c 'from deepsearch_glm.utils.load_pretrained_models import load_pretrained_nlp_models; load_pretrained_nlp_models(verbose=True);'

--- a/transforms/language/pdf2parquet/python/Makefile
+++ b/transforms/language/pdf2parquet/python/Makefile
@@ -6,6 +6,7 @@ REPOROOT=../../../..
 # to override/redefine the rules below. 
 
 # $(REPOROOT)/.make.versions file contains the versions
+include $(REPOROOT)/transforms/.make.transforms
 
 TRANSFORM_NAME=pdf2parquet
 
@@ -21,7 +22,6 @@ ifeq ($(OS),Linux)
 	endif
 endif
 
-include $(REPOROOT)/transforms/.make.transforms
 
 venv::	.transforms.python-venv
 

--- a/transforms/language/pdf2parquet/python/Makefile
+++ b/transforms/language/pdf2parquet/python/Makefile
@@ -12,6 +12,14 @@ TRANSFORM_NAME=pdf2parquet
 RUN_ARGS=" --data_local_config \"{ 'input_folder' : '../test-data/input', 'output_folder' : '../output'}\"  \
 	--data_files_to_use \"['.pdf','.zip']\" "
 
+LINUX_WITH_CPU_TORCH?=true
+OS := $(shell uname -s)
+ifeq ($(OS),Linux)
+	ifeq ($(LINUX_WITH_CPU_TORCH),true)
+	PIP_INSTALL_EXTRA_ARGS=--extra-index-url=https://download.pytorch.org/whl/cpu
+	DOCKER_BUILD_EXTRA_ARGS=--build-arg PIP_INSTALL_EXTRA_ARGS=${PIP_INSTALL_EXTRA_ARGS}
+	endif
+endif
 
 include $(REPOROOT)/transforms/.make.transforms
 

--- a/transforms/language/pdf2parquet/ray/Dockerfile
+++ b/transforms/language/pdf2parquet/ray/Dockerfile
@@ -21,11 +21,11 @@ RUN cd data-processing-lib-python && pip install --no-cache-dir -e .
 COPY --chown=ray:users data-processing-lib-ray/ data-processing-lib-ray/ 
 RUN cd data-processing-lib-ray    && pip install --no-cache-dir -e .
 COPY --chown=ray:users python-transform/  python-transform/
-RUN cd python-transform && pip install --no-cache-dir -e .
+RUN cd python-transform && pip install ${PIP_INSTALL_EXTRA_ARGS} --no-cache-dir -e .
 
 
 COPY --chown=ray:users pyproject.toml pyproject.toml 
-RUN pip install --no-cache-dir -e .
+RUN pip install ${PIP_INSTALL_EXTRA_ARGS} --no-cache-dir -e .
 
 # Download models
 RUN python -c 'from deepsearch_glm.utils.load_pretrained_models import load_pretrained_nlp_models; load_pretrained_nlp_models(verbose=True);'

--- a/transforms/language/pdf2parquet/ray/Dockerfile
+++ b/transforms/language/pdf2parquet/ray/Dockerfile
@@ -7,6 +7,8 @@ RUN pip install --upgrade --no-cache-dir pip
 # install pytest
 RUN pip install --no-cache-dir pytest
 
+ARG PIP_INSTALL_EXTRA_ARGS
+
 RUN \
     sudo apt-get update \
     # for opencv, towhee

--- a/transforms/language/pdf2parquet/ray/Makefile
+++ b/transforms/language/pdf2parquet/ray/Makefile
@@ -9,6 +9,15 @@ include $(REPOROOT)/transforms/.make.transforms
 
 TRANSFORM_NAME=pdf2parquet
 
+LINUX_WITH_CPU_TORCH?=true
+OS := $(shell uname -s)
+ifeq ($(OS),Linux)
+	ifeq ($(LINUX_WITH_CPU_TORCH),true)
+	PIP_INSTALL_EXTRA_ARGS=--extra-index-url=https://download.pytorch.org/whl/cpu
+	DOCKER_BUILD_EXTRA_ARGS=--build-arg PIP_INSTALL_EXTRA_ARGS=${PIP_INSTALL_EXTRA_ARGS}
+	endif
+endif
+
 BASE_IMAGE=${RAY_BASE_IMAGE}
 venv::	.transforms.ray-venv
 

--- a/transforms/language/text_encoder/python/Dockerfile
+++ b/transforms/language/text_encoder/python/Dockerfile
@@ -10,6 +10,8 @@ RUN useradd -ms /bin/bash dpk
 USER dpk
 WORKDIR /home/dpk
 
+ARG PIP_INSTALL_EXTRA_ARGS
+
 # Copy and install data processing libraries 
 # These are expected to be placed in the docker context before this is run (see the make image).
 COPY --chown=dpk:root data-processing-lib-python/ data-processing-lib-python/

--- a/transforms/language/text_encoder/python/Dockerfile
+++ b/transforms/language/text_encoder/python/Dockerfile
@@ -18,7 +18,7 @@ RUN cd data-processing-lib-python && pip install --no-cache-dir -e .
 # END OF STEPS destined for a data-prep-kit base image 
 
 COPY --chown=dpk:root pyproject.toml pyproject.toml 
-RUN pip install --no-cache-dir -e .
+RUN pip install ${PIP_INSTALL_EXTRA_ARGS} --no-cache-dir -e .
 
 # copy transform main() entry point to the image 
 COPY ./src/text_encoder_transform_python.py .

--- a/transforms/language/text_encoder/python/Makefile
+++ b/transforms/language/text_encoder/python/Makefile
@@ -6,6 +6,7 @@ REPOROOT=../../../..
 # to override/redefine the rules below. 
 
 # $(REPOROOT)/.make.versions file contains the versions
+include $(REPOROOT)/transforms/.make.transforms
 
 TRANSFORM_NAME=text_encoder
 
@@ -18,7 +19,6 @@ ifeq ($(OS),Linux)
 	endif
 endif
 
-include $(REPOROOT)/transforms/.make.transforms
 
 venv::	.transforms.python-venv
 

--- a/transforms/language/text_encoder/python/Makefile
+++ b/transforms/language/text_encoder/python/Makefile
@@ -9,6 +9,15 @@ REPOROOT=../../../..
 
 TRANSFORM_NAME=text_encoder
 
+LINUX_WITH_CPU_TORCH?=true
+OS := $(shell uname -s)
+ifeq ($(OS),Linux)
+	ifeq ($(LINUX_WITH_CPU_TORCH),true)
+	PIP_INSTALL_EXTRA_ARGS=--extra-index-url=https://download.pytorch.org/whl/cpu
+	DOCKER_BUILD_EXTRA_ARGS=--build-arg PIP_INSTALL_EXTRA_ARGS=${PIP_INSTALL_EXTRA_ARGS}
+	endif
+endif
+
 include $(REPOROOT)/transforms/.make.transforms
 
 venv::	.transforms.python-venv

--- a/transforms/language/text_encoder/ray/Dockerfile
+++ b/transforms/language/text_encoder/ray/Dockerfile
@@ -4,6 +4,8 @@ FROM ${BASE_IMAGE}
 # install pytest
 RUN pip install --no-cache-dir pytest
 
+ARG PIP_INSTALL_EXTRA_ARGS
+
 # Copy and install data processing libraries 
 # These are expected to be placed in the docker context before this is run (see the make image).
 COPY --chown=ray:users data-processing-lib-python/ data-processing-lib-python/

--- a/transforms/language/text_encoder/ray/Dockerfile
+++ b/transforms/language/text_encoder/ray/Dockerfile
@@ -11,14 +11,14 @@ RUN cd data-processing-lib-python && pip install --no-cache-dir -e .
 COPY --chown=ray:users data-processing-lib-ray/ data-processing-lib-ray/ 
 RUN cd data-processing-lib-ray    && pip install --no-cache-dir -e .
 COPY --chown=ray:users python-transform/  python-transform/
-RUN cd python-transform && pip install --no-cache-dir -e .
+RUN cd python-transform && pip install ${PIP_INSTALL_EXTRA_ARGS} --no-cache-dir -e .
 
 #COPY requirements.txt requirements.txt
 #RUN pip install --no-cache-dir -r  requirements.txt
 
 COPY --chown=ray:users src/ src/
 COPY --chown=ray:users pyproject.toml pyproject.toml 
-RUN pip install --no-cache-dir -e .
+RUN pip install ${PIP_INSTALL_EXTRA_ARGS} --no-cache-dir -e .
 
 # copy the main() entry point to the image 
 COPY ./src/text_encoder_transform_ray.py .

--- a/transforms/language/text_encoder/ray/Makefile
+++ b/transforms/language/text_encoder/ray/Makefile
@@ -9,6 +9,15 @@ include $(REPOROOT)/transforms/.make.transforms
 
 TRANSFORM_NAME=text_encoder
 
+LINUX_WITH_CPU_TORCH?=true
+OS := $(shell uname -s)
+ifeq ($(OS),Linux)
+	ifeq ($(LINUX_WITH_CPU_TORCH),true)
+	PIP_INSTALL_EXTRA_ARGS=--extra-index-url=https://download.pytorch.org/whl/cpu
+	DOCKER_BUILD_EXTRA_ARGS=--build-arg PIP_INSTALL_EXTRA_ARGS=${PIP_INSTALL_EXTRA_ARGS}
+	endif
+endif
+
 BASE_IMAGE=${RAY_BASE_IMAGE}
 venv::	.transforms.ray-venv
 

--- a/transforms/universal/noop/python/Makefile
+++ b/transforms/universal/noop/python/Makefile
@@ -6,10 +6,10 @@ REPOROOT=../../../..
 # to override/redefine the rules below. 
 
 # $(REPOROOT)/.make.versions file contains the versions
+include $(REPOROOT)/transforms/.make.transforms
 
 TRANSFORM_NAME=noop
 
-include $(REPOROOT)/transforms/.make.transforms
 
 venv::	.transforms.python-venv
 


### PR DESCRIPTION
## Why are these changes needed?

These transforms depend on the [PyTorch](https://pytorch.org/) library. Depending on your architecture, you might want to use a different distribution of torch. For example, you might want support for different accelerator or for a cpu-only version. All the different ways for installing torch are listed on their website https://pytorch.org/.

With this PR we switch to the simpler cpu-only version of `torch` for the docker images and the CI. Users can still get the full torch package from pypi, simply setting `LINUX_WITH_CPU_TORCH=false`.
