### PR TITLE
align docling versions among transforms

### DIFF
--- a/transforms/language/pdf2parquet/python/Dockerfile
+++ b/transforms/language/pdf2parquet/python/Dockerfile
@@ -26,6 +26,7 @@ RUN cd data-processing-lib-python && pip install --no-cache-dir -e .
 # END OF STEPS destined for a data-prep-kit base image 
 
 COPY --chown=dpk:root pyproject.toml pyproject.toml 
+COPY --chown=dpk:root requirements.txt requirements.txt
 RUN pip install ${PIP_INSTALL_EXTRA_ARGS} --no-cache-dir -e .
 
 # Download models

--- a/transforms/language/pdf2parquet/python/pyproject.toml
+++ b/transforms/language/pdf2parquet/python/pyproject.toml
@@ -11,7 +11,7 @@ authors = [
 ]
 dependencies = [
     "data-prep-toolkit==0.2.2.dev0",
-    "docling-core==1.2.0",
+    "docling-core==1.3.0",
     "docling-ibm-models==1.1.7",
     "deepsearch-glm==0.21.0",
     "docling==1.11.0",

--- a/transforms/language/pdf2parquet/python/pyproject.toml
+++ b/transforms/language/pdf2parquet/python/pyproject.toml
@@ -9,18 +9,14 @@ authors = [
     { name = "Michele Dolfi", email = "dol@zurich.ibm.com" },
     { name = "Christoph Auer", email = "cau@zurich.ibm.com" },
 ]
-dependencies = [
-    "data-prep-toolkit==0.2.2.dev0",
-    "docling-core==1.3.0",
-    "docling-ibm-models==1.1.7",
-    "deepsearch-glm==0.21.0",
-    "docling==1.11.0",
-    "filetype >=1.2.0, <2.0.0",
-]
+dynamic = ["dependencies"]
 
 [build-system]
 requires = ["setuptools>=68.0.0", "wheel", "setuptools_scm[toml]>=7.1.0"]
 build-backend = "setuptools.build_meta"
+
+[tool.setuptools.dynamic]
+dependencies = {file = ["requirements.txt"]}
 
 [project.optional-dependencies]
 dev = [

--- a/transforms/language/pdf2parquet/python/requirements.txt
+++ b/transforms/language/pdf2parquet/python/requirements.txt
@@ -1,0 +1,6 @@
+data-prep-toolkit==0.2.2.dev0
+docling-core==1.3.0
+docling-ibm-models==1.1.7
+deepsearch-glm==0.21.0
+docling==1.11.0
+filetype >=1.2.0, <2.0.0

--- a/transforms/language/pdf2parquet/ray/Dockerfile
+++ b/transforms/language/pdf2parquet/ray/Dockerfile
@@ -27,6 +27,7 @@ RUN cd python-transform && pip install ${PIP_INSTALL_EXTRA_ARGS} --no-cache-dir 
 
 
 COPY --chown=ray:users pyproject.toml pyproject.toml 
+COPY --chown=ray:users requirements.txt requirements.txt
 RUN pip install ${PIP_INSTALL_EXTRA_ARGS} --no-cache-dir -e .
 
 # Download models

--- a/transforms/language/pdf2parquet/ray/pyproject.toml
+++ b/transforms/language/pdf2parquet/ray/pyproject.toml
@@ -9,14 +9,15 @@ authors = [
     { name = "Michele Dolfi", email = "dol@zurich.ibm.com" },
     { name = "Christoph Auer", email = "cau@zurich.ibm.com" },
 ]
-dependencies = [
-    "dpk-pdf2parquet-transform-python==0.2.2.dev0",
-    "data-prep-toolkit-ray==0.2.2.dev0",
-]
+
+dynamic = ["dependencies"]
 
 [build-system]
 requires = ["setuptools>=68.0.0", "wheel", "setuptools_scm[toml]>=7.1.0"]
 build-backend = "setuptools.build_meta"
+
+[tool.setuptools.dynamic]
+dependencies = {file = ["requirements.txt"]}
 
 [project.optional-dependencies]
 dev = [

--- a/transforms/language/pdf2parquet/ray/requirements.txt
+++ b/transforms/language/pdf2parquet/ray/requirements.txt
@@ -1,2 +1,7 @@
 dpk-pdf2parquet-transform-python==0.2.2.dev0
 data-prep-toolkit-ray==0.2.2.dev0
+docling-core==1.3.0
+docling-ibm-models==1.1.7
+deepsearch-glm==0.21.0
+docling==1.11.0
+filetype >=1.2.0, <2.0.0

--- a/transforms/language/pdf2parquet/ray/requirements.txt
+++ b/transforms/language/pdf2parquet/ray/requirements.txt
@@ -1,0 +1,2 @@
+dpk-pdf2parquet-transform-python==0.2.2.dev0
+data-prep-toolkit-ray==0.2.2.dev0


### PR DESCRIPTION
## Why are these changes needed?

This transform aligns the docling-core version used in `pdf2parquet` and `doc_chunk`, which simplified the creation of the single package.


## Related issue number (if any).


