### PR TITLE
relax hap denpendencies on torch to overcome error on MacOS I7 with python 3.11

### DIFF
--- a/transforms/pyproject.toml
+++ b/transforms/pyproject.toml
@@ -80,11 +80,11 @@ web2parquet = { file = ["universal/web2parquet/requirements.txt"]}
 # Does not seem to work for our custom layout
 # copy all files to a single src and let automatic discovery find them
 
-[tool.setuptools.package-data]
-"*" = ["*.txt"]
+#[tool.setuptools.package-data]
+#"*" = ["*.txt"]
 
-[tool.setuptools.packages.find]
-where = ["src"]
+#[tool.setuptools.packages.find]
+#where = ["src"]
 
 #[tool.setuptools.package-dir]
 #dpk_web2parquet = "universal/web2parquet/dpk_web2parquet"

--- a/transforms/universal/hap/python/requirements.txt
+++ b/transforms/universal/hap/python/requirements.txt
@@ -1,5 +1,5 @@
 data-prep-toolkit==0.2.2.dev2
 nltk==3.9.1
 transformers==4.38.2
-torch==2.4.1
+torch>=2.2.2,<=2.4.1
 pandas==2.2.2

--- a/transforms/universal/hap/ray/requirements.txt
+++ b/transforms/universal/hap/ray/requirements.txt
@@ -2,5 +2,5 @@ data-prep-toolkit[ray]==0.2.2.dev2
 dpk-hap-transform-python==0.2.2.dev2
 nltk==3.9.1
 transformers==4.38.2
-torch==2.4.1
+torch>=2.2.2,<=2.4.1
 pandas==2.2.2


### PR DESCRIPTION
## Why are these changes needed?

relax dependency to overcome failure on pip install by using:

torch>=2.2.2,<2.4.1

## Related issue number (if any).


https://github.com/IBM/data-prep-kit/issues/829