### PR TITLE
disable test workflow when no code files change

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,6 @@ on:
             - "**.md"
             - "examples/**"
             - "**/doc/**"
-            - "data-processing-lib/doc/**"
             - "**/.gitignore"
             - "**/.dockerignore"
     pull_request:
@@ -23,7 +22,6 @@ on:
             - "**.md"
             - "examples/**"
             - "**/doc/**"
-            - "data-processing-lib/doc/**"
             - "**/.gitignore"
             - "**/.dockerignore"
 env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,7 +22,7 @@ on:
         paths-ignore:
             - "**.md"
             - "examples/**"
-            - "doc/**"
+            - "**/doc/**"
             - "data-processing-lib/doc/**"
             - "**/.gitignore"
             - "**/.dockerignore"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,12 +8,26 @@ on:
             - "releases/**"
         tags:
             - "*"
+        paths-ignore:
+            - "**.md"
+            - "examples/**"
+            - "**/doc/**"
+            - "data-processing-lib/doc/**"
+            - "**/.gitignore"
+            - "**/.dockerignore"
     pull_request:
         branches:
             - "dev"
             - "releases/**"
+        paths-ignore:
+            - "**.md"
+            - "examples/**"
+            - "doc/**"
+            - "data-processing-lib/doc/**"
+            - "**/.gitignore"
+            - "**/.dockerignore"
 env:
-  KFP_BLACK_LIST: "doc_chunk-ray,pdf2parquet-ray,pii_redactor"
+    KFP_BLACK_LIST: "doc_chunk-ray,pdf2parquet-ray,pii_redactor"
 
 jobs:
     check_if_push_images:


### PR DESCRIPTION
## Why are these changes needed?
We would like to speed up the ci/cd process where possible.  
This disables retesting when non-code (e.g., *.md, examples/*, etc) change.

## Related issue number (if any).
Issue 515 https://github.com/IBM/data-prep-kit/issues/515

