### PR TITLE
set spark base image tag to that from .make.versions

### DIFF
--- a/data-processing-lib/spark/Makefile
+++ b/data-processing-lib/spark/Makefile
@@ -4,7 +4,6 @@ include $(REPOROOT)/.make.defaults
 SPARK_VERSION=3.5.2
 DOCKER_IMAGE_NAME=data-prep-kit-spark-$(SPARK_VERSION)
 DOCKER_IMAGE_LIB_NAME=data-prep-kit-spark
-DOCKER_IMAGE_VERSION := latest
 
 
 .check-env::

--- a/transforms/universal/doc_id/spark/Dockerfile
+++ b/transforms/universal/doc_id/spark/Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE=data-prep-kit-spark-3.5.2:latest
+ARG BASE_IMAGE=quay.io/dataprep1/data-prep-kit/data-prep-kit-spark-3.5.2:latest
 FROM ${BASE_IMAGE}
 
 USER root

--- a/transforms/universal/doc_id/spark/Dockerfile
+++ b/transforms/universal/doc_id/spark/Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE=quay.io/dataprep1/data-prep-kit/data-prep-kit-spark-3.5.2:0.2.1.dev0
+ARG BASE_IMAGE=data-prep-kit-spark-3.5.2:latest
 FROM ${BASE_IMAGE}
 
 USER root

--- a/transforms/universal/filter/spark/Dockerfile
+++ b/transforms/universal/filter/spark/Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE=data-prep-kit-spark-3.5.2:latest
+ARG BASE_IMAGE=quay.io/dataprep1/data-prep-kit/data-prep-kit-spark-3.5.2:latest
 FROM ${BASE_IMAGE}
 
 USER root

--- a/transforms/universal/filter/spark/Dockerfile
+++ b/transforms/universal/filter/spark/Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE=quay.io/dataprep1/data-prep-kit/data-prep-kit-spark-3.5.2:0.2.1.dev0
+ARG BASE_IMAGE=data-prep-kit-spark-3.5.2:latest
 FROM ${BASE_IMAGE}
 
 USER root

--- a/transforms/universal/noop/spark/Dockerfile
+++ b/transforms/universal/noop/spark/Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE=data-prep-kit-spark-3.5.2:latest
+ARG BASE_IMAGE=quay.io/dataprep1/data-prep-kit/data-prep-kit-spark-3.5.2:latest
 FROM ${BASE_IMAGE}
 
 USER root

--- a/transforms/universal/noop/spark/Dockerfile
+++ b/transforms/universal/noop/spark/Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE=quay.io/dataprep1/data-prep-kit/data-prep-kit-spark-3.5.2:0.2.1.dev0
+ARG BASE_IMAGE=data-prep-kit-spark-3.5.2:latest
 FROM ${BASE_IMAGE}
 
 USER root


### PR DESCRIPTION
## Why are these changes needed?
Releasing has problems since the tag for the base spark image was fixed to be `latest`.  
It now is set from .make.versions, like other images.

## Related issue number (if any).
#625 

