### PR TITLE
The allowed-code-languages.txt is not good formatted, so consequence unexpected result

### DIFF
--- a/examples/notebooks/code/sample-notebook.ipynb
+++ b/examples/notebooks/code/sample-notebook.ipynb
@@ -496,7 +496,7 @@
     "# !wget https://raw.githubusercontent.com/IBM/data-prep-kit/dev/transforms/code/proglang_select/python/test-data/languages/allowed-code-languages.txt\n",
     "\n",
     "# Create a file with language of interest\n",
-    "! echo \"JavaScript\\nC++\\nC\\nGo\\nJava\" >> allowed-code-languages.txt\n",
+    "! echo -e \"JavaScript\\nC++\\nC\\nGO\\nJava\" >> allowed-code-languages.txt\n",
     "\n",
     "selected_languages_file = \"./allowed-code-languages.txt\"\n",
     "\n",


### PR DESCRIPTION
## Why are these changes needed?
In sample notebook, the `Programming Language Selection` phase not work as expect

## Related issue number (if any).
1. allowed-code-languages.txt not good formatted, missing the `\n`
2. the content of `language` column is uppercase, for example: `GO` not `Go`
  

