### PR TITLE
disable publish-image rule for pii_redactor to allow merge to pass

### DIFF
--- a/transforms/language/pii_redactor/ray/Makefile
+++ b/transforms/language/pii_redactor/ray/Makefile
@@ -30,7 +30,9 @@ build:: build-dist image
 
 publish: publish-image
 
-publish-image:: .transforms.publish-image-ray
+#publish-image:: .transforms.publish-image-ray
+publish-image:: 
+	@echo "Skip... do nothing! pushing CI/CD over a cliff with OSError on text_encoder "
 
 setup:: .transforms.setup
 


### PR DESCRIPTION
## Why are these changes needed?
To allow PR _merges_ (not PR builds) to succeed.

Fixes pii_redactor/ray/Makefile to not try and publish the image that was not build by test-image target.

## Related issue number (if any).
Issue #569 
