### PR TITLE
Fix kind load command for kfp image.

### DIFF
--- a/kfp/kfp_ray_components/Makefile
+++ b/kfp/kfp_ray_components/Makefile
@@ -2,6 +2,12 @@
 # # know where they are running from.
 REPOROOT=../..
 
+ifeq ($(KFPv2), 1)
+        DOCKER_IMAGE_NAME=kfp-data-processing_v2
+else
+        DOCKER_IMAGE_NAME=kfp-data-processing
+endif
+
 # Include the common rules.
 # Use "make help" to see them.
 include $(REPOROOT)/.make.defaults
@@ -9,12 +15,6 @@ include $(REPOROOT)/.make.defaults
 #DOCKER_IMG=${DOCKER_HOSTNAME}/${DOCKER_NAMESPACE}/${DOCKER_IMAGE_NAME}:${DOCKER_IMAGE_VERSION}
 DOCKER_IMG=$(DOCKER_LOCAL_IMAGE)
 BASE_IMAGE=${RAY_BASE_IMAGE}
-
-ifeq ($(KFPv2), 1)
-        DOCKER_IMAGE_NAME=kfp-data-processing_v2
-else
-        DOCKER_IMAGE_NAME=kfp-data-processing
-endif
 
 .PHONY: .lib-src-image
 .lib-src-image:: .default.build-lib-wheel


### PR DESCRIPTION
## Why are these changes needed?
In recent transform refactoring PRs, such as those for  [ededup](https://github.com/IBM/data-prep-kit/pull/878) and [tokenization](https://github.com/IBM/data-prep-kit/pull/869), the `kind load` command is executed twice for the transform image in the kfp tests. This happens instead of executing it once for the `kfp-data-processing` image and once for the transform image. This issue can be observed in the logs of KFP runs in these PRs by searching for the `kind load` string.

This PR aims to address this issue.

**Explanation of the Error:**

To understand why `kfp-data-processing:latest quay.io/dataprep1/data-prep-kit/kfp-data-processing:latest` is not loaded as expected in [kfp-load-kind target](https://github.com/IBM/data-prep-kit/blob/dev/kfp/kfp_ray_components/Makefile#L58) let's look at the [Makefile](https://github.com/IBM/data-prep-kit/blob/dev/kfp/kfp_ray_components/Makefile#L7) in kfp/kfp_ray_components:

in its first line it includes `.make.defaults` which defines `DOCKER_REMOTE_IMAGE`:
```bash
DOCKER_REMOTE_IMAGE=$(DOCKER_REGISTRY_ENDPOINT)/$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_VERSION)
```

This is a [recursively expanded variable](https://earthly.dev/blog/makefile-variables/), meaning its value is dynamically recalculated each time it is referenced, using the current values of any variables it depends on.

The recent transform refactoring PRs define the `DOCKER_IMAGE_NAME` variable in kfp_ray/Makefile as follows:

```bash
DOCKER_IMAGE_NAME = $(TRANSFORM_NAME)-$(TRANSFORM_RUNTIME)
```

Which is also recursively expanded variable, causing `DOCKER_REMOTE_IMAGE` to be as follows:
```bash
DOCKER_REMOTE_IMAGE=$(DOCKER_REGISTRY_ENDPOINT)/$(TRANSFORM_NAME)-$(TRANSFORM_RUNTIME):$(DOCKER_IMAGE_VERSION)
```

This explains why when executing `kind-load-image` target `DOCKER_REMOTE_IMAGE` equals to  `quay.io/dataprep1/data-prep-kit/ededup-ray:latest`. 
