### PR TITLE
small fixes

### DIFF
--- a/transforms/code/code_profiler/Makefile
+++ b/transforms/code/code_profiler/Makefile
@@ -38,16 +38,12 @@ set-versions:
 
 .PHONY: workflow-venv
 workflow-venv:
-	$(MAKE) -C kfp_ray workflow-venv
 
 .PHONY: workflow-test
 workflow-test:
-	$(MAKE) -C kfp_ray workflow-test
 
 .PHONY: workflow-upload
 workflow-upload:
-	$(MAKE) -C kfp_ray workflow-upload
 
 .PHONY: workflow-build
 workflow-build:
-	$(MAKE) -C  kfp_ray workflow-build

--- a/transforms/universal/ededup/kfp_ray/ededup_wf.py
+++ b/transforms/universal/ededup/kfp_ray/ededup_wf.py
@@ -43,14 +43,14 @@ if os.getenv("KFPv2", "0") == "1":
     compute_exec_params_op = dsl.component_decorator.component(
         func=ededup_compute_execution_params, base_image=base_kfp_image
     )
+    print(
+        "WARNING: the ray cluster name can be non-unique at runtime, please do not execute simultaneous Runs of the "
+        + "same version of the same pipeline !!!"
+    )
     run_id = uuid.uuid4().hex
 else:
     compute_exec_params_op = comp.create_component_from_func(
         func=ededup_compute_execution_params, base_image=base_kfp_image
-    )
-    print(
-        "WARNING: the ray cluster name can be non-unique at runtime, please do not execute simultaneous Runs of the "
-        + "same version of the same pipeline !!!"
     )
     run_id = dsl.RUN_ID_PLACEHOLDER
 


### PR DESCRIPTION
## Why are these changes needed?

The `code/code_profiler/Makefile` file had KFP workflow rules, despite that there wasn't the `kfp_ray` dir.
The `universal/ededup/kfp_ray/ededup_wf.py` file printed the ray cluster KFPv2 non uniqueness warning in the case of KFPv1. 



