### PR TITLE
KFP v2: Fix wrong Ray cluster name 

### DIFF
--- a/kfp/kfp_support_lib/shared_workflow_support/src/runtime_utils/kfp_utils.py
+++ b/kfp/kfp_support_lib/shared_workflow_support/src/runtime_utils/kfp_utils.py
@@ -84,7 +84,14 @@ class KFPUtils:
         if run_id == "":
             logger.error("Run ID must not be provided")
             sys.exit(1)
-        return f"{ray_name[:9]}-{run_id[:5]}"
+        else:
+            ray_name_suffix = run_id[:5]
+            ray_name_suffix = ray_name_suffix.replace("_", "-").lower()
+            pattern = r"[^a-zA-Z0-9-]"  # the ray_name cannot contain upper case here, but leave it just in case.
+            ray_name_suffix = re.sub(pattern, "", ray_name_suffix)
+            ray_name_suffix = ray_name_suffix.strip("-")  # remove any dash char that appears at the end
+
+        return f"{ray_name[:9]}-{ray_name_suffix}"
 
     @staticmethod
     def dict_to_req(d: dict[str, Any], executor: str = "transformer_launcher.py") -> str:


### PR DESCRIPTION
## Why are these changes needed?

After https://github.com/IBM/data-prep-kit/pull/956, what a Ray cluster name is concatenation of a user provided string and the pipeline name, the result string can illegal name for Ray cluster and its Service.


## Related issue number (if any).
#988

