### PR TITLE
Update transform.py

### DIFF
--- a/transforms/universal/hap/dpk_hap/transform.py
+++ b/transforms/universal/hap/dpk_hap/transform.py
@@ -38,7 +38,7 @@ class HAPTransform(AbstractTableTransform):
         self.max_length = config.get("max_length", 512)
         self.batch_size = config.get("batch_size", 128)
         self.tokenizer = AutoTokenizer.from_pretrained(self.model_name_or_path)
-        self.model = AutoModelForSequenceClassification.from_pretrained(self.model_name_or_path)
+        self.model = AutoModelForSequenceClassification.from_pretrained(self.model_name_or_path).to(device)
 
     def _apply_model(self, data: list, batch_size: int) -> list[float]:
         num_batches = len(data) // batch_size


### PR DESCRIPTION
added safely .to(device) to model since the script already defines the device on line 24 (rather than using .to('cuda')) @shahrokhDaijavad (@touma-I )

## Why are these changes needed?
to fix gpu usage error in the model in response to the request [here](https://github.com/IBM/data-prep-kit/issues/1047#issuecomment-2660306794)

#1047


