### PR TITLE
Grant non-root users the necessary permissions to the ray directory

### DIFF
--- a/kfp/kfp_ray_components/Dockerfile
+++ b/kfp/kfp_ray_components/Dockerfile
@@ -30,6 +30,9 @@ COPY ./src /pipelines/component/src
 # Set environment
 ENV KFP_v2=$KFP_v2
 
+# Grant non-root users the necessary permissions to the ray directory
+RUN chmod 755 /home/ray
+
 # Put these at the end since they seem to upset the docker cache.
 ARG BUILD_DATE
 ARG GIT_COMMIT

--- a/transforms/code/code2parquet/ray/Dockerfile
+++ b/transforms/code/code2parquet/ray/Dockerfile
@@ -32,6 +32,9 @@ COPY src/code2parquet_local_ray.py local/
 COPY test/ test/
 COPY test-data/ test-data/
 
+# Grant non-root users the necessary permissions to the ray directory
+RUN chmod 755 /home/ray
+
 # Set environment
 ENV PYTHONPATH /home/ray
 

--- a/transforms/code/code_profiler/ray/Dockerfile
+++ b/transforms/code/code_profiler/ray/Dockerfile
@@ -33,6 +33,9 @@ COPY ./src/code_profiler_local_ray.py local/
 COPY test/ test/
 COPY test-data/ test-data/
 
+# Grant non-root users the necessary permissions to the ray directory
+RUN chmod 755 /home/ray
+
 # Set environment
 ENV PYTHONPATH /home/ray
 

--- a/transforms/code/code_quality/ray/Dockerfile
+++ b/transforms/code/code_quality/ray/Dockerfile
@@ -37,6 +37,9 @@ COPY ./src/code_quality_local_ray.py local/
 COPY test/ test/
 COPY test-data/ test-data/
 
+# Grant non-root users the necessary permissions to the ray directory
+RUN chmod 755 /home/ray
+
 # Set environment
 ENV PYTHONPATH /home/ray
 

--- a/transforms/code/header_cleanser/ray/Dockerfile
+++ b/transforms/code/header_cleanser/ray/Dockerfile
@@ -32,6 +32,9 @@ COPY src/header_cleanser_local_ray.py local/
 COPY test/ test/
 COPY test-data/ test-data/
 
+# Grant non-root users the necessary permissions to the ray directory
+RUN chmod 755 /home/ray
+
 # Set environment
 ENV PYTHONPATH /home/ray
 

--- a/transforms/code/license_select/ray/Dockerfile
+++ b/transforms/code/license_select/ray/Dockerfile
@@ -29,6 +29,9 @@ COPY src/license_select_local_ray.py local/
 COPY test/ test/
 COPY test-data/ test-data/
 
+# Grant non-root users the necessary permissions to the ray directory
+RUN chmod 755 /home/ray
+
 # Put these at the end since they seem to upset the docker cache.
 ARG BUILD_DATE
 ARG GIT_COMMIT

--- a/transforms/code/malware/ray/Dockerfile
+++ b/transforms/code/malware/ray/Dockerfile
@@ -59,6 +59,9 @@ COPY src/malware_local_ray.py  local/
 COPY test/ test/
 COPY test-data/ test-data/
 
+# Grant non-root users the necessary permissions to the ray directory
+RUN chmod 755 /home/ray
+
 ENV PYTHONPATH /home/ray
 
 USER root

--- a/transforms/code/proglang_select/ray/Dockerfile
+++ b/transforms/code/proglang_select/ray/Dockerfile
@@ -33,6 +33,9 @@ COPY ./src/proglang_select_local_ray.py local/
 COPY test/ test/
 COPY test-data/ test-data/
 
+# Grant non-root users the necessary permissions to the ray directory
+RUN chmod 755 /home/ray
+
 # Set environment
 ENV PYTHONPATH /home/ray
 

--- a/transforms/code/repo_level_ordering/ray/Dockerfile
+++ b/transforms/code/repo_level_ordering/ray/Dockerfile
@@ -27,6 +27,9 @@ COPY ./src/repo_level_order_s3_ray.py local/
 COPY test/ test/
 COPY test-data/ test-data/
 
+# Grant non-root users the necessary permissions to the ray directory
+RUN chmod 755 /home/ray
+
 # Set environment
 ENV PYTHONPATH /home/ray:/home/ray/src
 

--- a/transforms/language/doc_chunk/ray/Dockerfile
+++ b/transforms/language/doc_chunk/ray/Dockerfile
@@ -33,6 +33,9 @@ COPY ./src/doc_chunk_local_ray.py local/
 COPY test/ test/
 COPY test-data/ test-data/
 
+# Grant non-root users the necessary permissions to the ray directory
+RUN chmod 755 /home/ray
+
 # Set environment
 ENV PYTHONPATH /home/ray
 

--- a/transforms/language/doc_quality/ray/Dockerfile
+++ b/transforms/language/doc_quality/ray/Dockerfile
@@ -32,6 +32,9 @@ COPY test/ test/
 COPY test-data/ test-data/
 COPY ldnoobw/ ldnoobw/
 
+# Grant non-root users the necessary permissions to the ray directory
+RUN chmod 755 /home/ray
+
 # Set environment
 ENV PYTHONPATH /home/ray
 

--- a/transforms/language/html2parquet/ray/Dockerfile
+++ b/transforms/language/html2parquet/ray/Dockerfile
@@ -33,6 +33,9 @@ COPY --chown=ray:users ./src/html2parquet_local_ray.py local/
 COPY test/ test/
 COPY test-data/ test-data/
 
+# Grant non-root users the necessary permissions to the ray directory
+RUN chmod 755 /home/ray
+
 # Set environment
 ENV PYTHONPATH /home/ray
 

--- a/transforms/language/lang_id/ray/Dockerfile
+++ b/transforms/language/lang_id/ray/Dockerfile
@@ -44,6 +44,9 @@ COPY ./src/lang_id_local_ray.py local/
 COPY test/ test/
 COPY test-data/ test-data/
 
+# Grant non-root users the necessary permissions to the ray directory
+RUN chmod 755 /home/ray
+
 # Set environment
 ENV PYTHONPATH /home/ray
 

--- a/transforms/language/pdf2parquet/ray/Dockerfile
+++ b/transforms/language/pdf2parquet/ray/Dockerfile
@@ -46,6 +46,9 @@ COPY --chown=ray:users ./src/pdf2parquet_local_ray.py local/
 COPY test/ test/
 COPY test-data/ test-data/
 
+# Grant non-root users the necessary permissions to the ray directory
+RUN chmod 755 /home/ray
+
 # Set environment
 ENV PYTHONPATH /home/ray
 

--- a/transforms/language/pii_redactor/ray/Dockerfile
+++ b/transforms/language/pii_redactor/ray/Dockerfile
@@ -33,6 +33,9 @@ COPY ./src/pii_redactor_local_ray.py local/
 COPY test/ test/
 COPY test-data/ test-data/
 
+# Grant non-root users the necessary permissions to the ray directory
+RUN chmod 755 /home/ray
+
 # Set environment
 ENV PYTHONPATH /home/ray
 

--- a/transforms/language/text_encoder/ray/Dockerfile
+++ b/transforms/language/text_encoder/ray/Dockerfile
@@ -32,6 +32,9 @@ COPY ./src/text_encoder_local_ray.py local/
 COPY test/ test/
 COPY test-data/ test-data/
 
+# Grant non-root users the necessary permissions to the ray directory
+RUN chmod 755 /home/ray
+
 # Set environment
 ENV PYTHONPATH /home/ray
 

--- a/transforms/universal/doc_id/ray/Dockerfile
+++ b/transforms/universal/doc_id/ray/Dockerfile
@@ -33,6 +33,9 @@ COPY src/doc_id_local_ray.py local/
 COPY test/ test/
 COPY test-data/ test-data/
 
+# Grant non-root users the necessary permissions to the ray directory
+RUN chmod 755 /home/ray
+
 # Set environment
 ENV PYTHONPATH /home/ray
 

--- a/transforms/universal/ededup/ray/Dockerfile
+++ b/transforms/universal/ededup/ray/Dockerfile
@@ -33,6 +33,9 @@ COPY src/ededup_local_ray.py local/
 COPY test/ test/
 COPY test-data/ test-data/
 
+# Grant non-root users the necessary permissions to the ray directory
+RUN chmod 755 /home/ray
+
 # Set environment
 ENV PYTHONPATH /home/ray
 

--- a/transforms/universal/fdedup/ray/Dockerfile
+++ b/transforms/universal/fdedup/ray/Dockerfile
@@ -35,6 +35,9 @@ COPY --chown=ray:users ./src/signature_calc_local_ray.py local/fdedup_local_ray.
 COPY test/ test/
 COPY test-data/ test-data/
 
+# Grant non-root users the necessary permissions to the ray directory
+RUN chmod 755 /home/ray
+
 USER root
 RUN chmod a+rwx /home/ray
 USER ray

--- a/transforms/universal/filter/ray/Dockerfile
+++ b/transforms/universal/filter/ray/Dockerfile
@@ -33,6 +33,9 @@ COPY src/filter_local_ray.py local/
 COPY test/ test/
 COPY test-data/ test-data/
 
+# Grant non-root users the necessary permissions to the ray directory
+RUN chmod 755 /home/ray
+
 # Set environment
 ENV PYTHONPATH /home/ray
 

--- a/transforms/universal/hap/ray/Dockerfile
+++ b/transforms/universal/hap/ray/Dockerfile
@@ -34,6 +34,9 @@ COPY ./src/hap_local_ray.py local/
 COPY test/ test/
 COPY test-data/ test-data/
 
+# Grant non-root users the necessary permissions to the ray directory
+RUN chmod 755 /home/ray
+
 # Set environment
 ENV PYTHONPATH /home/ray
 

--- a/transforms/universal/noop/ray/Dockerfile
+++ b/transforms/universal/noop/ray/Dockerfile
@@ -33,6 +33,9 @@ COPY ./src/noop_local_ray.py local/
 COPY test/ test/
 COPY test-data/ test-data/
 
+# Grant non-root users the necessary permissions to the ray directory
+RUN chmod 755 /home/ray
+
 # Set environment
 ENV PYTHONPATH /home/ray
 

--- a/transforms/universal/profiler/ray/Dockerfile
+++ b/transforms/universal/profiler/ray/Dockerfile
@@ -34,6 +34,9 @@ COPY src/profiler_local_ray.py local/
 COPY test/ test/
 COPY test-data/ test-data/
 
+# Grant non-root users the necessary permissions to the ray directory
+RUN chmod 755 /home/ray
+
 # Set environment
 ENV PYTHONPATH /home/ray
 

--- a/transforms/universal/resize/ray/Dockerfile
+++ b/transforms/universal/resize/ray/Dockerfile
@@ -30,6 +30,9 @@ COPY ./src/resize_local_ray.py local/
 COPY test/ test/
 COPY test-data/ test-data/
 
+# Grant non-root users the necessary permissions to the ray directory
+RUN chmod 755 /home/ray
+
 USER root
 RUN chown -R ray /home/ray/test
 RUN chown -R ray /home/ray/test-data

--- a/transforms/universal/tokenization/ray/Dockerfile
+++ b/transforms/universal/tokenization/ray/Dockerfile
@@ -32,6 +32,9 @@ COPY src/tokenization_local_ray.py local/
 COPY test/ test/
 COPY test-data/ test-data/
 
+# Grant non-root users the necessary permissions to the ray directory
+RUN chmod 755 /home/ray
+
 # Set environment
 ENV PYTHONPATH /home/ray
 


### PR DESCRIPTION
## Why are these changes needed?

Running the images with non root user results in "permission denied" error.
This PR fixes that by granting non-root users the necessary permissions to the ray directory


