### PR TITLE
Fix PDF with RAG url in readme

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -6,7 +6,7 @@ Welcome to cooking with Data Prep Kit. Here we share some of our most asked, sea
  - [**Data Files**](./data-files/)
  - [**Introductory Recipe Notebook to get started**](notebooks/Run_your_first_transform_colab.ipynb)
  - [**Recipes for Processing Code and Language Data for Finetuning LLMs**](./notebooks/fine%20tuning/code/)
- - [**Recipe for building RAG system using pdf data**](./notebooks/rag/)
+ - [**Recipe for building RAG system using pdf data**](./notebooks/rag-pdf-1)
  - [**Recipe for building RAG system using html data**](./notebooks/rag-html-1/)
  - [**Recipe for curating customer service data for HAP**](./notebooks/hap/)
  - [**Recipe for curating customer service data for PII**](./notebooks/PII/)


### PR DESCRIPTION
Fix PDF with RAG url in readme

## Why are these changes needed?
The readme in examples/ dir has a broken link for PDF-with-RAG

## Related issue number (if any).


