### PR TITLE
Fix metadata logging even when actors crash 

### DIFF
--- a/data-processing-lib/ray/src/data_processing_ray/runtime/ray/transform_orchestrator.py
+++ b/data-processing-lib/ray/src/data_processing_ray/runtime/ray/transform_orchestrator.py
@@ -62,7 +62,7 @@ def orchestrate(
         if is_folder:
             # folder transform
             files = runtime.get_folders(data_access=data_access)
-            logger.info(f"Number of folders is {len(files)}")        # Get files to process
+            logger.info(f"Number of folders is {len(files)}")  # Get files to process
         else:
             files, profile, retries = data_access.get_files_to_process()
             if len(files) == 0:
@@ -142,7 +142,8 @@ def orchestrate(
         # Compute execution statistics
         logger.debug("Computing execution stats")
         stats = runtime.compute_execution_stats(ray.get(statistics.get_execution_stats.remote()))
-        stats["processing_time"] = round(stats["processing_time"], 3)
+        if "processing_time" in stats:
+            stats["processing_time"] = round(stats["processing_time"], 3)
 
         # build and save metadata
         logger.debug("Building job metadata")


### PR DESCRIPTION
## Why are these changes needed?

In case the ray actors crash, the key `processing_time` may not be updated to stats, so while rounding off this key, we may get an exception which stops metadata from being written.

## Related issue number (if any).
Also seen in the crash here. https://github.com/IBM/data-prep-kit/issues/719


