### PR TITLE
Fix missing dev1 in README.md pip install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,8 +79,8 @@ conda install gxx_linux-64
 Next, install the data prep toolkit library. This library installs both the python and ray versions of the transforms. For better management of dependencies, it is recommended to install the same tagged version of both the library and the transform. 
 
 ```bash
-pip3 install  data-prep-toolkit[ray]==0.2.2
-pip3 install  data-prep-toolkit-transforms[ray,all]==0.2.2
+pip3 install  'data-prep-toolkit[ray]==0.2.2.dev1'
+pip3 install  'data-prep-toolkit-transforms[ray,all]==0.2.2.dev1'
 pip3 install jupyterlab   ipykernel  ipywidgets
 
 ## install custom kernel


### PR DESCRIPTION
## Why are these changes needed?

Fix typo in README.md file as it was referencing a release version that does not yet exists. Set the tag to the current dev version: 0.2.2.dev1

## Related issue number (if any).


