### PR TITLE
bump connector version

### DIFF
--- a/data-connector-lib/pyproject.toml
+++ b/data-connector-lib/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "data_prep_connector"
-version = "0.2.3.dev0"
+version = "0.2.3.dev1"
 requires-python = ">=3.10,<3.13"
 keywords = [
     "data",


### PR DESCRIPTION
## Why are these changes needed?

I made a dev release including the change #738. We need to increment the data connector version.

## Related issue number (if any).

#737
