### PR TITLE
Fixing cicd failures based on ubuntu-latest changing

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -8,7 +8,7 @@ on:
             - "releases/**"
 jobs:
     deploy:
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-22.04
         env:
             REPO_URL: "https://github.com/${{ github.repository }}"
             REPO_BRANCH: "dev"

--- a/.github/workflows/deploy-library.yml
+++ b/.github/workflows/deploy-library.yml
@@ -14,7 +14,7 @@ permissions:
 jobs:
     build-package:
         name: Build Ray data processing libraries
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-22.04
         steps:
             - name: Checkout
               uses: actions/checkout@v4
@@ -30,7 +30,7 @@ jobs:
         name: Publish packages to test.pypi.org
         # disabled
         if: false
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-22.04
         needs: build-package
 
         steps:
@@ -47,7 +47,7 @@ jobs:
 
     publish-pypi:
         name: Publish release to pypi.org
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-22.04
         needs: build-package
         # disabled as of now
         if: false

--- a/.github/workflows/deploy-transforms.yml
+++ b/.github/workflows/deploy-transforms.yml
@@ -9,7 +9,7 @@ on:
 jobs:
     build-images:
         name: Build and check images
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-22.04
         steps:
             - name: Checkout
               uses: actions/checkout@v4
@@ -23,7 +23,7 @@ jobs:
         name: Publish packages to quay.io
         # disabled
         if: false
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-22.04
         needs: build-images
 
         steps:

--- a/.github/workflows/test-code-code2parquet-kfp.yml
+++ b/.github/workflows/test-code-code2parquet-kfp.yml
@@ -43,7 +43,7 @@ concurrency:
 
 jobs:
     test-kfp-v1:
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-22.04
         steps:
             - name: Checkout
               uses: actions/checkout@v4
@@ -79,7 +79,7 @@ jobs:
                    fi
 
     test-kfp-v2:
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-22.04
         steps:
             - name: Checkout
               uses: actions/checkout@v4

--- a/.github/workflows/test-code-code2parquet.yml
+++ b/.github/workflows/test-code-code2parquet.yml
@@ -51,7 +51,7 @@ jobs:
         # The images are pushed if it is a merge to dev branch or a new tag is created.
         # The latter being part of the release process.
         # The images tag is derived from the value of the DOCKER_IMAGE_VERSION variable set in the .make.versions file.
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-22.04
         outputs:
             publish_images: ${{ steps.version.outputs.publish_images }}
         steps:
@@ -68,7 +68,7 @@ jobs:
                   fi
                   echo "publish_images=$publish_images" >> "$GITHUB_OUTPUT"
     test-src:
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-22.04
         steps:
             - name: Checkout
               uses: actions/checkout@v4
@@ -90,7 +90,7 @@ jobs:
                   fi
     test-image:
         needs: [check_if_push_image]
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-22.04
         timeout-minutes: 120
         env:
             DOCKER_REGISTRY_USER: ${{ secrets.DOCKER_REGISTRY_USER }}

--- a/.github/workflows/test-code-code_quality-kfp.yml
+++ b/.github/workflows/test-code-code_quality-kfp.yml
@@ -43,7 +43,7 @@ concurrency:
 
 jobs:
     test-kfp-v1:
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-22.04
         steps:
             - name: Checkout
               uses: actions/checkout@v4
@@ -79,7 +79,7 @@ jobs:
                    fi
 
     test-kfp-v2:
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-22.04
         steps:
             - name: Checkout
               uses: actions/checkout@v4

--- a/.github/workflows/test-code-code_quality.yml
+++ b/.github/workflows/test-code-code_quality.yml
@@ -51,7 +51,7 @@ jobs:
         # The images are pushed if it is a merge to dev branch or a new tag is created.
         # The latter being part of the release process.
         # The images tag is derived from the value of the DOCKER_IMAGE_VERSION variable set in the .make.versions file.
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-22.04
         outputs:
             publish_images: ${{ steps.version.outputs.publish_images }}
         steps:
@@ -68,7 +68,7 @@ jobs:
                   fi
                   echo "publish_images=$publish_images" >> "$GITHUB_OUTPUT"
     test-src:
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-22.04
         steps:
             - name: Checkout
               uses: actions/checkout@v4
@@ -90,7 +90,7 @@ jobs:
                   fi
     test-image:
         needs: [check_if_push_image]
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-22.04
         timeout-minutes: 120
         env:
             DOCKER_REGISTRY_USER: ${{ secrets.DOCKER_REGISTRY_USER }}

--- a/.github/workflows/test-code-header_cleanser-kfp.yml
+++ b/.github/workflows/test-code-header_cleanser-kfp.yml
@@ -43,7 +43,7 @@ concurrency:
 
 jobs:
     test-kfp-v1:
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-22.04
         steps:
             - name: Checkout
               uses: actions/checkout@v4
@@ -79,7 +79,7 @@ jobs:
                    fi
 
     test-kfp-v2:
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-22.04
         steps:
             - name: Checkout
               uses: actions/checkout@v4

--- a/.github/workflows/test-code-header_cleanser.yml
+++ b/.github/workflows/test-code-header_cleanser.yml
@@ -51,7 +51,7 @@ jobs:
         # The images are pushed if it is a merge to dev branch or a new tag is created.
         # The latter being part of the release process.
         # The images tag is derived from the value of the DOCKER_IMAGE_VERSION variable set in the .make.versions file.
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-22.04
         outputs:
             publish_images: ${{ steps.version.outputs.publish_images }}
         steps:
@@ -68,7 +68,7 @@ jobs:
                   fi
                   echo "publish_images=$publish_images" >> "$GITHUB_OUTPUT"
     test-src:
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-22.04
         steps:
             - name: Checkout
               uses: actions/checkout@v4
@@ -90,7 +90,7 @@ jobs:
                   fi
     test-image:
         needs: [check_if_push_image]
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-22.04
         timeout-minutes: 120
         env:
             DOCKER_REGISTRY_USER: ${{ secrets.DOCKER_REGISTRY_USER }}

--- a/.github/workflows/test-code-license_select-kfp.yml
+++ b/.github/workflows/test-code-license_select-kfp.yml
@@ -43,7 +43,7 @@ concurrency:
 
 jobs:
     test-kfp-v1:
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-22.04
         steps:
             - name: Checkout
               uses: actions/checkout@v4
@@ -79,7 +79,7 @@ jobs:
                    fi
 
     test-kfp-v2:
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-22.04
         steps:
             - name: Checkout
               uses: actions/checkout@v4

--- a/.github/workflows/test-code-license_select.yml
+++ b/.github/workflows/test-code-license_select.yml
@@ -51,7 +51,7 @@ jobs:
         # The images are pushed if it is a merge to dev branch or a new tag is created.
         # The latter being part of the release process.
         # The images tag is derived from the value of the DOCKER_IMAGE_VERSION variable set in the .make.versions file.
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-22.04
         outputs:
             publish_images: ${{ steps.version.outputs.publish_images }}
         steps:
@@ -68,7 +68,7 @@ jobs:
                   fi
                   echo "publish_images=$publish_images" >> "$GITHUB_OUTPUT"
     test-src:
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-22.04
         steps:
             - name: Checkout
               uses: actions/checkout@v4
@@ -90,7 +90,7 @@ jobs:
                   fi
     test-image:
         needs: [check_if_push_image]
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-22.04
         timeout-minutes: 120
         env:
             DOCKER_REGISTRY_USER: ${{ secrets.DOCKER_REGISTRY_USER }}

--- a/.github/workflows/test-code-malware-kfp.yml
+++ b/.github/workflows/test-code-malware-kfp.yml
@@ -43,7 +43,7 @@ concurrency:
 
 jobs:
     test-kfp-v1:
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-22.04
         steps:
             - name: Checkout
               uses: actions/checkout@v4
@@ -79,7 +79,7 @@ jobs:
                    fi
 
     test-kfp-v2:
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-22.04
         steps:
             - name: Checkout
               uses: actions/checkout@v4

--- a/.github/workflows/test-code-malware.yml
+++ b/.github/workflows/test-code-malware.yml
@@ -51,7 +51,7 @@ jobs:
         # The images are pushed if it is a merge to dev branch or a new tag is created.
         # The latter being part of the release process.
         # The images tag is derived from the value of the DOCKER_IMAGE_VERSION variable set in the .make.versions file.
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-22.04
         outputs:
             publish_images: ${{ steps.version.outputs.publish_images }}
         steps:
@@ -68,7 +68,7 @@ jobs:
                   fi
                   echo "publish_images=$publish_images" >> "$GITHUB_OUTPUT"
     test-src:
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-22.04
         steps:
             - name: Checkout
               uses: actions/checkout@v4
@@ -90,7 +90,7 @@ jobs:
                   fi
     test-image:
         needs: [check_if_push_image]
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-22.04
         timeout-minutes: 120
         env:
             DOCKER_REGISTRY_USER: ${{ secrets.DOCKER_REGISTRY_USER }}

--- a/.github/workflows/test-code-proglang_select-kfp.yml
+++ b/.github/workflows/test-code-proglang_select-kfp.yml
@@ -43,7 +43,7 @@ concurrency:
 
 jobs:
     test-kfp-v1:
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-22.04
         steps:
             - name: Checkout
               uses: actions/checkout@v4
@@ -79,7 +79,7 @@ jobs:
                    fi
 
     test-kfp-v2:
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-22.04
         steps:
             - name: Checkout
               uses: actions/checkout@v4

--- a/.github/workflows/test-code-proglang_select.yml
+++ b/.github/workflows/test-code-proglang_select.yml
@@ -51,7 +51,7 @@ jobs:
         # The images are pushed if it is a merge to dev branch or a new tag is created.
         # The latter being part of the release process.
         # The images tag is derived from the value of the DOCKER_IMAGE_VERSION variable set in the .make.versions file.
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-22.04
         outputs:
             publish_images: ${{ steps.version.outputs.publish_images }}
         steps:
@@ -68,7 +68,7 @@ jobs:
                   fi
                   echo "publish_images=$publish_images" >> "$GITHUB_OUTPUT"
     test-src:
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-22.04
         steps:
             - name: Checkout
               uses: actions/checkout@v4
@@ -90,7 +90,7 @@ jobs:
                   fi
     test-image:
         needs: [check_if_push_image]
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-22.04
         timeout-minutes: 120
         env:
             DOCKER_REGISTRY_USER: ${{ secrets.DOCKER_REGISTRY_USER }}

--- a/.github/workflows/test-code-repo_level_ordering-kfp.yml
+++ b/.github/workflows/test-code-repo_level_ordering-kfp.yml
@@ -43,7 +43,7 @@ concurrency:
 
 jobs:
     test-kfp-v1:
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-22.04
         steps:
             - name: Checkout
               uses: actions/checkout@v4
@@ -79,7 +79,7 @@ jobs:
                    fi
 
     test-kfp-v2:
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-22.04
         steps:
             - name: Checkout
               uses: actions/checkout@v4

--- a/.github/workflows/test-code-repo_level_ordering.yml
+++ b/.github/workflows/test-code-repo_level_ordering.yml
@@ -51,7 +51,7 @@ jobs:
         # The images are pushed if it is a merge to dev branch or a new tag is created.
         # The latter being part of the release process.
         # The images tag is derived from the value of the DOCKER_IMAGE_VERSION variable set in the .make.versions file.
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-22.04
         outputs:
             publish_images: ${{ steps.version.outputs.publish_images }}
         steps:
@@ -68,7 +68,7 @@ jobs:
                   fi
                   echo "publish_images=$publish_images" >> "$GITHUB_OUTPUT"
     test-src:
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-22.04
         steps:
             - name: Checkout
               uses: actions/checkout@v4
@@ -90,7 +90,7 @@ jobs:
                   fi
     test-image:
         needs: [check_if_push_image]
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-22.04
         timeout-minutes: 120
         env:
             DOCKER_REGISTRY_USER: ${{ secrets.DOCKER_REGISTRY_USER }}

--- a/.github/workflows/test-kfp-transform.template
+++ b/.github/workflows/test-kfp-transform.template
@@ -43,7 +43,7 @@ concurrency:
 
 jobs:
     test-kfp-v1:
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-22.04
         steps:
             - name: Checkout
               uses: actions/checkout@v4
@@ -79,7 +79,7 @@ jobs:
                    fi
 
     test-kfp-v2:
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-22.04
         steps:
             - name: Checkout
               uses: actions/checkout@v4

--- a/.github/workflows/test-kfp.yml
+++ b/.github/workflows/test-kfp.yml
@@ -56,7 +56,7 @@ jobs:
         # The images are pushed if it is a merge to dev branch or a new tag is created.
         # The latter being part of the release process.
         # The images tag is derived from the value of the DOCKER_IMAGE_VERSION variable set in the .make.versions file.
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-22.04
         outputs:
             publish_images: ${{ steps.version.outputs.publish_images }}
         steps:
@@ -73,7 +73,7 @@ jobs:
                   fi
                   echo "publish_images=$publish_images" >> "$GITHUB_OUTPUT"
     test-kfp-v1:
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-22.04
         steps:
             - name: Checkout
               uses: actions/checkout@v4
@@ -122,7 +122,7 @@ jobs:
                   echo "Run ${transforms[$index]} completed"
 
     test-kfp-v2:
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-22.04
         steps:
             - name: Checkout
               uses: actions/checkout@v4
@@ -172,7 +172,7 @@ jobs:
                   header_text "Run ${transforms[$index]} completed"
     build-kfp-components:
         needs: [check_if_push_images]
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-22.04
         timeout-minutes: 30
         env:
             DOCKER_REGISTRY_USER: ${{ secrets.DOCKER_REGISTRY_USER }}

--- a/.github/workflows/test-kfp.yml
+++ b/.github/workflows/test-kfp.yml
@@ -9,6 +9,7 @@ on:
         tags:
             - "*"
         paths:
+            - ".make.*"
             - "kfp/**"
             - "!kfp/**.md"
             - "!kfp/**/test/**"
@@ -27,6 +28,7 @@ on:
             - "dev"
             - "releases/**"
         paths:
+            - ".make.*"
             - "kfp/**"
             - "!kfp/**/test/**"
             - "!kfp/**.md"

--- a/.github/workflows/test-language-doc_chunk-kfp.yml
+++ b/.github/workflows/test-language-doc_chunk-kfp.yml
@@ -43,7 +43,7 @@ concurrency:
 
 jobs:
     test-kfp-v1:
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-22.04
         steps:
             - name: Checkout
               uses: actions/checkout@v4
@@ -79,7 +79,7 @@ jobs:
                    fi
 
     test-kfp-v2:
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-22.04
         steps:
             - name: Checkout
               uses: actions/checkout@v4

--- a/.github/workflows/test-language-doc_chunk.yml
+++ b/.github/workflows/test-language-doc_chunk.yml
@@ -51,7 +51,7 @@ jobs:
         # The images are pushed if it is a merge to dev branch or a new tag is created.
         # The latter being part of the release process.
         # The images tag is derived from the value of the DOCKER_IMAGE_VERSION variable set in the .make.versions file.
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-22.04
         outputs:
             publish_images: ${{ steps.version.outputs.publish_images }}
         steps:
@@ -68,7 +68,7 @@ jobs:
                   fi
                   echo "publish_images=$publish_images" >> "$GITHUB_OUTPUT"
     test-src:
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-22.04
         steps:
             - name: Checkout
               uses: actions/checkout@v4
@@ -90,7 +90,7 @@ jobs:
                   fi
     test-image:
         needs: [check_if_push_image]
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-22.04
         timeout-minutes: 120
         env:
             DOCKER_REGISTRY_USER: ${{ secrets.DOCKER_REGISTRY_USER }}

--- a/.github/workflows/test-language-doc_quality-kfp.yml
+++ b/.github/workflows/test-language-doc_quality-kfp.yml
@@ -43,7 +43,7 @@ concurrency:
 
 jobs:
     test-kfp-v1:
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-22.04
         steps:
             - name: Checkout
               uses: actions/checkout@v4
@@ -79,7 +79,7 @@ jobs:
                    fi
 
     test-kfp-v2:
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-22.04
         steps:
             - name: Checkout
               uses: actions/checkout@v4

--- a/.github/workflows/test-language-doc_quality.yml
+++ b/.github/workflows/test-language-doc_quality.yml
@@ -51,7 +51,7 @@ jobs:
         # The images are pushed if it is a merge to dev branch or a new tag is created.
         # The latter being part of the release process.
         # The images tag is derived from the value of the DOCKER_IMAGE_VERSION variable set in the .make.versions file.
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-22.04
         outputs:
             publish_images: ${{ steps.version.outputs.publish_images }}
         steps:
@@ -68,7 +68,7 @@ jobs:
                   fi
                   echo "publish_images=$publish_images" >> "$GITHUB_OUTPUT"
     test-src:
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-22.04
         steps:
             - name: Checkout
               uses: actions/checkout@v4
@@ -90,7 +90,7 @@ jobs:
                   fi
     test-image:
         needs: [check_if_push_image]
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-22.04
         timeout-minutes: 120
         env:
             DOCKER_REGISTRY_USER: ${{ secrets.DOCKER_REGISTRY_USER }}

--- a/.github/workflows/test-language-html2parquet.yml
+++ b/.github/workflows/test-language-html2parquet.yml
@@ -51,7 +51,7 @@ jobs:
         # The images are pushed if it is a merge to dev branch or a new tag is created.
         # The latter being part of the release process.
         # The images tag is derived from the value of the DOCKER_IMAGE_VERSION variable set in the .make.versions file.
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-22.04
         outputs:
             publish_images: ${{ steps.version.outputs.publish_images }}
         steps:
@@ -68,7 +68,7 @@ jobs:
                   fi
                   echo "publish_images=$publish_images" >> "$GITHUB_OUTPUT"
     test-src:
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-22.04
         steps:
             - name: Checkout
               uses: actions/checkout@v4
@@ -90,7 +90,7 @@ jobs:
                   fi
     test-image:
         needs: [check_if_push_image]
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-22.04
         timeout-minutes: 120
         env:
             DOCKER_REGISTRY_USER: ${{ secrets.DOCKER_REGISTRY_USER }}

--- a/.github/workflows/test-language-lang_id-kfp.yml
+++ b/.github/workflows/test-language-lang_id-kfp.yml
@@ -43,7 +43,7 @@ concurrency:
 
 jobs:
     test-kfp-v1:
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-22.04
         steps:
             - name: Checkout
               uses: actions/checkout@v4
@@ -79,7 +79,7 @@ jobs:
                    fi
 
     test-kfp-v2:
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-22.04
         steps:
             - name: Checkout
               uses: actions/checkout@v4

--- a/.github/workflows/test-language-lang_id.yml
+++ b/.github/workflows/test-language-lang_id.yml
@@ -51,7 +51,7 @@ jobs:
         # The images are pushed if it is a merge to dev branch or a new tag is created.
         # The latter being part of the release process.
         # The images tag is derived from the value of the DOCKER_IMAGE_VERSION variable set in the .make.versions file.
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-22.04
         outputs:
             publish_images: ${{ steps.version.outputs.publish_images }}
         steps:
@@ -68,7 +68,7 @@ jobs:
                   fi
                   echo "publish_images=$publish_images" >> "$GITHUB_OUTPUT"
     test-src:
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-22.04
         steps:
             - name: Checkout
               uses: actions/checkout@v4
@@ -90,7 +90,7 @@ jobs:
                   fi
     test-image:
         needs: [check_if_push_image]
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-22.04
         timeout-minutes: 120
         env:
             DOCKER_REGISTRY_USER: ${{ secrets.DOCKER_REGISTRY_USER }}

--- a/.github/workflows/test-language-pdf2parquet-kfp.yml
+++ b/.github/workflows/test-language-pdf2parquet-kfp.yml
@@ -43,7 +43,7 @@ concurrency:
 
 jobs:
     test-kfp-v1:
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-22.04
         steps:
             - name: Checkout
               uses: actions/checkout@v4
@@ -79,7 +79,7 @@ jobs:
                    fi
 
     test-kfp-v2:
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-22.04
         steps:
             - name: Checkout
               uses: actions/checkout@v4

--- a/.github/workflows/test-language-pdf2parquet.yml
+++ b/.github/workflows/test-language-pdf2parquet.yml
@@ -51,7 +51,7 @@ jobs:
         # The images are pushed if it is a merge to dev branch or a new tag is created.
         # The latter being part of the release process.
         # The images tag is derived from the value of the DOCKER_IMAGE_VERSION variable set in the .make.versions file.
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-22.04
         outputs:
             publish_images: ${{ steps.version.outputs.publish_images }}
         steps:
@@ -68,7 +68,7 @@ jobs:
                   fi
                   echo "publish_images=$publish_images" >> "$GITHUB_OUTPUT"
     test-src:
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-22.04
         steps:
             - name: Checkout
               uses: actions/checkout@v4
@@ -90,7 +90,7 @@ jobs:
                   fi
     test-image:
         needs: [check_if_push_image]
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-22.04
         timeout-minutes: 120
         env:
             DOCKER_REGISTRY_USER: ${{ secrets.DOCKER_REGISTRY_USER }}

--- a/.github/workflows/test-language-pii_redactor-kfp.yml
+++ b/.github/workflows/test-language-pii_redactor-kfp.yml
@@ -43,7 +43,7 @@ concurrency:
 
 jobs:
     test-kfp-v1:
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-22.04
         steps:
             - name: Checkout
               uses: actions/checkout@v4
@@ -79,7 +79,7 @@ jobs:
                    fi
 
     test-kfp-v2:
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-22.04
         steps:
             - name: Checkout
               uses: actions/checkout@v4

--- a/.github/workflows/test-language-pii_redactor.yml
+++ b/.github/workflows/test-language-pii_redactor.yml
@@ -51,7 +51,7 @@ jobs:
         # The images are pushed if it is a merge to dev branch or a new tag is created.
         # The latter being part of the release process.
         # The images tag is derived from the value of the DOCKER_IMAGE_VERSION variable set in the .make.versions file.
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-22.04
         outputs:
             publish_images: ${{ steps.version.outputs.publish_images }}
         steps:
@@ -68,7 +68,7 @@ jobs:
                   fi
                   echo "publish_images=$publish_images" >> "$GITHUB_OUTPUT"
     test-src:
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-22.04
         steps:
             - name: Checkout
               uses: actions/checkout@v4
@@ -90,7 +90,7 @@ jobs:
                   fi
     test-image:
         needs: [check_if_push_image]
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-22.04
         timeout-minutes: 120
         env:
             DOCKER_REGISTRY_USER: ${{ secrets.DOCKER_REGISTRY_USER }}

--- a/.github/workflows/test-language-text_encoder-kfp.yml
+++ b/.github/workflows/test-language-text_encoder-kfp.yml
@@ -43,7 +43,7 @@ concurrency:
 
 jobs:
     test-kfp-v1:
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-22.04
         steps:
             - name: Checkout
               uses: actions/checkout@v4
@@ -79,7 +79,7 @@ jobs:
                    fi
 
     test-kfp-v2:
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-22.04
         steps:
             - name: Checkout
               uses: actions/checkout@v4

--- a/.github/workflows/test-language-text_encoder.yml
+++ b/.github/workflows/test-language-text_encoder.yml
@@ -51,7 +51,7 @@ jobs:
         # The images are pushed if it is a merge to dev branch or a new tag is created.
         # The latter being part of the release process.
         # The images tag is derived from the value of the DOCKER_IMAGE_VERSION variable set in the .make.versions file.
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-22.04
         outputs:
             publish_images: ${{ steps.version.outputs.publish_images }}
         steps:
@@ -68,7 +68,7 @@ jobs:
                   fi
                   echo "publish_images=$publish_images" >> "$GITHUB_OUTPUT"
     test-src:
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-22.04
         steps:
             - name: Checkout
               uses: actions/checkout@v4
@@ -90,7 +90,7 @@ jobs:
                   fi
     test-image:
         needs: [check_if_push_image]
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-22.04
         timeout-minutes: 120
         env:
             DOCKER_REGISTRY_USER: ${{ secrets.DOCKER_REGISTRY_USER }}

--- a/.github/workflows/test-misc.yml
+++ b/.github/workflows/test-misc.yml
@@ -29,7 +29,7 @@ on:
 
 jobs:
     test-make:
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-22.04
         steps:
             - name: Checkout
               uses: actions/checkout@v4
@@ -37,7 +37,7 @@ jobs:
               run: |
                   make -n clean test build publish set-versions
     check-transform-test-workflows:
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-22.04
         steps:
             - name: Checkout
               uses: actions/checkout@v4

--- a/.github/workflows/test-misc.yml
+++ b/.github/workflows/test-misc.yml
@@ -9,6 +9,7 @@ on:
         tags:
             - "*"
         paths-ignore:
+            - ".make.*"
             - "**.md"
             - "examples/**"
             - "**/doc/**"
@@ -20,6 +21,7 @@ on:
             - "dev"
             - "releases/**"
         paths-ignore:
+            - ".make.*"
             - "**.md"
             - "examples/**"
             - "**/doc/**"

--- a/.github/workflows/test-packaging-python.yml
+++ b/.github/workflows/test-packaging-python.yml
@@ -9,6 +9,7 @@ on:
         tags:
             - "*"
         paths:
+            - ".make.*"
             - "transforms/packaging/python/**"
             - "!**.md"
             - "!**/doc/**"
@@ -19,6 +20,7 @@ on:
             - "dev"
             - "releases/**"
         paths:
+            - ".make.*"
             - "transforms/packaging/python/**"
             - "!**.md"
             - "!**/doc/**"

--- a/.github/workflows/test-packaging-python.yml
+++ b/.github/workflows/test-packaging-python.yml
@@ -27,7 +27,7 @@ on:
 
 jobs:
     test-src:
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-22.04
         steps:
             - name: Checkout
               uses: actions/checkout@v4

--- a/.github/workflows/test-packaging-ray.yml
+++ b/.github/workflows/test-packaging-ray.yml
@@ -9,6 +9,7 @@ on:
         tags:
             - "*"
         paths:
+            - ".make.*"
             - "transforms/packaging/ray/**"
             - "!**.md"
             - "!**/doc/**"
@@ -19,6 +20,7 @@ on:
             - "dev"
             - "releases/**"
         paths:
+            - ".make.*"
             - "transforms/packaging/ray/**"
             - "!**.md"
             - "!**/doc/**"

--- a/.github/workflows/test-packaging-ray.yml
+++ b/.github/workflows/test-packaging-ray.yml
@@ -27,7 +27,7 @@ on:
 
 jobs:
     test-src:
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-22.04
         steps:
             - name: Checkout
               uses: actions/checkout@v4

--- a/.github/workflows/test-processing-lib.yml
+++ b/.github/workflows/test-processing-lib.yml
@@ -36,7 +36,7 @@ jobs:
         # The images are pushed if it is a merge to dev branch or a new tag is created.
         # The latter being part of the release process.
         # The images tag is derived from the value of the DOCKER_IMAGE_VERSION variable set in the .make.versions file.
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-22.04
         outputs:
             publish_images: ${{ steps.version.outputs.publish_images }}
         steps:
@@ -53,7 +53,7 @@ jobs:
                   fi
                   echo "publish_images=$publish_images" >> "$GITHUB_OUTPUT"
     test-python-lib:
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-22.04
         steps:
             - name: Checkout
               uses: actions/checkout@v4
@@ -61,7 +61,7 @@ jobs:
               run: |
                   make -C data-processing-lib/python DOCKER=docker venv test
     test-ray-lib:
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-22.04
         steps:
             - name: Checkout
               uses: actions/checkout@v4
@@ -69,7 +69,7 @@ jobs:
               run: |
                   make -C data-processing-lib/ray DOCKER=docker venv test
     test-spark-lib:
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-22.04
         steps:
             - name: Checkout
               uses: actions/checkout@v4
@@ -79,7 +79,7 @@ jobs:
     test-data-processing-lib-images:
         needs: [check_if_push_images]
         if: needs.check_if_push_images.outputs.publish_images == 'true'
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-22.04
         env:
             DOCKER_REGISTRY_USER: ${{ secrets.DOCKER_REGISTRY_USER }}
             DOCKER_REGISTRY_KEY: ${{ secrets.DOCKER_REGISTRY_KEY }}

--- a/.github/workflows/test-processing-lib.yml
+++ b/.github/workflows/test-processing-lib.yml
@@ -10,6 +10,7 @@ on:
             - "*"
         paths:
             # Note: the transform workflows are expected to trigger when data-processing-lib/** changes
+            - ".make.*"
             - "data-processing-lib/**"
             - "!data-processing-lib/**.md"
             - "!data-processing-lib/**/doc/**"
@@ -20,6 +21,7 @@ on:
             - "releases/**"
         paths:
             # Note: the transform workflows are expected to trigger when data-processing-lib/** changes
+            - ".make.*"
             - "data-processing-lib/**"
             - "!data-processing-lib/**.md"
             - "!data-processing-lib/**/doc/**"

--- a/.github/workflows/test-transform.template
+++ b/.github/workflows/test-transform.template
@@ -51,7 +51,7 @@ jobs:
         # The images are pushed if it is a merge to dev branch or a new tag is created.
         # The latter being part of the release process.
         # The images tag is derived from the value of the DOCKER_IMAGE_VERSION variable set in the .make.versions file.
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-22.04
         outputs:
             publish_images: ${{ steps.version.outputs.publish_images }}
         steps:
@@ -68,7 +68,7 @@ jobs:
                   fi
                   echo "publish_images=$publish_images" >> "$GITHUB_OUTPUT"
     test-src:
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-22.04
         steps:
             - name: Checkout
               uses: actions/checkout@v4
@@ -90,7 +90,7 @@ jobs:
                   fi
     test-image:
         needs: [check_if_push_image]
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-22.04
         timeout-minutes: 120
         env:
             DOCKER_REGISTRY_USER: ${{ secrets.DOCKER_REGISTRY_USER }}

--- a/.github/workflows/test-universal-doc_id-kfp.yml
+++ b/.github/workflows/test-universal-doc_id-kfp.yml
@@ -43,7 +43,7 @@ concurrency:
 
 jobs:
     test-kfp-v1:
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-22.04
         steps:
             - name: Checkout
               uses: actions/checkout@v4
@@ -79,7 +79,7 @@ jobs:
                    fi
 
     test-kfp-v2:
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-22.04
         steps:
             - name: Checkout
               uses: actions/checkout@v4

--- a/.github/workflows/test-universal-doc_id.yml
+++ b/.github/workflows/test-universal-doc_id.yml
@@ -51,7 +51,7 @@ jobs:
         # The images are pushed if it is a merge to dev branch or a new tag is created.
         # The latter being part of the release process.
         # The images tag is derived from the value of the DOCKER_IMAGE_VERSION variable set in the .make.versions file.
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-22.04
         outputs:
             publish_images: ${{ steps.version.outputs.publish_images }}
         steps:
@@ -68,7 +68,7 @@ jobs:
                   fi
                   echo "publish_images=$publish_images" >> "$GITHUB_OUTPUT"
     test-src:
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-22.04
         steps:
             - name: Checkout
               uses: actions/checkout@v4
@@ -90,7 +90,7 @@ jobs:
                   fi
     test-image:
         needs: [check_if_push_image]
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-22.04
         timeout-minutes: 120
         env:
             DOCKER_REGISTRY_USER: ${{ secrets.DOCKER_REGISTRY_USER }}

--- a/.github/workflows/test-universal-ededup-kfp.yml
+++ b/.github/workflows/test-universal-ededup-kfp.yml
@@ -43,7 +43,7 @@ concurrency:
 
 jobs:
     test-kfp-v1:
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-22.04
         steps:
             - name: Checkout
               uses: actions/checkout@v4
@@ -79,7 +79,7 @@ jobs:
                    fi
 
     test-kfp-v2:
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-22.04
         steps:
             - name: Checkout
               uses: actions/checkout@v4

--- a/.github/workflows/test-universal-ededup.yml
+++ b/.github/workflows/test-universal-ededup.yml
@@ -51,7 +51,7 @@ jobs:
         # The images are pushed if it is a merge to dev branch or a new tag is created.
         # The latter being part of the release process.
         # The images tag is derived from the value of the DOCKER_IMAGE_VERSION variable set in the .make.versions file.
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-22.04
         outputs:
             publish_images: ${{ steps.version.outputs.publish_images }}
         steps:
@@ -68,7 +68,7 @@ jobs:
                   fi
                   echo "publish_images=$publish_images" >> "$GITHUB_OUTPUT"
     test-src:
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-22.04
         steps:
             - name: Checkout
               uses: actions/checkout@v4
@@ -90,7 +90,7 @@ jobs:
                   fi
     test-image:
         needs: [check_if_push_image]
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-22.04
         timeout-minutes: 120
         env:
             DOCKER_REGISTRY_USER: ${{ secrets.DOCKER_REGISTRY_USER }}

--- a/.github/workflows/test-universal-fdedup-kfp.yml
+++ b/.github/workflows/test-universal-fdedup-kfp.yml
@@ -43,7 +43,7 @@ concurrency:
 
 jobs:
     test-kfp-v1:
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-22.04
         steps:
             - name: Checkout
               uses: actions/checkout@v4
@@ -79,7 +79,7 @@ jobs:
                    fi
 
     test-kfp-v2:
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-22.04
         steps:
             - name: Checkout
               uses: actions/checkout@v4

--- a/.github/workflows/test-universal-fdedup.yml
+++ b/.github/workflows/test-universal-fdedup.yml
@@ -51,7 +51,7 @@ jobs:
         # The images are pushed if it is a merge to dev branch or a new tag is created.
         # The latter being part of the release process.
         # The images tag is derived from the value of the DOCKER_IMAGE_VERSION variable set in the .make.versions file.
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-22.04
         outputs:
             publish_images: ${{ steps.version.outputs.publish_images }}
         steps:
@@ -68,7 +68,7 @@ jobs:
                   fi
                   echo "publish_images=$publish_images" >> "$GITHUB_OUTPUT"
     test-src:
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-22.04
         steps:
             - name: Checkout
               uses: actions/checkout@v4
@@ -90,7 +90,7 @@ jobs:
                   fi
     test-image:
         needs: [check_if_push_image]
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-22.04
         timeout-minutes: 120
         env:
             DOCKER_REGISTRY_USER: ${{ secrets.DOCKER_REGISTRY_USER }}

--- a/.github/workflows/test-universal-filter-kfp.yml
+++ b/.github/workflows/test-universal-filter-kfp.yml
@@ -43,7 +43,7 @@ concurrency:
 
 jobs:
     test-kfp-v1:
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-22.04
         steps:
             - name: Checkout
               uses: actions/checkout@v4
@@ -79,7 +79,7 @@ jobs:
                    fi
 
     test-kfp-v2:
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-22.04
         steps:
             - name: Checkout
               uses: actions/checkout@v4

--- a/.github/workflows/test-universal-filter.yml
+++ b/.github/workflows/test-universal-filter.yml
@@ -51,7 +51,7 @@ jobs:
         # The images are pushed if it is a merge to dev branch or a new tag is created.
         # The latter being part of the release process.
         # The images tag is derived from the value of the DOCKER_IMAGE_VERSION variable set in the .make.versions file.
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-22.04
         outputs:
             publish_images: ${{ steps.version.outputs.publish_images }}
         steps:
@@ -68,7 +68,7 @@ jobs:
                   fi
                   echo "publish_images=$publish_images" >> "$GITHUB_OUTPUT"
     test-src:
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-22.04
         steps:
             - name: Checkout
               uses: actions/checkout@v4
@@ -90,7 +90,7 @@ jobs:
                   fi
     test-image:
         needs: [check_if_push_image]
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-22.04
         timeout-minutes: 120
         env:
             DOCKER_REGISTRY_USER: ${{ secrets.DOCKER_REGISTRY_USER }}

--- a/.github/workflows/test-universal-hap.yml
+++ b/.github/workflows/test-universal-hap.yml
@@ -51,7 +51,7 @@ jobs:
         # The images are pushed if it is a merge to dev branch or a new tag is created.
         # The latter being part of the release process.
         # The images tag is derived from the value of the DOCKER_IMAGE_VERSION variable set in the .make.versions file.
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-22.04
         outputs:
             publish_images: ${{ steps.version.outputs.publish_images }}
         steps:
@@ -68,7 +68,7 @@ jobs:
                   fi
                   echo "publish_images=$publish_images" >> "$GITHUB_OUTPUT"
     test-src:
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-22.04
         steps:
             - name: Checkout
               uses: actions/checkout@v4
@@ -90,7 +90,7 @@ jobs:
                   fi
     test-image:
         needs: [check_if_push_image]
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-22.04
         timeout-minutes: 120
         env:
             DOCKER_REGISTRY_USER: ${{ secrets.DOCKER_REGISTRY_USER }}

--- a/.github/workflows/test-universal-noop-kfp.yml
+++ b/.github/workflows/test-universal-noop-kfp.yml
@@ -43,7 +43,7 @@ concurrency:
 
 jobs:
     test-kfp-v1:
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-22.04
         steps:
             - name: Checkout
               uses: actions/checkout@v4
@@ -79,7 +79,7 @@ jobs:
                    fi
 
     test-kfp-v2:
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-22.04
         steps:
             - name: Checkout
               uses: actions/checkout@v4

--- a/.github/workflows/test-universal-noop.yml
+++ b/.github/workflows/test-universal-noop.yml
@@ -51,7 +51,7 @@ jobs:
         # The images are pushed if it is a merge to dev branch or a new tag is created.
         # The latter being part of the release process.
         # The images tag is derived from the value of the DOCKER_IMAGE_VERSION variable set in the .make.versions file.
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-22.04
         outputs:
             publish_images: ${{ steps.version.outputs.publish_images }}
         steps:
@@ -68,7 +68,7 @@ jobs:
                   fi
                   echo "publish_images=$publish_images" >> "$GITHUB_OUTPUT"
     test-src:
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-22.04
         steps:
             - name: Checkout
               uses: actions/checkout@v4
@@ -90,7 +90,7 @@ jobs:
                   fi
     test-image:
         needs: [check_if_push_image]
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-22.04
         timeout-minutes: 120
         env:
             DOCKER_REGISTRY_USER: ${{ secrets.DOCKER_REGISTRY_USER }}

--- a/.github/workflows/test-universal-profiler-kfp.yml
+++ b/.github/workflows/test-universal-profiler-kfp.yml
@@ -43,7 +43,7 @@ concurrency:
 
 jobs:
     test-kfp-v1:
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-22.04
         steps:
             - name: Checkout
               uses: actions/checkout@v4
@@ -79,7 +79,7 @@ jobs:
                    fi
 
     test-kfp-v2:
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-22.04
         steps:
             - name: Checkout
               uses: actions/checkout@v4

--- a/.github/workflows/test-universal-profiler.yml
+++ b/.github/workflows/test-universal-profiler.yml
@@ -51,7 +51,7 @@ jobs:
         # The images are pushed if it is a merge to dev branch or a new tag is created.
         # The latter being part of the release process.
         # The images tag is derived from the value of the DOCKER_IMAGE_VERSION variable set in the .make.versions file.
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-22.04
         outputs:
             publish_images: ${{ steps.version.outputs.publish_images }}
         steps:
@@ -68,7 +68,7 @@ jobs:
                   fi
                   echo "publish_images=$publish_images" >> "$GITHUB_OUTPUT"
     test-src:
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-22.04
         steps:
             - name: Checkout
               uses: actions/checkout@v4
@@ -90,7 +90,7 @@ jobs:
                   fi
     test-image:
         needs: [check_if_push_image]
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-22.04
         timeout-minutes: 120
         env:
             DOCKER_REGISTRY_USER: ${{ secrets.DOCKER_REGISTRY_USER }}

--- a/.github/workflows/test-universal-resize-kfp.yml
+++ b/.github/workflows/test-universal-resize-kfp.yml
@@ -43,7 +43,7 @@ concurrency:
 
 jobs:
     test-kfp-v1:
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-22.04
         steps:
             - name: Checkout
               uses: actions/checkout@v4
@@ -79,7 +79,7 @@ jobs:
                    fi
 
     test-kfp-v2:
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-22.04
         steps:
             - name: Checkout
               uses: actions/checkout@v4

--- a/.github/workflows/test-universal-resize.yml
+++ b/.github/workflows/test-universal-resize.yml
@@ -51,7 +51,7 @@ jobs:
         # The images are pushed if it is a merge to dev branch or a new tag is created.
         # The latter being part of the release process.
         # The images tag is derived from the value of the DOCKER_IMAGE_VERSION variable set in the .make.versions file.
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-22.04
         outputs:
             publish_images: ${{ steps.version.outputs.publish_images }}
         steps:
@@ -68,7 +68,7 @@ jobs:
                   fi
                   echo "publish_images=$publish_images" >> "$GITHUB_OUTPUT"
     test-src:
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-22.04
         steps:
             - name: Checkout
               uses: actions/checkout@v4
@@ -90,7 +90,7 @@ jobs:
                   fi
     test-image:
         needs: [check_if_push_image]
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-22.04
         timeout-minutes: 120
         env:
             DOCKER_REGISTRY_USER: ${{ secrets.DOCKER_REGISTRY_USER }}

--- a/.github/workflows/test-universal-tokenization-kfp.yml
+++ b/.github/workflows/test-universal-tokenization-kfp.yml
@@ -43,7 +43,7 @@ concurrency:
 
 jobs:
     test-kfp-v1:
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-22.04
         steps:
             - name: Checkout
               uses: actions/checkout@v4
@@ -79,7 +79,7 @@ jobs:
                    fi
 
     test-kfp-v2:
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-22.04
         steps:
             - name: Checkout
               uses: actions/checkout@v4

--- a/.github/workflows/test-universal-tokenization.yml
+++ b/.github/workflows/test-universal-tokenization.yml
@@ -51,7 +51,7 @@ jobs:
         # The images are pushed if it is a merge to dev branch or a new tag is created.
         # The latter being part of the release process.
         # The images tag is derived from the value of the DOCKER_IMAGE_VERSION variable set in the .make.versions file.
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-22.04
         outputs:
             publish_images: ${{ steps.version.outputs.publish_images }}
         steps:
@@ -68,7 +68,7 @@ jobs:
                   fi
                   echo "publish_images=$publish_images" >> "$GITHUB_OUTPUT"
     test-src:
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-22.04
         steps:
             - name: Checkout
               uses: actions/checkout@v4
@@ -90,7 +90,7 @@ jobs:
                   fi
     test-image:
         needs: [check_if_push_image]
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-22.04
         timeout-minutes: 120
         env:
             DOCKER_REGISTRY_USER: ${{ secrets.DOCKER_REGISTRY_USER }}

--- a/.github/workflows/workflow-manual-run.yml
+++ b/.github/workflows/workflow-manual-run.yml
@@ -22,7 +22,7 @@ jobs:
             KFPv2: ${{ github.event.inputs.kfp_v2 }}
             WORKFLOW_PATH: ${{ github.event.inputs.workflow-path }}
             DEBUG_MODE: ${{ github.event.inputs.debug }}
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-22.04
         steps:
             - name: Checkout
               uses: actions/checkout@v4

--- a/.make.defaults
+++ b/.make.defaults
@@ -22,7 +22,6 @@
 # To augment the the clean rule
 # clean: .clean
 # 	rm -rf other-stuff
-#
 #######################################################################################
 SHELL=/bin/bash
 include $(REPOROOT)/.make.versions


### PR DESCRIPTION
## Why are these changes needed?
It appears github has upgraded ubuntu-latest to now be running python 3.12.  This is causing build failures. 
To fix this, we can try reverting to 22.04 which we used to use up until a few days ago.

## Related issue number (if any).

#703
