### PR TITLE
Custom column validator for pdf2parquet

### DIFF
--- a/data-processing-lib/python/src/data_processing/test_support/launch/transform_test.py
+++ b/data-processing-lib/python/src/data_processing/test_support/launch/transform_test.py
@@ -65,7 +65,7 @@ class AbstractTransformLauncherTest(AbstractTest):
         Confirm that the two directories contains the same files.
         Stubbed out like this to allow spark tests to override this since spark tends to rename the files.
         """
-        AbstractTest.validate_directory_contents(dir, expected, ignore_columns)
+        self.validate_directory_contents(dir, expected, ignore_columns)
 
     def _install_test_fixtures(self, metafunc):
         # Apply the fixtures for the method with these input names (i.e. test_transform()).

--- a/transforms/language/pdf2parquet/python/test/test_pdf2parquet_python.py
+++ b/transforms/language/pdf2parquet/python/test/test_pdf2parquet_python.py
@@ -13,11 +13,16 @@
 import ast
 import os
 
+import pyarrow as pa
 from data_processing.runtime.pure_python import PythonTransformLauncher
+from data_processing.test_support.abstract_test import _allowed_float_percent_diff
 from data_processing.test_support.launch.transform_test import (
     AbstractTransformLauncherTest,
 )
+from docling_core.types import Document
+from docling_core.types.doc.base import BaseText
 from pdf2parquet_transform_python import Pdf2ParquetPythonTransformConfiguration
+from pydantic import ValidationError
 
 
 class TestPythonPdf2ParquetTransform(AbstractTransformLauncherTest):
@@ -35,7 +40,7 @@ class TestPythonPdf2ParquetTransform(AbstractTransformLauncherTest):
         }
 
         # this is added as a fixture to remove these columns from comparison
-        ignore_columns = ["date_acquired", "document_id", "pdf_convert_time"]
+        ignore_columns = ["date_acquired", "document_id", "pdf_convert_time", "hash"]
 
         fixtures = []
         launcher = PythonTransformLauncher(Pdf2ParquetPythonTransformConfiguration())
@@ -84,3 +89,100 @@ class TestPythonPdf2ParquetTransform(AbstractTransformLauncherTest):
         )
 
         return fixtures
+
+    @classmethod
+    def validate_expected_row(
+        cls,
+        table_index: int,
+        row_index: int,
+        test_row: pa.Table,
+        expected_row: pa.Table,
+    ):
+        """
+        Compare the two rows for equality, allowing float values to be within a percentage
+        of each other as defined by global _allowed_float_percent_diff.
+        We assume the schema has already been compared and is equivalent.
+        Args:
+            table_index: index of tables that is the source of the rows.
+            row_index:
+            test_row:
+            expected_row:
+        """
+
+        assert test_row.num_rows == 1, "Invalid usage.  Expected test table with 1 row"
+        assert (
+            expected_row.num_rows == 1
+        ), "Invalid usage.  Expected expected table with 1 row"
+        if test_row != expected_row:
+            # Else look for floating point values that might differ within the allowance
+            msg = f"Row {row_index} of table {table_index} are not equal\n\tTransformed: {test_row}\n\tExpected   : {expected_row}"
+            assert test_row.num_columns == expected_row.num_columns, msg
+            num_columns = test_row.num_columns
+            for i in range(num_columns):
+                # Over each cell/column in the row
+                test_column = test_row.column(i)
+                expected_column = expected_row.column(i)
+                if test_column != expected_column:
+                    # Check if the value is a float and if so, allow a fuzzy match
+                    test_value = test_column.to_pylist()[0]
+                    expected_value = expected_column.to_pylist()[0]
+
+                    # Test for Document type
+                    try:
+
+                        expected_doc = Document.model_validate_json(expected_value)
+                        test_doc = Document.model_validate_json(test_value)
+                        cls.validate_documents(
+                            row_index=row_index,
+                            table_index=table_index,
+                            test_doc=test_doc,
+                            expected_doc=expected_doc,
+                        )
+
+                        continue
+
+                    except ValidationError:
+                        pass
+
+                    # Test for floats
+                    is_float = isinstance(test_value, float) and isinstance(
+                        expected_value, float
+                    )
+                    if is_float:
+                        # It IS a float, so allow a fuzzy match
+                        allowed_diff = abs(_allowed_float_percent_diff * expected_value)
+                        diff = abs(test_value - expected_value)
+                        assert diff <= allowed_diff, msg
+
+                        continue
+
+                    # Its NOT a float or other managed types, so do a normal compare
+                    assert test_column == expected_column, msg
+
+    @classmethod
+    def validate_documents(
+        cls,
+        row_index: int,
+        table_index: int,
+        test_doc: Document,
+        expected_doc: Document,
+    ):
+        msg = f"Row {row_index} of table {table_index} are not equal\n\t"
+        assert len(test_doc.main_text) == len(expected_doc.main_text), (
+            msg + f"Main Text lengths do not match."
+        )
+
+        for i in range(len(expected_doc.main_text)):
+            expected_item = expected_doc.main_text[i]
+            test_item = test_doc.main_text[i]
+
+            # Validate type
+            assert expected_item.obj_type == test_item.obj_type, (
+                msg + f"Object type does not match."
+            )
+
+            # Validate text content
+            if isinstance(expected_item, BaseText):
+                assert expected_item.text == test_item.text, (
+                    msg + f"Text does not match."
+                )


### PR DESCRIPTION
## Why are these changes needed?

With this PR we should resolve the instability of the `pdf2parquet` tests. Lately failing on tiny differences in the bbox predictions (452 vs 451).

To enable a custom validator for the pdf2parquet transform, we turn the `@staticmethod` to `@classmethod`, which allows for easier overloading.

Possible extension (in the future): allow transforms test to define custom validator for specific columns.

## Related issue number (if any).


