### PR TITLE
Reorganized landing page readme and added readme to examples folder

### DIFF
--- a/ADVANCED.md
+++ b/ADVANCED.md
@@ -1,0 +1,55 @@
+
+<h1 align="center">Data Prep Kit for Advanced Users</h1>
+
+### Add your own transform
+
+At the core of the framework, is a data processing library, that provides a systematic way to implement the data processing modules. The library is python-based and enables the application of "transforms" to a one or more input data files to produce one or more output data files. We use the popular [parquet](https://arrow.apache.org/docs/python/parquet.html) format to store the data (code or language). 
+Every parquet file follows a set [schema](transforms/code/code2parquet/python/README.md). A user can use one or more transforms (or modules) as discussed above to process their data. 
+A transform can follow one of the two patterns: annotator or filter.
+
+- **Annotator** An annotator transform adds information during the processing by adding one more columns to the parquet files.
+The annotator design also allows a user to verify the results of the processing before the actual filtering of the data.
+
+- **Filter** A filter transform processes the data and outputs the transformed data, e.g., exact deduplication.
+A general purpose [SQL-based filter transform](transforms/universal/filter) enables a powerful mechanism for identifying columns and rows of interest for downstream processing.
+
+For a new module to be added, a user can pick the right design based on the processing to be applied. More details [here](transforms).
+
+One can leverage Python-based processing logic and the Data Processing Library to easily build and contribute new transforms. We have provided an [example transform](transforms/universal/noop) that can serve as a template to add new simple transforms. Follow the step by step [tutorial](data-processing-lib/doc/simplest-transform-tutorial.md) to help you add your own new transform. 
+
+For a deeper understanding of the library's architecture, its transforms, and available runtimes, we encourage the reader to consult the comprehensive [overview document](data-processing-lib/doc/overview.md) alongside dedicated sections on [transforms](data-processing-lib/doc/transforms.md) and [runtimes](data-processing-lib/doc/transform-runtimes.md).
+
+Additionally, check out our [video tutorial](https://www.youtube.com/watch?v=0WUMG6HIgMg) for a visual, example-driven guide on adding custom modules.
+
+
+## 💻 -> 🖥️☁️ From laptop to cluster <a name = "laptop_cluster"></a>
+Data-prep-kit provides the flexibility to transition your projects from proof-of-concept (PoC) stage to full-scale production mode, offering all the necessary tools to run your data transformations at high volume. In this section, we enable you how to run your transforms at scale and how to automate them. 
+
+### Scaling of Transforms
+
+To enable processing of large data volumes leveraging multi-mode clusters, [Ray](https://docs.ray.io/en/latest/index.html) 
+or [Spark](https://spark.apache.org) wrappers are provided, to readily scale out the Python implementations.
+
+A generalized workflow is shown [here](doc/data-processing.md).
+
+### Automation
+
+The toolkit also supports transform execution automation based on 
+[Kubeflow pipelines](https://www.kubeflow.org/docs/components/pipelines/v1/introduction/) (KFP),
+tested on a locally deployed [Kind cluster](https://kind.sigs.k8s.io/) and external OpenShift clusters. There is an 
+automation to create a Kind cluster and deploy all required components on it.
+The KFP implementation is based on the [KubeRay Operator](https://docs.ray.io/en/master/cluster/kubernetes/getting-started.html)
+for creating and managing the Ray cluster and [KubeRay API server](https://github.com/ray-project/kuberay/tree/master/apiserver)
+to interact with the KubeRay operator. An additional [framework](kfp/kfp_support_lib) along with several
+[kfp components](kfp/kfp_ray_components) is used to simplify the pipeline implementation.
+
+A simple transform pipeline [tutorial](kfp/doc/simple_transform_pipeline.md) explains the pipeline creation and execution. 
+In addition, if you want to combine several transformers in a single pipeline, you can look at [multi-steps pipeline](kfp/doc/multi_transform_pipeline.md) 
+
+When you finish working with the cluster, and want to clean up or destroy it. See the 
+[clean up the cluster](kfp/doc/setup.md#cleanup)
+
+
+### Run your first transform using command line options
+
+You can run transforms via docker image or using virtual environments. This [document](doc/quick-start/run-transform-venv.md) shows how to run a transform using virtual environment. You can follow this [document](doc/quick-start/run-transform-image.md) to run using docker image. 

--- a/ADVANCED.md
+++ b/ADVANCED.md
@@ -1,6 +1,8 @@
 
 <h1 align="center">Data Prep Kit for Advanced Users</h1>
 
+![alt text](doc/Data-prep-kit-diagram.png)
+
 ### Add your own transform
 
 At the core of the framework, is a data processing library, that provides a systematic way to implement the data processing modules. The library is python-based and enables the application of "transforms" to a one or more input data files to produce one or more output data files. We use the popular [parquet](https://arrow.apache.org/docs/python/parquet.html) format to store the data (code or language). 

--- a/ADVANCED.md
+++ b/ADVANCED.md
@@ -51,6 +51,20 @@ In addition, if you want to combine several transformers in a single pipeline, y
 When you finish working with the cluster, and want to clean up or destroy it. See the 
 [clean up the cluster](kfp/doc/setup.md#cleanup)
 
+### Using data from HuggingFace 
+
+If you wish to download and use real parquet data files from HuggingFace while testing any of the toolkit transforms, use HuggingFace [download APIs](https://huggingface.co/docs/huggingface_hub/en/guides/download) that provide caching and optimize the download process. Here is an example of the code needed to download a sample file: 
+
+ ```bash
+ !pip install --upgrade huggingface_hub
+from huggingface_hub import hf_hub_download
+import pandas as pd
+
+REPO_ID = "HuggingFaceFW/fineweb"
+FILENAME = "data/CC-MAIN-2013-20/000_00000.parquet"
+
+hf_hub_download(repo_id=REPO_ID, filename=FILENAME, repo_type="dataset")
+```
 
 ### Run your first transform using command line options
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 <h1 align="center">Data Prep Kit</h1>
 
+![alt text](doc/Data-prep-kit-diagram.png)
+
 <div align="center"> 
 
 <?  [![Status](https://img.shields.io/badge/status-active-success.svg)]() ?>
@@ -9,47 +11,23 @@
 <?  [![GitHub Pull Requests](https://img.shields.io/github/issues-pr/kylelobo/The-Documentation-Compendium.svg)](https://github.com/IBM/data-prep-kit/pulls) ?>
 </div> 
 
-Data Prep Kit is a community project to democratize and accelerate unstructured data preparation for LLM app developers. 
-With the explosive growth of LLM-enabled use cases, developers are faced with the enormous challenge of preparing use case-specific unstructured data to fine-tune, instruct-tune the LLMs or to build RAG applications for LLMs.
-As the variety of use cases grow, so does the need to support:
-
-- New ways of transforming the data to enhance the performance of the resulting LLMs for each specific use case.
-- A large variety in the scale of data to be processed, from laptop-scale to datacenter-scale
-- Support for different data modalities including language, code, vision, multimodal etc
-
-Data Prep Kit offers implementations of commonly needed data preparation steps, called *modules* or *transforms*, for both Code and Language modalities, with vision to extend to images, speech and multimodal data. 
-The goal is to offer high-level APIs for developers to quickly get started in working with their data, without needing expertise in the underlying runtimes and frameworks.
-
-![alt text](doc/Data-prep-kit-diagram.png)
-
-
-## 📝 Table of Contents
-
-- [About](#about)
-- [Getting Started](#gettingstarted)
-- [Scaling transforms from laptop to cluster](#laptop_cluster)
-- [Repository Use and Navigation](doc/repo.md)
-- [How to Contribute](CONTRIBUTING.md)
-- [Resources (papers, talks, presentations and tutorials)](resources.md)
-- [Citations](#citations)
-
 ## &#x1F4D6; About <a name = "about"></a>
 
-Data Prep Kit is a toolkit for streamlining data preparation for developers looking to build LLM-enabled applications via fine-tuning, RAG or instruction-tuning.
-Data Prep Kit contributes a set of modules that the developer can get started with to easily build data pipelines suitable for their use case.
-These modules have been tested while producing pre-training datasets for the [Granite open source LLM models](https://huggingface.co/ibm-granite).
-
-The modules are built on common frameworks (for Spark and Ray), called the *data processing library* that allows the developers to build new custom modules that readily scale across a variety of runtimes.
+Data Prep Kit is a community-driven project simplifying unstructured data preparation for LLM application development. It addresses the growing challenge of preparing diverse data (language, code, vision, multimodal) for fine-tuning, instruction-tuning, and RAG applications. 
 
 Features of the toolkit: 
 
-- It aims to accelerate unstructured data prep for the "long tail" of LLM use cases.
-- It offers a growing set of [module](transforms) implementations across multiple runtimes, targeting laptop-scale to datacenter-scale processing.
-- It provides a growing set of [sample data processing pipelines](examples) that can be used for real enterprise use cases.
-- It provides the [Data processing library](data-processing-lib/ray) to enable contribution of new custom modules targeting new use cases.
+- The kit provides growing set of pre-built [modules/transforms](transforms) with sample implementations across multiple runtimes, targeting laptop-scale to datacenter-scale processing.
+- These modules have been tested while producing pre-training datasets for the [Granite open source LLM models](https://huggingface.co/ibm-granite).
+- Data modalities supported _today_: Natural Language and Code.
+- Plug and play [complete data processing recipes](examples) that can be used for real enterprise use cases like RAG, fine-tuning etc.
+- [Data processing library](data-processing-lib/ray) to enable contribution of new custom modules. Check out [guidance](ADVANCED.md) for advanced users from adding your transform to scaling and automation.
+- How to [contribute](CONTRIBUTING.md).
 - It uses [Kubeflow Pipelines](https://www.kubeflow.org/docs/components/pipelines/v1/introduction/)-based [workflow automation](kfp/doc/simple_transform_pipeline.md).
+- The modules are built on common frameworks for Python, Spark and Ray runtimes.
+- [Repository Structure and Use](doc/repo.md).
+- Access [Resources (papers, talks, presentations and tutorials)](resources.md).
 
-Data modalities supported _today_: Code and Natural Language.
 
 ## &#x1F680; Getting Started <a name = "gettingstarted"></a>
 
@@ -124,58 +102,6 @@ The matrix below shows the the combination of modules and supported runtimes. Al
 
 
 Contributors are welcome to add new modules to expand to other data modalities as well as add runtime support for existing modules!
-
-### Add your own transform
-
-At the core of the framework, is a data processing library, that provides a systematic way to implement the data processing modules. The library is python-based and enables the application of "transforms" to a one or more input data files to produce one or more output data files. We use the popular [parquet](https://arrow.apache.org/docs/python/parquet.html) format to store the data (code or language). 
-Every parquet file follows a set [schema](transforms/code/code2parquet/python/README.md). A user can use one or more transforms (or modules) as discussed above to process their data. 
-A transform can follow one of the two patterns: annotator or filter.
-
-- **Annotator** An annotator transform adds information during the processing by adding one more columns to the parquet files.
-The annotator design also allows a user to verify the results of the processing before the actual filtering of the data.
-
-- **Filter** A filter transform processes the data and outputs the transformed data, e.g., exact deduplication.
-A general purpose [SQL-based filter transform](transforms/universal/filter) enables a powerful mechanism for identifying columns and rows of interest for downstream processing.
-
-For a new module to be added, a user can pick the right design based on the processing to be applied. More details [here](transforms).
-
-One can leverage Python-based processing logic and the Data Processing Library to easily build and contribute new transforms. We have provided an [example transform](transforms/universal/noop) that can serve as a template to add new simple transforms. Follow the step by step [tutorial](data-processing-lib/doc/simplest-transform-tutorial.md) to help you add your own new transform. 
-
-For a deeper understanding of the library's architecture, its transforms, and available runtimes, we encourage the reader to consult the comprehensive [overview document](data-processing-lib/doc/overview.md) alongside dedicated sections on [transforms](data-processing-lib/doc/transforms.md) and [runtimes](data-processing-lib/doc/transform-runtimes.md).
-
-Additionally, check out our [video tutorial](https://www.youtube.com/watch?v=0WUMG6HIgMg) for a visual, example-driven guide on adding custom modules.
-
-
-## 💻 -> 🖥️☁️ From laptop to cluster <a name = "laptop_cluster"></a>
-Data-prep-kit provides the flexibility to transition your projects from proof-of-concept (PoC) stage to full-scale production mode, offering all the necessary tools to run your data transformations at high volume. In this section, we enable you how to run your transforms at scale and how to automate them. 
-
-### Scaling of Transforms
-
-To enable processing of large data volumes leveraging multi-mode clusters, [Ray](https://docs.ray.io/en/latest/index.html) 
-or [Spark](https://spark.apache.org) wrappers are provided, to readily scale out the Python implementations.
-
-A generalized workflow is shown [here](doc/data-processing.md).
-
-### Automation
-
-The toolkit also supports transform execution automation based on 
-[Kubeflow pipelines](https://www.kubeflow.org/docs/components/pipelines/v1/introduction/) (KFP),
-tested on a locally deployed [Kind cluster](https://kind.sigs.k8s.io/) and external OpenShift clusters. There is an 
-automation to create a Kind cluster and deploy all required components on it.
-The KFP implementation is based on the [KubeRay Operator](https://docs.ray.io/en/master/cluster/kubernetes/getting-started.html)
-for creating and managing the Ray cluster and [KubeRay API server](https://github.com/ray-project/kuberay/tree/master/apiserver)
-to interact with the KubeRay operator. An additional [framework](kfp/kfp_support_lib) along with several
-[kfp components](kfp/kfp_ray_components) is used to simplify the pipeline implementation.
-
-A simple transform pipeline [tutorial](kfp/doc/simple_transform_pipeline.md) explains the pipeline creation and execution. 
-In addition, if you want to combine several transformers in a single pipeline, you can look at [multi-steps pipeline](kfp/doc/multi_transform_pipeline.md) 
-
-When you finish working with the cluster, and want to clean up or destroy it. See the 
-[clean up the cluster](kfp/doc/setup.md#cleanup)
-
-### Run your first transform using command line options
-
-You can run transforms via docker image or using virtual environments. This [document](doc/quick-start/run-transform-venv.md) shows how to run a transform using virtual environment. You can follow this [document](doc/quick-start/run-transform-image.md) to run using docker image. 
 
 ## Citations <a name = "citations"></a>
 

--- a/README.md
+++ b/README.md
@@ -54,6 +54,10 @@ For advanced users, [here](ADVANCED.md) is more information for adding your own 
 
 Please click [here](doc/quick-start/quick-start.md#running-transforms-on-windows) for guidance on how to run transforms in Windows.
 
+### Using HuggingFace data files 
+
+All the transforms in the kit include small sample data files for testing, but advanced users who want to download real data files from HuggingFace and use them in testing, can refer to [this](ADVANCED.md#using-data-from-huggingface). 
+
 
 ## Current list of transforms <a name="table"></a>
 The matrix below shows the the combination of modules and supported runtimes. All the modules can be accessed [here](transforms) and can be combined to form data processing pipelines, as shown in the [examples](examples) folder. 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 <h1 align="center">Data Prep Kit</h1>
 
-![alt text](doc/Data-prep-kit-diagram.png)
+<?[alt text](doc/Data-prep-kit-diagram.png)>
 
 <div align="center"> 
 
@@ -11,61 +11,52 @@
 <?  [![GitHub Pull Requests](https://img.shields.io/github/issues-pr/kylelobo/The-Documentation-Compendium.svg)](https://github.com/IBM/data-prep-kit/pulls) ?>
 </div> 
 
-## &#x1F4D6; About <a name = "about"></a>
+Data Prep Kit is a community-driven project that simplifies unstructured data preparation for LLM application development. It addresses the growing challenge of preparing diverse data (language, code, vision, multimodal) for fine-tuning, instruction-tuning, and RAG applications. The modules in the kit have been tested in producing pre-training datasets for the [Granite open source LLM models](https://huggingface.co/ibm-granite).
 
-Data Prep Kit is a community-driven project simplifying unstructured data preparation for LLM application development. It addresses the growing challenge of preparing diverse data (language, code, vision, multimodal) for fine-tuning, instruction-tuning, and RAG applications. 
+## Features <a name = "features"></a>
 
-Features of the toolkit: 
+- The kit provides a growing set of [modules/transforms](#table) targeting laptop-scale to datacenter-scale processing.
+- The data modalities supported _today_ are: Natural Language and Code.
+- The modules are built on common frameworks for Python, Ray and Spark runtimes for scaling up data processing.
+- The kit provides a framework for developing custom transforms for processing parquet files. 
+- The kit uses [Kubeflow Pipelines](https://www.kubeflow.org/docs/components/pipelines/v1/introduction/)-based [workflow automation](kfp/doc/simple_transform_pipeline.md).
 
-- The kit provides growing set of pre-built [modules/transforms](transforms) with sample implementations across multiple runtimes, targeting laptop-scale to datacenter-scale processing.
-- These modules have been tested while producing pre-training datasets for the [Granite open source LLM models](https://huggingface.co/ibm-granite).
-- Data modalities supported _today_: Natural Language and Code.
-- Plug and play [complete data processing recipes](examples) that can be used for real enterprise use cases like RAG, fine-tuning etc.
-- [Data processing library](data-processing-lib/ray) to enable contribution of new custom modules. Check out [guidance](ADVANCED.md) for advanced users from adding your transform to scaling and automation.
-- How to [contribute](CONTRIBUTING.md).
-- It uses [Kubeflow Pipelines](https://www.kubeflow.org/docs/components/pipelines/v1/introduction/)-based [workflow automation](kfp/doc/simple_transform_pipeline.md).
-- The modules are built on common frameworks for Python, Spark and Ray runtimes.
-- [Repository Structure and Use](doc/repo.md).
-- Access [Resources (papers, talks, presentations and tutorials)](resources.md).
+## Installation
 
+The latest version of the Data Prep Kit is available on PyPi for Python 3.10, 3.11 or 3.12. It can be installed using: 
+
+```bash
+pip install  'data-prep-toolkit-transforms[all]'
+```
+
+This will install all available transforms. 
+
+For guidance on creating the virtual environment for installing the data prep kit, click [here](doc/quick-start/quick-start.md).
 
 ## &#x1F680; Getting Started <a name = "gettingstarted"></a>
 
 ### Fastest way to experience Data Prep Kit
 
-With no setup necessary, let's use a Google Colab friendly notebook to try Data Prep Kit. This is a simple transform to extract content from PDF files: [examples/notebooks/Run_your_first_transform_colab.ipynb](examples/notebooks/Run_your_first_transform_colab.ipynb)  | [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/IBM/data-prep-kit/blob/dev/examples/notebooks/Run_your_first_transform_colab.ipynb). ([Here](doc/google-colab.md) are some tips for running Data Prep Kit transforms on Google Colab. For this simple example, these tips are either already taken care of, or are not needed.)  The same notebook can be downloaded and run on the local machine, without cloning the repo or any other setup. For additional guidance on setting up Jupyter lab, click [here](doc/quick-start/quick-start.md#jupyter). 
+With no setup necessary, let's use a Google Colab friendly notebook to try Data Prep Kit. This is a simple transform to extract content from PDF files: [examples/notebooks/Run_your_first_transform_colab.ipynb](examples/notebooks/Run_your_first_transform_colab.ipynb)  | [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/IBM/data-prep-kit/blob/dev/examples/notebooks/Run_your_first_transform_colab.ipynb). ([Here](doc/google-colab.md) are some tips for running Data Prep Kit transforms on Google Colab. For this simple example, these tips are either already taken care of, or are not needed.)  The same notebook can be downloaded and run on the local machine, without cloning the repo or any other setup. 
 
-### Install data prep kit from PyPi
-
-The latest version of the Data Prep Kit is available on PyPi for Python 3.10, 3.11 or 3.12. It can be installed using: 
-
-```bash
-pip install  'data-prep-toolkit-transforms[ray,all]'
-```
-
-The above installs all available transforms. 
-
-When installing select transforms, users can specify the name of the transform in the pip command, rather than [all]. For example, use the following command to install only the pdf2parquet transform:
-```bash
-pip install 'data-prep-toolkit-transforms[pdf2parquet]'
-```
-For additional guidance on creating the virtual environment for installing the data prep kit, click [here](doc/quick-start/quick-start.md#conda).
-
-### Run your first data prep pipeline
+### Examples
 
 Now that you have run a single transform, the next step is to explore how to put these transforms 
-together to run a data prep pipeline for an end to end use case like fine tuning a model or building 
-a RAG application. 
-This [notebook](examples/notebooks/fine%20tuning/code/sample-notebook.ipynb) gives an example of 
-how to build an end to end data prep pipeline for fine tuning for code LLMs. 
-You can also explore how to build a RAG pipeline [here](examples/notebooks/rag).
+together to run a data prep pipeline for end to end real enterprise use cases like fine-tuning a model or building a RAG application. 
+
+We have a complete set of data processing [recipes](examples) for such use cases. 
+
+We also have [a developer tutorial](doc/quick-start/contribute-your-own-transform.md) for contributing a new transform to the kit. 
+
+For advanced users, [here](ADVANCED.md) is more information for adding your own transform, its scaling and automation. Also,repository structure and use are discussed [here](doc/repo.md).
 
 ### Windows users
 
-Please click [here](doc/quick-start/quick-start.md#running-transforms-on-windows) for guidance on how to run transforms in Windows. 
+Please click [here](doc/quick-start/quick-start.md#running-transforms-on-windows) for guidance on how to run transforms in Windows.
 
-### Current list of transforms 
-The matrix below shows the the combination of modules and supported runtimes. All the modules can be accessed [here](transforms) and can be combined to form data processing pipelines, as shown in the [examples](examples/notebooks) folder. 
+
+## Current list of transforms <a name="table"></a>
+The matrix below shows the the combination of modules and supported runtimes. All the modules can be accessed [here](transforms) and can be combined to form data processing pipelines, as shown in the [examples](examples) folder. 
 
 
 | Modules                                                                              |    Python-only     |        Ray         |       Spark        |     KFP on Ray     |
@@ -100,10 +91,16 @@ The matrix below shows the the combination of modules and supported runtimes. Al
 | [License Select Annotation](transforms/code/license_select/python/README.md)         | :white_check_mark: | :white_check_mark: |                    | :white_check_mark: |
 | [Code profiler](transforms/code/code_profiler/README.md)                             | :white_check_mark: | :white_check_mark: |                    |  |
 
+## Contributing
+Contributors are welcome to add new modules to expand to other data modalities as well as add runtime support for existing modules! Please read [this](CONTRIBUTING.md) for details.
 
-Contributors are welcome to add new modules to expand to other data modalities as well as add runtime support for existing modules!
+## Get help and support
+Please feel free to connect with us using the [discussion](https://github.com/IBM/data-prep-kit/discussions) section.
 
-## Citations <a name = "citations"></a>
+## Resources
+[Papers, talks, presentations and tutorials](resources.md).
+
+## Citation <a name = "citations"></a>
 
 If you use Data Prep Kit in your research, please cite our paper:
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,13 @@
+
+<h1 align="center">About Data Prep Kit Recipes</h1>
+
+Welcome to cooking with Data Prep Kit. Here we share some of our most asked, searched and shared Data Prep Kit recipes for processing unstructued and structured data for plethora of use cases like RAG, finetuning etc. along with examples of KFP workflows.
+
+ - [**Data Files**](examples/data-files/)
+ - [**Introductory Recipe Notebook to get started**](examples/notebooks/Run_your_first_transform_colab.ipynb)
+ - [**Recipes for Processing Code and Language Data for Finetuning LLMs**](examples/notebooks/fine tuning)
+ - [**Recipe for building RAG system using pdf data**](examples/notebooks/rag)
+ - [**Recipe for building RAG system using html data**](examples/notebooks/rag-html-1)
+ - [**Recipe for curating customer service data for HAP**](examples/notebooks/hap)
+ - [**Recipe for curating customer service data for PII**](examples/notebooks/PII)
+ - [**KFP Pipeline Walkthrough**](kfp-pipelines/superworkflows)

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,13 +1,13 @@
 
 <h1 align="center">About Data Prep Kit Recipes</h1>
 
-Welcome to cooking with Data Prep Kit. Here we share some of our most asked, searched and shared Data Prep Kit recipes for processing unstructued and structured data for plethora of use cases like RAG, finetuning etc. along with examples of KFP workflows.
+Welcome to cooking with Data Prep Kit. Here we share some of our most asked, searched and shared Data Prep Kit recipes for processing unstructured and structured data for plethora of use cases like RAG, fine-tuning etc. along with examples of KFP workflows.
 
- - [**Data Files**](examples/data-files/)
- - [**Introductory Recipe Notebook to get started**](examples/notebooks/Run_your_first_transform_colab.ipynb)
- - [**Recipes for Processing Code and Language Data for Finetuning LLMs**](<examples/notebooks/fine tuning>)
- - [**Recipe for building RAG system using pdf data**](examples/notebooks/rag)
- - [**Recipe for building RAG system using html data**](examples/notebooks/rag-html-1)
- - [**Recipe for curating customer service data for HAP**](examples/notebooks/hap)
- - [**Recipe for curating customer service data for PII**](examples/notebooks/PII)
+ - [**Data Files**](./data-files/)
+ - [**Introductory Recipe Notebook to get started**](notebooks/Run_your_first_transform_colab.ipynb)
+ - [**Recipes for Processing Code and Language Data for Finetuning LLMs**](./notebooks/fine%20tuning/code/)
+ - [**Recipe for building RAG system using pdf data**](./notebooks/rag/)
+ - [**Recipe for building RAG system using html data**](./notebooks/rag-html-1/)
+ - [**Recipe for curating customer service data for HAP**](./notebooks/hap/)
+ - [**Recipe for curating customer service data for PII**](./notebooks/PII/)
  - [**KFP Pipeline Walkthrough**](kfp-pipelines/superworkflows)

--- a/examples/README.md
+++ b/examples/README.md
@@ -5,7 +5,7 @@ Welcome to cooking with Data Prep Kit. Here we share some of our most asked, sea
 
  - [**Data Files**](examples/data-files/)
  - [**Introductory Recipe Notebook to get started**](examples/notebooks/Run_your_first_transform_colab.ipynb)
- - [**Recipes for Processing Code and Language Data for Finetuning LLMs**](examples/notebooks/fine tuning)
+ - [**Recipes for Processing Code and Language Data for Finetuning LLMs**](<examples/notebooks/fine tuning>)
  - [**Recipe for building RAG system using pdf data**](examples/notebooks/rag)
  - [**Recipe for building RAG system using html data**](examples/notebooks/rag-html-1)
  - [**Recipe for curating customer service data for HAP**](examples/notebooks/hap)


### PR DESCRIPTION
## Why are these changes needed?
As per  our discussions - simplified main landing page read me and added read me to recipe/examples folder

## Related issue number (if any).
https://github.com/IBM/data-prep-kit/issues/872


