### PR TITLE
workflow to publish data-connector-lib

### DIFF
--- a/.github/workflows/deploy-connector.yml
+++ b/.github/workflows/deploy-connector.yml
@@ -1,0 +1,59 @@
+name: Build, Test, and Upload PyPI package of data-connector-lib
+
+on:
+    release:
+        types:
+            - published
+    workflow_dispatch:
+
+permissions:
+    contents: read
+    # see https://docs.pypi.org/trusted-publishers/
+    id-token: write
+
+jobs:
+    build-package:
+        name: Build data connector library
+        runs-on: ubuntu-22.04
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v4
+              with:
+                  # for setuptools-scm
+                  fetch-depth: 0
+            - name: Build Packages for pypi
+              run: |
+                  make -C data-connector-lib build
+    publish-test-pypi:
+        name: Publish packages to test.pypi.org
+        # disabled
+        if: false
+        runs-on: ubuntu-22.04
+        needs: build-package
+
+        steps:
+            - name: Fetch build artifacts
+              uses: actions/download-artifact@v4
+              with:
+                  name: Packages
+                  path: dist
+
+            - name: Upload to Test PyPI
+              uses: pypa/gh-action-pypi-publish@release/v1
+              with:
+                  repository-url: https://test.pypi.org/legacy/
+
+    publish-pypi:
+        name: Publish release to pypi.org
+        runs-on: ubuntu-22.04
+        needs: build-package
+        # disabled as of now
+        if: false
+        steps:
+            - name: Fetch build artifacts
+              uses: actions/download-artifact@v4
+              with:
+                  name: Packages
+                  path: dist
+            - name: Upload to PyPI
+              uses: pypa/gh-action-pypi-publish@release/v1

--- a/data-connector-lib/doc/overview.md
+++ b/data-connector-lib/doc/overview.md
@@ -10,6 +10,20 @@ Features:
 - Mime type filters: You can restrict mime types which can be downloaded.
 - Parallel processing: Requests to websites are processed in parallel.
 
+## How to install
+
+### From PyPI
+
+```sh
+pip install data-prep-connector
+```
+
+### From Github
+
+```sh
+pip install git+https://github.com/IBM/data-prep-kit.git@dev#subdirectory=data-connector-lib
+```
+
 ## Example usage
 
 ```python

--- a/data-connector-lib/pyproject.toml
+++ b/data-connector-lib/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-name = "dpk_connector"
+name = "data_prep_connector"
 version = "0.2.2.dev0"
 requires-python = ">=3.10"
 keywords = [


### PR DESCRIPTION
## Why are these changes needed?

To address the request below, we want to publish the data-connector-lib with the project name `data_prep_connector`. Actually, the publish jobs are disabled following the other modules, but I would like to add it for the data-connector-lib for future changes towards automatic release management.

## Related issue number (if any).

#697 
