### PR TITLE
set kuberay apiserver version

### DIFF
--- a/scripts/k8s-setup/ray_api_server_values.yaml
+++ b/scripts/k8s-setup/ray_api_server_values.yaml
@@ -8,7 +8,7 @@ replicaCount: 1
 name: "kuberay-apiserver"
 image:
     repository: quay.io/kuberay/apiserver
-    tag: nightly
+    tag: v1.2.2
     pullPolicy: IfNotPresent
 
 ## Install Default RBAC roles and bindings


### PR DESCRIPTION
## Why are these changes needed?
Replace the nightly built image with the latest release one (v1.2.2) 


