### PR TITLE
Fix 'IndexError: list index out of range' in header_cleanser

### DIFF
--- a/transforms/code/header_cleanser/python/src/header_cleanser_transform.py
+++ b/transforms/code/header_cleanser/python/src/header_cleanser_transform.py
@@ -83,6 +83,7 @@ def check_empty_comment(code, ignore_lines):
 
     if max_index <= len(code_list):
         max_index = max_index + 2
+    max_index = min(max_index, len(code_list))
 
     for index in range(min_index, max_index):
         if all(


### PR DESCRIPTION
## Why are these changes needed?

During my test of `header_cleanser` on KFP, I faced many warning messages:

```
(RayTransformFileProcessor pid=370, ip=xxx.xxx.xxx.xxx) 00:59:06 WARNING - Exception list index out of range processing file XXX/00001.parquet: Traceback (most recent call last):
(RayTransformFileProcessor pid=370, ip=xxx.xxx.xxx.xxx)   File "/home/ray/anaconda3/lib/python3.10/site-packages/data_processing/runtime/transform_file_processor.py", line 62, in process_file
(RayTransformFileProcessor pid=370, ip=xxx.xxx.xxx.xxx)     out_files, stats = self.transform.transform_binary(file_name=f_name, byte_array=filedata)
(RayTransformFileProcessor pid=370, ip=xxx.xxx.xxx.xxx)   File "/home/ray/anaconda3/lib/python3.10/site-packages/data_processing/transform/table_transform.py", line 59, in transform_binary
(RayTransformFileProcessor pid=370, ip=xxx.xxx.xxx.xxx)     out_tables, stats = self.transform(table=table, file_name=file_name)
(RayTransformFileProcessor pid=370, ip=xxx.xxx.xxx.xxx)   File "/home/ray/python-transform/src/header_cleanser_transform.py", line 162, in transform
(RayTransformFileProcessor pid=370, ip=xxx.xxx.xxx.xxx)     new_content, detect = remove_license_copyright(content)
(RayTransformFileProcessor pid=370, ip=xxx.xxx.xxx.xxx)   File "/home/ray/python-transform/src/header_cleanser_transform.py", line 140, in remove_license_copyright
(RayTransformFileProcessor pid=370, ip=xxx.xxx.xxx.xxx)     ignore_lines = check_empty_comment(code, ignore_lines)
(RayTransformFileProcessor pid=370, ip=xxx.xxx.xxx.xxx)   File "/home/ray/python-transform/src/header_cleanser_transform.py", line 92, in check_empty_comment
(RayTransformFileProcessor pid=370, ip=xxx.xxx.xxx.xxx)     for x in code_list[index]
(RayTransformFileProcessor pid=370, ip=xxx.xxx.xxx.xxx) IndexError: list index out of range
```

## Related issue number (if any).


