### PR TITLE
Update transform.py

### DIFF
--- a/transforms/universal/hap/dpk_hap/transform.py
+++ b/transforms/universal/hap/dpk_hap/transform.py
@@ -69,7 +69,7 @@ class HAPTransform(AbstractTableTransform):
         doc_scores = []
         for i in range(nb_doc):
             temp = [score for idx, score in zip(sent_ids, sent_scores) if i == idx]
-            doc_scores.append(max(temp))
+            doc_scores.append(max(temp, default=-1))
         return doc_scores
 
     def transform(self, table: pa.Table, file_name: str = None) -> tuple[list[pa.Table], dict[str, Any]]:

--- a/transforms/universal/hap/dpk_hap/transform.py
+++ b/transforms/universal/hap/dpk_hap/transform.py
@@ -69,7 +69,7 @@ class HAPTransform(AbstractTableTransform):
         doc_scores = []
         for i in range(nb_doc):
             temp = [score for idx, score in zip(sent_ids, sent_scores) if i == idx]
-            doc_scores.append(max(temp, default=-1))
+            doc_scores.append(max(temp, default=0))
         return doc_scores
 
     def transform(self, table: pa.Table, file_name: str = None) -> tuple[list[pa.Table], dict[str, Any]]:

--- a/transforms/universal/hap/dpk_hap/transform.py
+++ b/transforms/universal/hap/dpk_hap/transform.py
@@ -69,7 +69,7 @@ class HAPTransform(AbstractTableTransform):
         doc_scores = []
         for i in range(nb_doc):
             temp = [score for idx, score in zip(sent_ids, sent_scores) if i == idx]
-            doc_scores.append(max(temp, default=0))
+            doc_scores.append(max(temp, default=0)) #If the document is empty, the HAP score will be set to 0 since no HAP content is detected.
         return doc_scores
 
     def transform(self, table: pa.Table, file_name: str = None) -> tuple[list[pa.Table], dict[str, Any]]:

--- a/transforms/universal/hap/dpk_hap/transform.py
+++ b/transforms/universal/hap/dpk_hap/transform.py
@@ -68,6 +68,7 @@ class HAPTransform(AbstractTableTransform):
     def _apply_aggregate(self, nb_doc: int, sent_scores: list[float], sent_ids: list[int]) -> list[float]:
         doc_scores = []
         for i in range(nb_doc):
+           # Compile a list of hap score for each sentence in the document. IF the document is empty then zero out the    final score.
             temp = [score for idx, score in zip(sent_ids, sent_scores) if i == idx]
             doc_scores.append(max(temp, default=0)) #If the document is empty, the HAP score will be set to 0 since no HAP content is detected.
         return doc_scores


### PR DESCRIPTION
fixed error when `contents` column is empty

## Why are these changes needed?
To handle cases where the contents field may be empty when processing a large number of Parquet files using HAP transform

#1048 


