### PR TITLE
Add Tolerations and node selector to KFP pods

### DIFF
--- a/kfp/doc/simple_transform_pipeline.md
+++ b/kfp/doc/simple_transform_pipeline.md
@@ -18,6 +18,7 @@ Note: the project and the explanation below are based on [KFPv1](https://www.kub
   - [Input parameters definition](#inputs)
   - [Pipeline definition](#pipeline)
   - [Additional configuration](#add_config)
+  - [Tolerations and node selector](#tolerations)
 - [Compiling a pipeline](#compilation)
 - [Deploying a pipeline](#deploying)
 - [Executing pipeline and watching execution results](#execution)
@@ -208,6 +209,16 @@ The final thing that we need to do is set some pipeline global configuration:
 ```python
     # Configure the pipeline level to one week (in seconds)
     dsl.get_pipeline_conf().set_timeout(ONE_WEEK_SEC)
+```
+
+### KFP pods Toleration and node selector (Optional)<a name = "tolerations"></a> 
+To apply kuberenetes [Tolerations](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/) or [nodeSelector](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector) to KFP pods, you need to set `KFP_TOLERATIONS` or `KFP_NODE_SELECTOR` environment variables respectively before compiling the pipeline. Here's an example:
+
+```bash
+export KFP_TOLERATIONS='[{"key": "key","operator": "Equal", "value1": "value", "effect": "NoSchedule"}]'
+
+export KFP_NODE_SELECTOR='{"label_key":"cloud.google.com/gke-accelerator","label_value":"nvidia-tesla-p4"}'
+
 ```
 
 ## Compiling a pipeline <a name = "compilation"></a>

--- a/kfp/doc/simple_transform_pipeline.md
+++ b/kfp/doc/simple_transform_pipeline.md
@@ -220,6 +220,7 @@ export KFP_TOLERATIONS='[{"key": "key","operator": "Equal", "value1": "value", "
 export KFP_NODE_SELECTOR='{"label_key":"cloud.google.com/gke-accelerator","label_value":"nvidia-tesla-p4"}'
 
 ```
+In KFP v1, setting `KFP_TOLERATIONS` will apply to the Ray pods, overriding any tolerations specified in the `ray_head_options` and `ray_worker_options` pipeline parameters if they are present.
 
 ## Compiling a pipeline <a name = "compilation"></a>
 

--- a/kfp/kfp_ray_components/src/create_ray_cluster.py
+++ b/kfp/kfp_ray_components/src/create_ray_cluster.py
@@ -9,6 +9,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 ################################################################################
+import json
+import os
 import sys
 
 from runtime_utils import KFPUtils, RayRemoteJobs
@@ -42,6 +44,16 @@ def start_ray_cluster(
     head_node = head_options | {
         "ray_start_params": {"metrics-export-port": "8080", "num-cpus": "0", "dashboard-host": "0.0.0.0"}
     }
+    tolerations = os.getenv("KFP_TOLERATIONS", "")
+    if tolerations != "":
+        print(f"Adding tolerations {tolerations} for ray pods")
+        tolerations = json.loads(tolerations)
+        if "tolerations" in head_node:
+            print("Warning: head_node tolerations already defined, will overwrite it")
+        if "tolerations" in worker_node:
+            print("Warning: worker_node tolerations already defined, will overwrite it")
+        head_node["tolerations"] = tolerations
+        worker_node["tolerations"] = tolerations
     # create cluster
     remote_jobs = RayRemoteJobs(
         server_url=server_url,

--- a/kfp/kfp_support_lib/kfp_v1_workflow_support/src/workflow_support/compile_utils/component.py
+++ b/kfp/kfp_support_lib/kfp_v1_workflow_support/src/workflow_support/compile_utils/component.py
@@ -60,6 +60,7 @@ class ComponentUtils:
             try:
                 tolerations = os.getenv("KFP_TOLERATIONS", "")
                 if tolerations != "":
+                    print(f"Note: Applying Tolerations {tolerations} to kubeflow pipelines pods")
                     tolerations = json.loads(tolerations)
                     for toleration in tolerations:
                         component.add_toleration(
@@ -80,6 +81,7 @@ class ComponentUtils:
             try:
                 node_selector = os.getenv("KFP_NODE_SELECTOR", "")
                 if node_selector != "":
+                    print(f"Note: Applying node_selector {node_selector} to kubeflow pipelines pods")
                     node_selector = json.loads(node_selector)
                     component.add_node_selector_constraint(node_selector["label_key"], node_selector["label_value"])
             except Exception as e:

--- a/kfp/kfp_support_lib/kfp_v1_workflow_support/src/workflow_support/compile_utils/component.py
+++ b/kfp/kfp_support_lib/kfp_v1_workflow_support/src/workflow_support/compile_utils/component.py
@@ -10,11 +10,20 @@
 # limitations under the License.
 ################################################################################
 
+import json
 import os
 
 import kfp.dsl as dsl
 from data_processing.utils import get_logger
 from kubernetes import client as k8s_client
+from kubernetes.client import (
+    V1Affinity,
+    V1NodeAffinity,
+    V1NodeSelector,
+    V1NodeSelectorRequirement,
+    V1NodeSelectorTerm,
+    V1Toleration,
+)
 
 
 logger = get_logger(__name__)
@@ -43,12 +52,49 @@ class ComponentUtils:
         :param image_pull_policy: pull policy to set to the component
         :param cache_strategy: cache strategy
         """
+
+        def _add_tolerations() -> None:
+            """
+            Adds Tolerations if specified
+            """
+            try:
+                tolerations = os.getenv("KFP_TOLERATIONS", "")
+                if tolerations != "":
+                    tolerations = json.loads(tolerations)
+                    for toleration in tolerations:
+                        component.add_toleration(
+                            V1Toleration(
+                                key=toleration["key"],
+                                operator=toleration["operator"],
+                                value=toleration["value"],
+                                effect=toleration["effect"],
+                            )
+                        )
+            except Exception as e:
+                logger.warning(f"Exception while handling tolerations {e}")
+
+        def _add_node_selector() -> None:
+            """ "
+            Adds mode selector if specified
+            """
+            try:
+                node_selector = os.getenv("KFP_NODE_SELECTOR", "")
+                if node_selector != "":
+                    node_selector = json.loads(node_selector)
+                    component.add_node_selector_constraint(node_selector["label_key"], node_selector["label_value"])
+            except Exception as e:
+                logger.warning(f"Exception while handling node_selector {e}")
+
         # Set cashing
         component.execution_options.caching_strategy.max_cache_staleness = cache_strategy
         # image pull policy
         component.container.set_image_pull_policy(image_pull_policy)
         # Set the timeout for the task
         component.set_timeout(timeout)
+        # Add tolerations
+        _add_tolerations()
+        # Add affinity
+        _add_node_selector()
 
     @staticmethod
     def set_s3_env_vars_to_component(

--- a/kfp/kfp_support_lib/kfp_v1_workflow_support/src/workflow_support/compile_utils/component.py
+++ b/kfp/kfp_support_lib/kfp_v1_workflow_support/src/workflow_support/compile_utils/component.py
@@ -60,7 +60,11 @@ class ComponentUtils:
             try:
                 tolerations = os.getenv("KFP_TOLERATIONS", "")
                 if tolerations != "":
-                    print(f"Note: Applying Tolerations {tolerations} to kubeflow pipelines pods")
+                    print(f"Note: Applying Tolerations {tolerations} to kfp and ray pods")
+
+                    # Add Tolerations as env var so it can used when creating the ray cluster
+                    component.add_env_variable(k8s_client.V1EnvVar(name="KFP_TOLERATIONS", value=tolerations))
+
                     tolerations = json.loads(tolerations)
                     for toleration in tolerations:
                         component.add_toleration(

--- a/kfp/kfp_support_lib/kfp_v1_workflow_support/src/workflow_support/compile_utils/component.py
+++ b/kfp/kfp_support_lib/kfp_v1_workflow_support/src/workflow_support/compile_utils/component.py
@@ -62,7 +62,7 @@ class ComponentUtils:
                 if tolerations != "":
                     print(f"Note: Applying Tolerations {tolerations} to kfp and ray pods")
 
-                    # Add Tolerations as env var so it can used when creating the ray cluster
+                    # Add Tolerations as env var so it can be used when creating the ray cluster
                     component.add_env_variable(k8s_client.V1EnvVar(name="KFP_TOLERATIONS", value=tolerations))
 
                     tolerations = json.loads(tolerations)

--- a/kfp/kfp_support_lib/kfp_v2_workflow_support/src/workflow_support/compile_utils/component.py
+++ b/kfp/kfp_support_lib/kfp_v2_workflow_support/src/workflow_support/compile_utils/component.py
@@ -42,13 +42,9 @@ class ComponentUtils:
             try:
                 tolerations = os.getenv("KFP_TOLERATIONS", "")
                 if tolerations != "":
-                    print(f"Note: Applying Tolerations {tolerations} to kfp and ray pods")
-
-                    # Add Tolerations as env var so it can used when creating the ray cluster
-                    task.add_pod_annotation("ray_tolerations", tolerations)
-                    kubernetes.use_field_path_as_env(
-                        task, env_name="KFP_TOLERATIONS", field_path="metadata.annotations['ray_tolerations']"
-                    )
+                    # TODO: apply the tolerations defined as env vars to ray pods.
+                    # Currently they can be specified in the pipeline params:
+                    # ray_head_options and ray_worker_options.
 
                     tolerations = json.loads(tolerations)
                     for toleration in tolerations:

--- a/kfp/kfp_support_lib/kfp_v2_workflow_support/src/workflow_support/compile_utils/component.py
+++ b/kfp/kfp_support_lib/kfp_v2_workflow_support/src/workflow_support/compile_utils/component.py
@@ -42,7 +42,14 @@ class ComponentUtils:
             try:
                 tolerations = os.getenv("KFP_TOLERATIONS", "")
                 if tolerations != "":
-                    print(f"Note: Applying Tolerations {tolerations} to kubeflow pipelines pods")
+                    print(f"Note: Applying Tolerations {tolerations} to kfp and ray pods")
+
+                    # Add Tolerations as env var so it can used when creating the ray cluster
+                    task.add_pod_annotation("ray_tolerations", tolerations)
+                    kubernetes.use_field_path_as_env(
+                        task, env_name="KFP_TOLERATIONS", field_path="metadata.annotations['ray_tolerations']"
+                    )
+
                     tolerations = json.loads(tolerations)
                     for toleration in tolerations:
                         kubernetes.add_toleration(
@@ -52,6 +59,7 @@ class ComponentUtils:
                             value=toleration["value"],
                             effect=toleration["effect"],
                         )
+
             except Exception as e:
                 logger.warning(f"Exception while handling tolerations {e}")
 

--- a/kfp/kfp_support_lib/kfp_v2_workflow_support/src/workflow_support/compile_utils/component.py
+++ b/kfp/kfp_support_lib/kfp_v2_workflow_support/src/workflow_support/compile_utils/component.py
@@ -42,6 +42,7 @@ class ComponentUtils:
             try:
                 tolerations = os.getenv("KFP_TOLERATIONS", "")
                 if tolerations != "":
+                    print(f"Note: Applying Tolerations {tolerations} to kubeflow pipelines pods")
                     tolerations = json.loads(tolerations)
                     for toleration in tolerations:
                         kubernetes.add_toleration(
@@ -58,6 +59,7 @@ class ComponentUtils:
             try:
                 node_selector = os.getenv("KFP_NODE_SELECTOR", "")
                 if node_selector != "":
+                    print(f"Note: Applying node_selector {node_selector} to kubeflow pipelines pods")
                     node_selector = json.loads(node_selector)
                     kubernetes.add_node_selector(
                         task,


### PR DESCRIPTION
## Why are these changes needed?
Add Tolerations and node selector to KFP pods

To apply kuberenetes [Tolerations](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/) or [nodeSelector](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector) to KFP pods, you need to set `KFP_TOLERATIONS` or `KFP_NODE_SELECTOR` environment variables respectively before compiling the pipeline. Here's an example:

```bash
export KFP_TOLERATIONS='[{"key": "key","operator": "Equal", "value1": "value", "effect": "NoSchedule"}]'

export KFP_NODE_SELECTOR='{"label_key":"cloud.google.com/gke-accelerator","label_value":"nvidia-tesla-p4"}'
```

## Related issue number (if any).
Relates to #620 

