### PR TITLE
Fix set_s3_env_vars_to_component in kfp v2.

### DIFF
--- a/kfp/kfp_support_lib/kfp_v2_workflow_support/src/workflow_support/compile_utils/component.py
+++ b/kfp/kfp_support_lib/kfp_v2_workflow_support/src/workflow_support/compile_utils/component.py
@@ -103,7 +103,7 @@ class ComponentUtils:
     def set_s3_env_vars_to_component(
         task: dsl.PipelineTask,
         secret: str = "",
-        env2key: Dict[str, str] = {"s3-key": "S3_KEY", "s3-secret": "S3_SECRET", "s3-endpoint": "ENDPOINT"},
+        env2key: Dict[str, str] = None,
         prefix: str = None,
     ) -> None:
         """
@@ -113,6 +113,8 @@ class ComponentUtils:
         :param env2key: dict with mapping each env variable to a key in the secret
         :param prefix: prefix to add to env name
         """
+        if env2key is None:
+            env2key = {"s3-key": "S3_KEY", "s3-secret": "S3_SECRET", "s3-endpoint": "ENDPOINT"}
 
         if prefix is not None:
             for secret_key, _ in env2key.items():


### PR DESCRIPTION
## Why are these changes needed?

`set_s3_env_vars_to_component` in kfp v2 accepts `env2key` dict  that is shared between the function invocation. This implementation can lead to errors, especially when the function is called multiple times, sometimes with a prefix. This PR fixes that.


