### PR TITLE
fix: pin all docling deps for more stability

### DIFF
--- a/transforms/language/pdf2parquet/python/pyproject.toml
+++ b/transforms/language/pdf2parquet/python/pyproject.toml
@@ -12,6 +12,8 @@ authors = [
 dependencies = [
     "data-prep-toolkit==0.2.1.dev0",
     "docling-core==1.2.0",
+    "docling-ibm-models==1.1.7",
+    "deepsearch-glm==0.21.0",
     "docling==1.11.0",
     "filetype >=1.2.0, <2.0.0",
 ]


### PR DESCRIPTION
## Why are these changes needed?

By pinning more internal docling deps we can guarantee a better stability in the Markdown/Json output.
Without this, sometime the output could vary a bit, since new upstream models are fixing processing bugs.
