### PR TITLE
Fix workflow failures due to usage of pip

### DIFF
--- a/scripts/workflow_helper.sh
+++ b/scripts/workflow_helper.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -euo pipefail
+
 op=$1
 
 install_tools(){
@@ -25,7 +27,7 @@ test_workflow(){
        local workflow="$1"
 
        echo "Testing $workflow" 
-       DEPLOY_KUBEFLOW=1 make -C $workflow setup                                                                               
+       DEPLOY_KUBEFLOW=1 make -C scripts/k8s-setup setup
        make -C $workflow workflow-test
        echo "Run workflow completed"
 }

--- a/scripts/workflow_helper.sh
+++ b/scripts/workflow_helper.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+
+# This ensures that the script exits immediately if any command
+# returns a non-zero status, preventing cases where the GitHub
+# Action running the script might overlook an error if it occurs.
 set -euo pipefail
 
 op=$1

--- a/transforms/.make.workflows
+++ b/transforms/.make.workflows
@@ -57,8 +57,9 @@ ${WORKFLOW_VENV_ACTIVATE}: ${REPOROOT}/.make.versions ${REPOROOT}/kfp/kfp_ray_co
 	pip install -e $(REPOROOT)/kfp/kfp_support_lib/shared_workflow_support; \
 	pip install -e $(REPOROOT)/kfp/kfp_support_lib/$(WORKFLOW_SUPPORT_LIB); \
 	$(MAKE) -C ${REPOROOT}/kfp/kfp_ray_components set-versions
-	pip install jinja2
-	pip install pyyaml
+	. ${WORKFLOW_VENV_ACTIVATE};     \
+	pip install jinja2;              \
+	pip install pyyaml;              \
 	pip install pre-commit
 	@# Help: Create the virtual environment common to all workflows
 

--- a/transforms/.make.workflows
+++ b/transforms/.make.workflows
@@ -56,8 +56,7 @@ ${WORKFLOW_VENV_ACTIVATE}: ${REPOROOT}/.make.versions ${REPOROOT}/kfp/kfp_ray_co
 	. ${WORKFLOW_VENV_ACTIVATE};     \
 	pip install -e $(REPOROOT)/kfp/kfp_support_lib/shared_workflow_support; \
 	pip install -e $(REPOROOT)/kfp/kfp_support_lib/$(WORKFLOW_SUPPORT_LIB); \
-	$(MAKE) -C ${REPOROOT}/kfp/kfp_ray_components set-versions
-	. ${WORKFLOW_VENV_ACTIVATE};     \
+	$(MAKE) -C ${REPOROOT}/kfp/kfp_ray_components set-versions; \
 	pip install jinja2;              \
 	pip install pyyaml;              \
 	pip install pre-commit

--- a/transforms/universal/noop/kfp_ray/noop_wf.py
+++ b/transforms/universal/noop/kfp_ray/noop_wf.py
@@ -98,7 +98,7 @@ TASK_NAME: str = "noop"
 def noop(
     # Ray cluster
     ray_name: str = "noop-kfp-ray",  # name of Ray cluster
-    # Add image_pull_secret and image_pull_policy to ray workers if needed
+    # Add image_pull_secret, image_pull_policy and tolerations to ray options if needed
     ray_head_options: dict = {"cpu": 1, "memory": 4, "image": task_image},
     ray_worker_options: dict = {"replicas": 2, "max_replicas": 2, "min_replicas": 2, "cpu": 2, "memory": 4, "image": task_image},
     server_url: str = "http://kuberay-apiserver-service.kuberay.svc.cluster.local:8888",


### PR DESCRIPTION
## Why are these changes needed?
This PR aims to resolve the recent GitHub Action failure, which occurred due to the use of pip instead of the pip within a virtual environment (venv):
```
pip install jinja2
error: externally-managed-environment

× This environment is externally managed
```

## Related issue number (if any).
partally solves #703 

