### PR TITLE
Add image_pull_secrets paameter to add_settings_to_comp for kfp v2

### DIFF
--- a/kfp/kfp_support_lib/kfp_v2_workflow_support/src/workflow_support/compile_utils/component.py
+++ b/kfp/kfp_support_lib/kfp_v2_workflow_support/src/workflow_support/compile_utils/component.py
@@ -40,7 +40,7 @@ class ComponentUtils:
         task: dsl.PipelineTask,
         timeout: int,
         image_pull_policy: str = "IfNotPresent",
-        image_pull_secret: str = "",
+        image_pull_secrets: list = [],
         cache_strategy: bool = False,
     ) -> None:
         """
@@ -48,7 +48,7 @@ class ComponentUtils:
         :param task: kfp task
         :param timeout: timeout to set to the component in seconds
         :param image_pull_policy: pull policy to set to the component
-        :param image_pull_secret: Secret containing the credentials to pull the task image.
+        :param image_pull_secrets: list of secrets containing the credentials to pull the task image.
         :param cache_strategy: cache strategy
         """
 
@@ -96,8 +96,8 @@ class ComponentUtils:
         kubernetes.set_image_pull_policy(task, image_pull_policy)
         # image pull secret can only be set at the component level in kfp v2
         # see: https://github.com/kubeflow/pipelines/issues/11498
-        if image_pull_secret != "" and len(image_pull_secret) != 0:
-            kubernetes.set_image_pull_secrets(task, [image_pull_secret])
+        if len(image_pull_secrets) != 0:
+            kubernetes.set_image_pull_secrets(task, image_pull_secrets)
         # Set the timeout for the task to one day (in seconds)
         kubernetes.set_timeout(task, seconds=timeout)
         # Add tolerations if specified

--- a/kfp/kfp_support_lib/kfp_v2_workflow_support/src/workflow_support/compile_utils/component.py
+++ b/kfp/kfp_support_lib/kfp_v2_workflow_support/src/workflow_support/compile_utils/component.py
@@ -40,6 +40,7 @@ class ComponentUtils:
         task: dsl.PipelineTask,
         timeout: int,
         image_pull_policy: str = "IfNotPresent",
+        secret_name: str = "",
         cache_strategy: bool = False,
     ) -> None:
         """
@@ -92,6 +93,10 @@ class ComponentUtils:
         task.set_caching_options(enable_caching=cache_strategy)
         # image pull policy
         kubernetes.set_image_pull_policy(task, image_pull_policy)
+        # image pull secret can only be set at the component level in kfp v2
+        # see: https://github.com/kubeflow/pipelines/issues/11498
+        if secret_name != "" and len(secret_name) != 0:
+            kubernetes.set_image_pull_secrets(task, [secret_name])
         # Set the timeout for the task to one day (in seconds)
         kubernetes.set_timeout(task, seconds=timeout)
         # Add tolerations if specified

--- a/kfp/kfp_support_lib/kfp_v2_workflow_support/src/workflow_support/compile_utils/component.py
+++ b/kfp/kfp_support_lib/kfp_v2_workflow_support/src/workflow_support/compile_utils/component.py
@@ -40,7 +40,7 @@ class ComponentUtils:
         task: dsl.PipelineTask,
         timeout: int,
         image_pull_policy: str = "IfNotPresent",
-        secret_name: str = "",
+        image_pull_secret: str = "",
         cache_strategy: bool = False,
     ) -> None:
         """
@@ -48,6 +48,7 @@ class ComponentUtils:
         :param task: kfp task
         :param timeout: timeout to set to the component in seconds
         :param image_pull_policy: pull policy to set to the component
+        :param image_pull_secret: Secret containing the credentials to pull the task image.
         :param cache_strategy: cache strategy
         """
 
@@ -95,8 +96,8 @@ class ComponentUtils:
         kubernetes.set_image_pull_policy(task, image_pull_policy)
         # image pull secret can only be set at the component level in kfp v2
         # see: https://github.com/kubeflow/pipelines/issues/11498
-        if secret_name != "" and len(secret_name) != 0:
-            kubernetes.set_image_pull_secrets(task, [secret_name])
+        if image_pull_secret != "" and len(image_pull_secret) != 0:
+            kubernetes.set_image_pull_secrets(task, [image_pull_secret])
         # Set the timeout for the task to one day (in seconds)
         kubernetes.set_timeout(task, seconds=timeout)
         # Add tolerations if specified


### PR DESCRIPTION
## Why are these changes needed?

To address https://github.com/IBM/data-prep-kit/issues/914 a new param was added to `add_settings_to_component` function.


To pass the secret name the following param should be added to `add_settings_to_component` call:

```
ComponentUtils.add_settings_to_component(compute_exec_params, ONE_HOUR_SEC * 2, image_pull_secrets=["secret-name"])
```

Note: image_pull_secrets could not be a pipeline input parameter because they are of type `PipelineParameterChannel` so we get the following error when trying to use them:

```
  File "kfp/kfp_support_lib/kfp_v2_workflow_support/src/workflow_support/compile_utils/component.py", line 99, in add_settings_to_component
    if len(image_pull_secrets) != 0:
TypeError: object of type 'PipelineParameterChannel' has no len()
```
## Related issue number (if any).

#914
