### PR TITLE
Fix License select kfp

### DIFF
--- a/scripts/k8s-setup/populate_minio.sh
+++ b/scripts/k8s-setup/populate_minio.sh
@@ -27,6 +27,8 @@ mc cp --recursive ${REPOROOT}/transforms/code/proglang_select/ray/test-data/lang
 mc cp --recursive ${REPOROOT}/transforms/code/malware/ray/test-data/input/ kfp/test/malware/input
 mc cp --recursive ${REPOROOT}/transforms/code/header_cleanser/ray/test-data/input/ kfp/test/header_cleanser/input
 mc cp --recursive ${REPOROOT}/transforms/code/repo_level_ordering/ray/test-data/input/ kfp/test/repo_level_ordering/input
+mc cp --recursive ${REPOROOT}/transforms/code/license_select/ray/test-data/input/ kfp/test/license_select/input
+mc cp --recursive ${REPOROOT}/transforms/code/license_select/ray/test-data/sample_approved_licenses.json kfp/test/license_select/
 # language
 mc cp --recursive ${REPOROOT}/transforms/language/lang_id/ray/test-data/input/ kfp/test/lang_id/input
 mc cp --recursive ${REPOROOT}/transforms/language/doc_quality/ray/test-data/input/ kfp/test/doc_quality/input

--- a/transforms/code/license_select/kfp_ray/license_select_wf.py
+++ b/transforms/code/license_select/kfp_ray/license_select_wf.py
@@ -40,7 +40,7 @@ def compute_exec_params_func(
     data_num_samples: int,
     runtime_pipeline_id: str,
     runtime_job_id: str,
-    runtime_code_location: str,
+    runtime_code_location: dict,
     lc_license_column_name: str,
     lc_licenses_file: str,
 ) -> dict:
@@ -117,9 +117,9 @@ def license_select(
     data_max_files: int = -1,
     data_num_samples: int = -1,
     # orchestrator
-    runtime_actor_options: dict = {"num_cpus": 0.8},
+    runtime_actor_options: dict = {"num_cpus": 0.7},
     runtime_pipeline_id: str = "runtime_pipeline_id",
-    runtime_code_location: str = "{'github': 'github', 'commit_hash': '12345', 'path': 'path'}",
+    runtime_code_location: dict = {'github': 'github', 'commit_hash': '12345', 'path': 'path'},
     # license select parameters
     lc_license_column_name: str = "license",
     lc_licenses_file: str = "test/license_select/sample_approved_licenses.json",

--- a/transforms/code/license_select/python/Makefile
+++ b/transforms/code/license_select/python/Makefile
@@ -17,8 +17,6 @@ include $(REPOROOT)/transforms/.make.transforms
 # Include the common configuration for this transform
 include ../transform.config
 
-DOCKER_IMAGE_VERSION=${LICENSE_SELECT_PYTHON_VERSION}
-
 # Use default rule inherited from makefile.common
 clean:: .transforms.clean
 

--- a/transforms/code/license_select/ray/Makefile
+++ b/transforms/code/license_select/ray/Makefile
@@ -19,8 +19,6 @@ include ../transform.config
 
 BASE_IMAGE=$(RAY_BASE_IMAGE)
 
-DOCKER_IMAGE_VERSION=${LICENSE_SELECT_RAY_VERSION}
-
 # Use default rule inherited from makefile.common
 clean:: .transforms.clean
 


### PR DESCRIPTION
## Why are these changes needed?
This PR tries to fix license_select kfp run

It contains the following:
- currently the image tag built with `make image` is `0.2.2.dev2` and not `latest` as expected.
- it updates `runtime_code_location` kfp param to be dict instead of str
- it uploads the input to minio

## Related issue number (if any).
https://github.com/IBM/data-prep-kit/issues/677

