### PR TITLE
Add Supported Languages Table to Lang_id transform

### DIFF
--- a/.github/workflows/test-language-lang_id-kfp.yml
+++ b/.github/workflows/test-language-lang_id-kfp.yml
@@ -46,8 +46,6 @@ concurrency:
 jobs:
     test-kfp-v1:
         runs-on: ubuntu-22.04
-        env:
-            HF_READ_ACCESS_TOKEN: ${{ secrets.HF_READ_ACCESS_TOKEN }}
         steps:
             - name: Checkout
               uses: actions/checkout@v4

--- a/.github/workflows/test-language-lang_id-kfp.yml
+++ b/.github/workflows/test-language-lang_id-kfp.yml
@@ -46,6 +46,8 @@ concurrency:
 jobs:
     test-kfp-v1:
         runs-on: ubuntu-22.04
+        env:
+            HF_READ_ACCESS_TOKEN: ${{ secrets.HF_READ_ACCESS_TOKEN }}
         steps:
             - name: Checkout
               uses: actions/checkout@v4

--- a/.github/workflows/test-language-lang_id.yml
+++ b/.github/workflows/test-language-lang_id.yml
@@ -70,8 +70,6 @@ jobs:
     test-src:
         runs-on: ubuntu-22.04
         env:
-            DOCKER_REGISTRY_USER: ${{ secrets.DOCKER_REGISTRY_USER }}
-            DOCKER_REGISTRY_KEY: ${{ secrets.DOCKER_REGISTRY_KEY }}
             HF_READ_ACCESS_TOKEN: ${{ secrets.HF_READ_ACCESS_TOKEN }}
         steps:
             - name: Checkout
@@ -79,7 +77,6 @@ jobs:
             - name: Free up space in github runner
               # Free space as indicated here : https://github.com/actions/runner-images/issues/2840#issuecomment-790492173
               run: |
-                  printenv
                   df -h
                   sudo rm -rf "/usr/local/share/boost"
                   sudo rm -rf "$AGENT_TOOLSDIRECTORY"

--- a/.github/workflows/test-language-lang_id.yml
+++ b/.github/workflows/test-language-lang_id.yml
@@ -69,12 +69,17 @@ jobs:
                   echo "publish_images=$publish_images" >> "$GITHUB_OUTPUT"
     test-src:
         runs-on: ubuntu-22.04
+        env:
+            DOCKER_REGISTRY_USER: ${{ secrets.DOCKER_REGISTRY_USER }}
+            DOCKER_REGISTRY_KEY: ${{ secrets.DOCKER_REGISTRY_KEY }}
+            HF_READ_ACCESS_TOKEN: ${{ secrets.HF_READ_ACCESS_TOKEN }}
         steps:
             - name: Checkout
               uses: actions/checkout@v4
             - name: Free up space in github runner
               # Free space as indicated here : https://github.com/actions/runner-images/issues/2840#issuecomment-790492173
               run: |
+                  printenv
                   df -h
                   sudo rm -rf "/usr/local/share/boost"
                   sudo rm -rf "$AGENT_TOOLSDIRECTORY"

--- a/transforms/language/lang_id/README.md
+++ b/transforms/language/lang_id/README.md
@@ -9,7 +9,7 @@ This transform will identify language of each text with confidence score with fa
 ## Contributors
 
 - Daiki Tsuzuku (dtsuzuku@jp.ibm.com)
-- Ryan Gordon (Ryan.Gordon@ibm.com)
+- Shahrokh Daijavad (shahrokh@us.ibm.com)
 
 ## Configuration and command line Options
 

--- a/transforms/language/lang_id/README.md
+++ b/transforms/language/lang_id/README.md
@@ -6,6 +6,11 @@ Please see the set of [transform project conventions](../../README.md#transform-
 ## Summary 
 This transform will identify language of each text with confidence score with fasttext language identification model. [ref](https://huggingface.co/facebook/fasttext-language-identification)
 
+## Contributors
+
+- Daiki Tsuzuku (dtsuzuku@jp.ibm.com)
+- Ryan Gordon (Ryan.Gordon@ibm.com)
+
 ## Configuration and command line Options
 
 The set of dictionary keys holding [LangIdentificationTransform](dpk_lang_id/transform.py) 

--- a/transforms/language/lang_id/README.md
+++ b/transforms/language/lang_id/README.md
@@ -56,6 +56,32 @@ Please see the set of
 for details on general project conventions, transform configuration,
 testing and IDE set up.
 
+# Supported Languages
+| Supported Languages |                     |                     |                     |                     |                     |                     |                     |
+| :-----------------: | :-----------------: | :-----------------: | :-----------------: | :-----------------: | :-----------------: | :-----------------: | :-----------------: |
+| Afrikaans           | Buriat              | Basque              | Indonesian          | Limburgish          | Neapolitan          | Rusyn               | Tagalog             |
+| Alemannic           | Catalan             | Persian             | Interlingue         | Lombard             | Low German          | Sanskrit            | Turkish             |
+| Amharic             | Chavacano           | Finnish             | Ilokano             | Lao                 | Nepali              | Yakut               | Tatar               |
+| Aragonese           | Chechen             | French              | Ido                 | Northern Luri       | Nepal Bhasa         | Sardinian           | Tuvan               |
+| Arabic              | Cebuano             | Northern Frisian    | Icelandic           | Lithuanian          | Dutch               | Sicilian            | Uighur              |
+| Egyptian Arabic     | Central Kurdish     | Western Frisian     | Italian             | Latvian             | Norwegian Nynorsk   | Scots               | Ukrainian           |
+| Assamese            | Corsican            | Irish               | Japanese            | Maithili            | Norwegian           | Sindhi              | Urdu                |
+| Asturian            | Czech               | Scottish Gaelic     | Lojban              | Malagasy            | Occitan             | Serbo-Croatian      | Uzbek               |
+| Avaric              | Chuvash             | Galician            | Javanese            | Eastern Mari        | Odia                | Sinhala             | Venetian            |
+| Azerbaijani         | Welsh               | Guarani             | Georgian            | Min                 | Ossetian            | Slovak              | Veps                |
+| South Azerbaijani   | Danish              | Goan Konkani        | Kazakh              | Macedonian          | Punjabi             | Slovenian           | Vietnamese          |
+| Bashkir             | German              | Gujarati            | Central Khmer       | Malayalam           | Kapampangan         | Somali              | West Flemish        |
+| Bavarian            | Dimli               | Manx                | Kannada             | Mongolian           | Palatine            | Albanian            | Volapük             |
+| Central Bikol       | Lower Sorbian       | Hebrew              | Korean              | Marathi             | Polish              | Serbian             | Walloon             |
+| Belarusian          | Doteli              | Hindi               | Karachay-Balkar     | Hill Mari           | Piedmontese         | Sundanese           | Waray               |
+| Bulgarian           | Divehi              | Fiji Hindi          | Kurdish             | Malay               | Western Punjabi     | Swedish             | Wu Chinese          |
+| Bihari languages    | Greek               | Croatian            | Komi                | Maltese             | Pashto              | Swahili             | Kalmyk              |
+| Bengali             | Emilian-Romagnol    | Upper Sorbian       | Cornish             | Mirandese           | Portuguese          | Tamil               | Extensible Music Format |
+| Tibetan             | English             | Haitian Creole      | Kyrgyz              | Burmese             | Quechua             | Telugu              | Yiddish             |
+| Bishnupriya Manipuri| Esperanto           | Hungarian           | Latin               | Asaro'o             | Romansh             | Tajik               | Yoruba              |
+| Breton              | Spanish             | Armenian            | Luxembourgish       | Mazandarani         | Romanian            | Thai                | Yue                 |
+| Bosnian             | Estonian            | Interlingua         | Lezgian             | Nahuatl             | Russian             | Turkmen             | Chinese             |
+
 ## Summary 
 This project wraps the language identification transform with a Ray runtime.
 

--- a/transforms/language/lang_id/README.md
+++ b/transforms/language/lang_id/README.md
@@ -55,37 +55,13 @@ To use the transform image to transform your data, please refer to the
 [running images quickstart](../../../doc/quick-start/run-transform-image.md),
 substituting the name of this transform image and runtime as appropriate.
 
+
+
 # Language Identification Ray Transform 
 Please see the set of
 [transform project conventions](../../README.md#transform-project-conventions)
 for details on general project conventions, transform configuration,
 testing and IDE set up.
-
-# Supported Languages
-|                     |                     |                     | Supported           | Languages           |    |  |  |
-| :-----------------: | :-----------------: | :-----------------: | :-----------------: | :-----------------: | :-----------------: | :-----------------: | :-----------------: |
-|Afrikaans 	|Buriat 	|Emilian-Romagnol 	|Ilokano 	|Lithuanian 	|Northern Frisian 	|Scottish Gaelic 	|Turkmen | 
-|Albanian 	|Burmese 	|English 	|Indonesian 	|Lojban 	|Northern Luri 	|Serbian 	|Tuvan |
-|Alemannic 	|Catalan 	|Esperanto 	|Interlingua 	|Lombard 	|Norwegian 	|Serbo-Croatian 	|Uighur |
-|Amharic 	|Cebuano 	|Estonian 	|Interlingue 	|Low German 	|Norwegian Nynorsk 	|Sicilian 	|Ukrainian |
-|Arabic 	|Central Bikol 	|Extensible Music Format	|Irish 	|Lower Sorbian 	|Occitan 	|Sindhi 	|Upper Sorbian |
-|Aragonese 	|Central Khmer 	|Fiji Hindi 	|Italian 	|Luxembourgish 	|Odia 	|Sinhala 	|Urdu  |
-|Armenian 	|Central Kurdish 	|Finnish 	|Japanese 	|Macedonian 	|Ossetian 	|Slovak 	|Uzbek  |
-|Asaro'o 	|Chavacano 	|French 	|Javanese 	|Maithili 	|Palatine 	|Slovenian 	|Venetian |
-|Assamese 	|Chechen 	|Galician 	|Kalmyk	|Malagasy 	|Pashto 	|Somali 	|Veps |
-|Asturian 	|Chinese	|Georgian 	|Kannada 	|Malay 	|Persian 	|South Azerbaijani 	|Vietnamese |
-|Avaric 	|Chuvash 	|German 	|Kapampangan 	|Malayalam 	|Piedmontese 	|Spanish 	|Volapük
-|Azerbaijani 	|Cornish 	|Goan Konkani 	|Karachay-Balkar 	|Maltese 	|Polish 	|Sundanese 	|Walloon|
-|Bashkir 	|Corsican 	|Greek 	|Kazakh 	|Manx 	|Portuguese 	|Swahili 	|Waray |
-|Basque 	|Croatian 	|Guarani 	|Komi 	|Marathi 	|Punjabi 	|Swedish 	|Welsh |
-|Bavarian 	|Czech 	|Gujarati 	|Korean 	|Mazandarani 	|Quechua 	|Tagalog	|West Flemish |
-|Belarusian 	|Danish 	|Haitian Creole 	|Kurdish 	|Min 	|Romanian 	|Tajik 	|Western Frisian |
-|Bengali 	|Dimli 	|Hebrew 	|Kyrgyz 	|Mirandese 	|Romansh 	|Tamil 	|Western Punjabi |
-|Bihari languages 	|Divehi 	|Hill Mari 	|Lao 	|Mongolian 	|Russian 	|Tatar	|Wu Chinese |
-|Bishnupriya Manipuri 	|Doteli 	|Hindi 	|Latin 	|Nahuatl 	|Rusyn 	|Telugu 	|Yakut |
-|Bosnian 	|Dutch 	|Hungarian 	|Latvian 	|Neapolitan 	|Sanskrit 	|Thai 	|Yiddish |
-|Breton 	|Eastern Mari 	|Icelandic 	|Lezgian 	|Nepal Bhasa 	|Sardinian 	|Tibetan 	|Yoruba |
-|Bulgarian 	|Egyptian Arabic 	|Ido 	|Limburgish 	|Nepali 	|Scots 	|Turkish	|Yue |
 
 ## Summary 
 This project wraps the language identification transform with a Ray runtime.
@@ -104,3 +80,34 @@ the set of
 To use the transform image to transform your data, please refer to the 
 [running images quickstart](../../../doc/quick-start/run-transform-image.md),
 substituting the name of this transform image and runtime as appropriate.
+
+# Supported Languages
+<style>
+table, th, td {
+   border: none;
+}
+</style>
+|                     |                     |                     |            |            |    |  |  |
+| :-----------------: | :-----------------: | :-----------------: | :-----------------: | :-----------------: | :-----------------: | :-----------------: | :-----------------: |
+|Afrikaans|Albanian|Alemannic|Amharic|Arabic|Aragonese|Armenian|Asaro'o
+|Assamese|Asturian|Avaric|Azerbaijani|Bashkir|Basque|Bavarian|Belarusian
+|Bengali|Bihari languages|Bishnupriya Manipuri|Bosnian|Breton|Bulgarian|Buriat|Burmese
+|Catalan|Cebuano|Central Bikol|Central Khmer|Central Kurdish|Chavacano|Chechen|Chinese
+|Chuvash|Cornish|Corsican|Croatian|Czech|Danish|Dimli|Divehi
+|Doteli|Dutch|Eastern Mari|Egyptian Arabic|Emilian-Romagnol|English|Esperanto|Estonian
+|Fiji Hindi|Finnish|French|Galician|Georgian|German|Goan Konkani|Greek
+Guarani|Gujarati|Haitian Creole|Hebrew|Hill Mari|Hindi|Hungarian|Icelandic
+Ido|Ilokano|Indonesian|Interlingua|Interlingue|Irish|Italian|Japanese
+Javanese|Kalmyk|Kannada|Kapampangan|Karachay-Balkar|Kazakh|Komi|Korean
+Kurdish|Kyrgyz|Lao|Latin|Latvian|Lezgian|Limburgish|Lithuanian
+Lojban|Lombard|Low German|Lower Sorbian|Luxembourgish|Macedonian|Maithili|Malagasy
+Malay|Malayalam|Maltese|Manx|Marathi|Mazandarani|Min|Mirandese
+Mongolian|Nahuatl|Neapolitan|Nepal Bhasa|Nepali|Northern Frisian|Northern Luri|Norwegian
+Norwegian Nynorsk|Occitan|Odia|Ossetian|Palatine|Pashto|Persian|Piedmontese
+Polish|Portuguese|Punjabi|Quechua|Romanian|Romansh|Russian|Rusyn
+Sanskrit|Sardinian|Scots|Scottish Gaelic|Serbian|Serbo-Croatian|Sicilian|Sindhi
+Sinhala|Slovak|Slovenian|Somali|South Azerbaijani|Spanish|Sundanese|Swahili
+Swedish|Tagalog|Tajik|Tamil|Tatar|Telugu|Thai|Tibetan
+Turkish|Turkmen|Tuvan|Uighur|Ukrainian|Upper Sorbian|Urdu|Uzbek
+Venetian|Veps|Vietnamese|Volapük|Walloon|Waray|Welsh|West Flemish
+Western Frisian|Western Punjabi|Wu Chinese|Yakut|Yiddish|Yoruba|Yue

--- a/transforms/language/lang_id/README.md
+++ b/transforms/language/lang_id/README.md
@@ -13,12 +13,12 @@ configuration for values are as follows:
 
 | Key name  | Default  | Description |
 |------------|----------|--------------|
-| _model_credential_ | _unset_ | specifies the credential you use to get model. This will be huggingface token. [Guide to get huggingface token](https://huggingface.co/docs/hub/security-tokens) |
-| _model_kind_ | _unset_ | specifies what kind of model you want to use for language identification. Currently, only `fasttext` is available. |
-| _model_url_ | _unset_ |  specifies url that model locates. For fasttext, this will be repo nme of the model, like `facebook/fasttext-language-identification` |
-| _content_column_name_ | `contents` | specifies name of the column containing documents |
-| _output_lang_column_name_ | `lang` | specifies name of the output column to hold predicted language code |
-| _output_score_column_name_ | `score` | specifies name of the output column to hold score of prediction |
+| _lang_id_model_credential_ | _unset_ | specifies the credential you use to get model. This will be huggingface token. [Guide to get huggingface token](https://huggingface.co/docs/hub/security-tokens) |
+| _lang_id_model_kind_ | _unset_ | specifies what kind of model you want to use for language identification. Currently, only `fasttext` is available. |
+| _lang_id_model_url_ | _unset_ |  specifies url that model locates. For fasttext, this will be repo nme of the model, like `facebook/fasttext-language-identification` |
+| _lang_id_content_column_name_ | `contents` | specifies name of the column containing documents |
+| _lang_id_output_lang_column_name_ | `lang` | specifies name of the output column to hold predicted language code |
+| _lang_id_output_score_column_name_ | `score` | specifies name of the output column to hold score of prediction |
 
 ## Running
 

--- a/transforms/language/lang_id/README.md
+++ b/transforms/language/lang_id/README.md
@@ -57,30 +57,30 @@ for details on general project conventions, transform configuration,
 testing and IDE set up.
 
 # Supported Languages
-| Supported Languages |                     |                     |                     |                     |                     |                     |                     |
+|                     |                     |                     | Supported           | Languages           |    |  |  |
 | :-----------------: | :-----------------: | :-----------------: | :-----------------: | :-----------------: | :-----------------: | :-----------------: | :-----------------: |
-| Afrikaans           | Buriat              | Basque              | Indonesian          | Limburgish          | Neapolitan          | Rusyn               | Tagalog             |
-| Alemannic           | Catalan             | Persian             | Interlingue         | Lombard             | Low German          | Sanskrit            | Turkish             |
-| Amharic             | Chavacano           | Finnish             | Ilokano             | Lao                 | Nepali              | Yakut               | Tatar               |
-| Aragonese           | Chechen             | French              | Ido                 | Northern Luri       | Nepal Bhasa         | Sardinian           | Tuvan               |
-| Arabic              | Cebuano             | Northern Frisian    | Icelandic           | Lithuanian          | Dutch               | Sicilian            | Uighur              |
-| Egyptian Arabic     | Central Kurdish     | Western Frisian     | Italian             | Latvian             | Norwegian Nynorsk   | Scots               | Ukrainian           |
-| Assamese            | Corsican            | Irish               | Japanese            | Maithili            | Norwegian           | Sindhi              | Urdu                |
-| Asturian            | Czech               | Scottish Gaelic     | Lojban              | Malagasy            | Occitan             | Serbo-Croatian      | Uzbek               |
-| Avaric              | Chuvash             | Galician            | Javanese            | Eastern Mari        | Odia                | Sinhala             | Venetian            |
-| Azerbaijani         | Welsh               | Guarani             | Georgian            | Min                 | Ossetian            | Slovak              | Veps                |
-| South Azerbaijani   | Danish              | Goan Konkani        | Kazakh              | Macedonian          | Punjabi             | Slovenian           | Vietnamese          |
-| Bashkir             | German              | Gujarati            | Central Khmer       | Malayalam           | Kapampangan         | Somali              | West Flemish        |
-| Bavarian            | Dimli               | Manx                | Kannada             | Mongolian           | Palatine            | Albanian            | Volapük             |
-| Central Bikol       | Lower Sorbian       | Hebrew              | Korean              | Marathi             | Polish              | Serbian             | Walloon             |
-| Belarusian          | Doteli              | Hindi               | Karachay-Balkar     | Hill Mari           | Piedmontese         | Sundanese           | Waray               |
-| Bulgarian           | Divehi              | Fiji Hindi          | Kurdish             | Malay               | Western Punjabi     | Swedish             | Wu Chinese          |
-| Bihari languages    | Greek               | Croatian            | Komi                | Maltese             | Pashto              | Swahili             | Kalmyk              |
-| Bengali             | Emilian-Romagnol    | Upper Sorbian       | Cornish             | Mirandese           | Portuguese          | Tamil               | Extensible Music Format |
-| Tibetan             | English             | Haitian Creole      | Kyrgyz              | Burmese             | Quechua             | Telugu              | Yiddish             |
-| Bishnupriya Manipuri| Esperanto           | Hungarian           | Latin               | Asaro'o             | Romansh             | Tajik               | Yoruba              |
-| Breton              | Spanish             | Armenian            | Luxembourgish       | Mazandarani         | Romanian            | Thai                | Yue                 |
-| Bosnian             | Estonian            | Interlingua         | Lezgian             | Nahuatl             | Russian             | Turkmen             | Chinese             |
+|Afrikaans 	|Buriat 	|Emilian-Romagnol 	|Ilokano 	|Lithuanian 	|Northern Frisian 	|Scottish Gaelic 	|Turkmen | 
+|Albanian 	|Burmese 	|English 	|Indonesian 	|Lojban 	|Northern Luri 	|Serbian 	|Tuvan |
+|Alemannic 	|Catalan 	|Esperanto 	|Interlingua 	|Lombard 	|Norwegian 	|Serbo-Croatian 	|Uighur |
+|Amharic 	|Cebuano 	|Estonian 	|Interlingue 	|Low German 	|Norwegian Nynorsk 	|Sicilian 	|Ukrainian |
+|Arabic 	|Central Bikol 	|Extensible Music Format	|Irish 	|Lower Sorbian 	|Occitan 	|Sindhi 	|Upper Sorbian |
+|Aragonese 	|Central Khmer 	|Fiji Hindi 	|Italian 	|Luxembourgish 	|Odia 	|Sinhala 	|Urdu  |
+|Armenian 	|Central Kurdish 	|Finnish 	|Japanese 	|Macedonian 	|Ossetian 	|Slovak 	|Uzbek  |
+|Asaro'o 	|Chavacano 	|French 	|Javanese 	|Maithili 	|Palatine 	|Slovenian 	|Venetian |
+|Assamese 	|Chechen 	|Galician 	|Kalmyk	|Malagasy 	|Pashto 	|Somali 	|Veps |
+|Asturian 	|Chinese	|Georgian 	|Kannada 	|Malay 	|Persian 	|South Azerbaijani 	|Vietnamese |
+|Avaric 	|Chuvash 	|German 	|Kapampangan 	|Malayalam 	|Piedmontese 	|Spanish 	|Volapük
+|Azerbaijani 	|Cornish 	|Goan Konkani 	|Karachay-Balkar 	|Maltese 	|Polish 	|Sundanese 	|Walloon|
+|Bashkir 	|Corsican 	|Greek 	|Kazakh 	|Manx 	|Portuguese 	|Swahili 	|Waray |
+|Basque 	|Croatian 	|Guarani 	|Komi 	|Marathi 	|Punjabi 	|Swedish 	|Welsh |
+|Bavarian 	|Czech 	|Gujarati 	|Korean 	|Mazandarani 	|Quechua 	|Tagalog	|West Flemish |
+|Belarusian 	|Danish 	|Haitian Creole 	|Kurdish 	|Min 	|Romanian 	|Tajik 	|Western Frisian |
+|Bengali 	|Dimli 	|Hebrew 	|Kyrgyz 	|Mirandese 	|Romansh 	|Tamil 	|Western Punjabi |
+|Bihari languages 	|Divehi 	|Hill Mari 	|Lao 	|Mongolian 	|Russian 	|Tatar	|Wu Chinese |
+|Bishnupriya Manipuri 	|Doteli 	|Hindi 	|Latin 	|Nahuatl 	|Rusyn 	|Telugu 	|Yakut |
+|Bosnian 	|Dutch 	|Hungarian 	|Latvian 	|Neapolitan 	|Sanskrit 	|Thai 	|Yiddish |
+|Breton 	|Eastern Mari 	|Icelandic 	|Lezgian 	|Nepal Bhasa 	|Sardinian 	|Tibetan 	|Yoruba |
+|Bulgarian 	|Egyptian Arabic 	|Ido 	|Limburgish 	|Nepali 	|Scots 	|Turkish	|Yue |
 
 ## Summary 
 This project wraps the language identification transform with a Ray runtime.

--- a/transforms/language/lang_id/README.md
+++ b/transforms/language/lang_id/README.md
@@ -9,7 +9,7 @@ This transform will identify language of each text with confidence score with fa
 ## Contributors
 
 - Daiki Tsuzuku (dtsuzuku@jp.ibm.com)
-- Shahrokh Daijavad (shahrokh@us.ibm.com)
+- Maroun Touma (touma@us.ibm.com)
 
 ## Configuration and command line Options
 

--- a/transforms/language/lang_id/README.md
+++ b/transforms/language/lang_id/README.md
@@ -82,11 +82,6 @@ To use the transform image to transform your data, please refer to the
 substituting the name of this transform image and runtime as appropriate.
 
 # Supported Languages
-<style>
-table, th, td {
-   border: none;
-}
-</style>
 |                     |                     |                     |            |            |    |  |  |
 | :-----------------: | :-----------------: | :-----------------: | :-----------------: | :-----------------: | :-----------------: | :-----------------: | :-----------------: |
 |Afrikaans|Albanian|Alemannic|Amharic|Arabic|Aragonese|Armenian|Asaro'o

--- a/transforms/language/lang_id/dpk_lang_id/local.py
+++ b/transforms/language/lang_id/dpk_lang_id/local.py
@@ -27,7 +27,7 @@ from lang_models import KIND_FASTTEXT
 input_folder = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "test-data", "input"))
 
 lang_id_params = {
-    model_credential_key: "PUT YOUR OWN HUGGINGFACE CREDENTIAL",
+    model_credential_key: os.environ.get('HF_READ_ACCESS_TOKEN', "PUT YOUR OWN HUGGINGFACE CREDENTIAL"),
     model_kind_key: KIND_FASTTEXT,
     model_url_key: "facebook/fasttext-language-identification",
     content_column_name_key: "text",

--- a/transforms/language/lang_id/dpk_lang_id/local_python.py
+++ b/transforms/language/lang_id/dpk_lang_id/local_python.py
@@ -41,7 +41,7 @@ params = {
     "runtime_job_id": "job_id",
     "runtime_code_location": ParamsUtils.convert_to_ast(code_location),
     # lang_id params
-    model_credential_cli_param: "PUT YOUR OWN HUGGINGFACE CREDENTIAL",
+    model_credential_cli_param: os.environ.get('HF_READ_ACCESS_TOKEN', "PUT YOUR OWN HUGGINGFACE CREDENTIAL"),
     model_kind_cli_param: KIND_FASTTEXT,
     model_url_cli_param: "facebook/fasttext-language-identification",
     content_column_name_cli_param: "text",

--- a/transforms/language/lang_id/dpk_lang_id/ray/local.py
+++ b/transforms/language/lang_id/dpk_lang_id/ray/local.py
@@ -49,7 +49,7 @@ params = {
     "runtime_creation_delay": 0,
     "runtime_code_location": ParamsUtils.convert_to_ast(code_location),
     # lang_id params
-    model_credential_cli_param: "PUT YOUR OWN HUGGINGFACE CREDENTIAL",
+    model_credential_cli_param: os.environ.get('HF_READ_ACCESS_TOKEN', "PUT YOUR OWN HUGGINGFACE CREDENTIAL"),
     model_kind_cli_param: KIND_FASTTEXT,
     model_url_cli_param: "facebook/fasttext-language-identification",
     content_column_name_cli_param: "text",

--- a/transforms/language/lang_id/dpk_lang_id/ray/s3.py
+++ b/transforms/language/lang_id/dpk_lang_id/ray/s3.py
@@ -56,7 +56,7 @@ params = {
     "runtime_creation_delay": 0,
     "runtime_code_location": ParamsUtils.convert_to_ast(code_location),
     # lang_id params
-    model_credential_cli_param: "PUT YOUR OWN HUGGINGFACE CREDENTIAL",
+    model_credential_cli_param: os.environ.get('HF_READ_ACCESS_TOKEN', "PUT YOUR OWN HUGGINGFACE CREDENTIAL"),
     model_kind_cli_param: KIND_FASTTEXT,
     model_url_cli_param: "facebook/fasttext-language-identification",
     content_column_name_cli_param: "text",

--- a/transforms/language/lang_id/kfp_ray/Makefile
+++ b/transforms/language/lang_id/kfp_ray/Makefile
@@ -29,7 +29,6 @@ workflow-build: workflow-venv
 
 .PHONY: workflow-test
 workflow-test: workflow-build
-	cat $(TRANSFORM_NAME)_wf.yaml
 	$(MAKE) TRANSFORM_SRC=${SRC_DIR} \
 		TRANSFORM_RUNTIME=$(TRANSFORM_RUNTIME) \
 		TRANSFORM_NAME=$(TRANSFORM_NAME) \

--- a/transforms/language/lang_id/kfp_ray/Makefile
+++ b/transforms/language/lang_id/kfp_ray/Makefile
@@ -29,6 +29,7 @@ workflow-build: workflow-venv
 
 .PHONY: workflow-test
 workflow-test: workflow-build
+	cat $(TRANSFORM_NAME)_wf.yaml
 	$(MAKE) TRANSFORM_SRC=${SRC_DIR} \
 		TRANSFORM_RUNTIME=$(TRANSFORM_RUNTIME) \
 		TRANSFORM_NAME=$(TRANSFORM_NAME) \

--- a/transforms/language/lang_id/kfp_ray/lang_id_multiple_wf.py
+++ b/transforms/language/lang_id/kfp_ray/lang_id_multiple_wf.py
@@ -122,7 +122,7 @@ def lang_id(
     runtime_pipeline_id: str = "pipeline_id",
     runtime_code_location: dict = {"github": "github", "commit_hash": "12345", "path": "path"},
     # lang_id parameters
-    lang_id_model_credential: str = os.environ.get('HF_READ_ACCESS_TOKEN', "PUT YOUR OWN HUGGINGFACE CREDENTIAL"),
+    lang_id_model_credential: str = "PUT YOUR OWN HUGGINGFACE CREDENTIAL",
     lang_id_model_kind: str = "fasttext",
     lang_id_model_url: str = "facebook/fasttext-language-identification",
     lang_id_content_column_name: str = "text",

--- a/transforms/language/lang_id/kfp_ray/lang_id_multiple_wf.py
+++ b/transforms/language/lang_id/kfp_ray/lang_id_multiple_wf.py
@@ -122,7 +122,7 @@ def lang_id(
     runtime_pipeline_id: str = "pipeline_id",
     runtime_code_location: dict = {"github": "github", "commit_hash": "12345", "path": "path"},
     # lang_id parameters
-    lang_id_model_credential: str = "PUT YOUR OWN HUGGINGFACE CREDENTIAL",
+    lang_id_model_credential: str = os.environ.get('HF_READ_ACCESS_TOKEN', "PUT YOUR OWN HUGGINGFACE CREDENTIAL"),
     lang_id_model_kind: str = "fasttext",
     lang_id_model_url: str = "facebook/fasttext-language-identification",
     lang_id_content_column_name: str = "text",

--- a/transforms/language/lang_id/kfp_ray/lang_id_multiple_wf.py
+++ b/transforms/language/lang_id/kfp_ray/lang_id_multiple_wf.py
@@ -26,6 +26,7 @@ task_image = "quay.io/dataprep1/data-prep-kit/lang_id-ray:latest"
 
 # the name of the job script
 EXEC_SCRIPT_NAME: str = "-m dpk_lang_id.ray.transform"
+HF_SECRET = os.environ.get('HF_READ_ACCESS_TOKEN', "PUT YOUR OWN HUGGINGFACE CREDENTIAL")
 
 # components
 base_kfp_image = "quay.io/dataprep1/data-prep-kit/kfp-data-processing:0.2.3"
@@ -122,7 +123,7 @@ def lang_id(
     runtime_pipeline_id: str = "pipeline_id",
     runtime_code_location: dict = {"github": "github", "commit_hash": "12345", "path": "path"},
     # lang_id parameters
-    lang_id_model_credential: str = "PUT YOUR OWN HUGGINGFACE CREDENTIAL",
+    lang_id_model_credential: str = HF_SECRET,
     lang_id_model_kind: str = "fasttext",
     lang_id_model_url: str = "facebook/fasttext-language-identification",
     lang_id_content_column_name: str = "text",

--- a/transforms/language/lang_id/kfp_ray/lang_id_wf.py
+++ b/transforms/language/lang_id/kfp_ray/lang_id_wf.py
@@ -123,7 +123,7 @@ def lang_id(
     runtime_pipeline_id: str = "pipeline_id",
     runtime_code_location: dict = {"github": "github", "commit_hash": "12345", "path": "path"},
     # lang_id parameters
-    lang_id_model_credential: str = "PUT YOUR OWN HUGGINGFACE CREDENTIAL",
+    lang_id_model_credential: str = os.environ.get('HF_READ_ACCESS_TOKEN', "PUT YOUR OWN HUGGINGFACE CREDENTIAL"),
     lang_id_model_kind: str = "fasttext",
     lang_id_model_url: str = "facebook/fasttext-language-identification",
     lang_id_content_column_name: str = "text",

--- a/transforms/language/lang_id/kfp_ray/lang_id_wf.py
+++ b/transforms/language/lang_id/kfp_ray/lang_id_wf.py
@@ -123,7 +123,7 @@ def lang_id(
     runtime_pipeline_id: str = "pipeline_id",
     runtime_code_location: dict = {"github": "github", "commit_hash": "12345", "path": "path"},
     # lang_id parameters
-    lang_id_model_credential: str = os.environ.get('HF_READ_ACCESS_TOKEN', "PUT YOUR OWN HUGGINGFACE CREDENTIAL"),
+    lang_id_model_credential: str = "PUT YOUR OWN HUGGINGFACE CREDENTIAL",
     lang_id_model_kind: str = "fasttext",
     lang_id_model_url: str = "facebook/fasttext-language-identification",
     lang_id_content_column_name: str = "text",

--- a/transforms/language/lang_id/kfp_ray/lang_id_wf.py
+++ b/transforms/language/lang_id/kfp_ray/lang_id_wf.py
@@ -26,6 +26,7 @@ task_image = "quay.io/dataprep1/data-prep-kit/lang_id-ray:latest"
 
 # the name of the job script
 EXEC_SCRIPT_NAME: str = "-m dpk_lang_id.ray.transform"
+HF_SECRET = os.environ.get('HF_READ_ACCESS_TOKEN', "PUT YOUR OWN HUGGINGFACE CREDENTIAL")
 
 # components
 base_kfp_image = "quay.io/dataprep1/data-prep-kit/kfp-data-processing:0.2.3"
@@ -123,7 +124,7 @@ def lang_id(
     runtime_pipeline_id: str = "pipeline_id",
     runtime_code_location: dict = {"github": "github", "commit_hash": "12345", "path": "path"},
     # lang_id parameters
-    lang_id_model_credential: str = "PUT YOUR OWN HUGGINGFACE CREDENTIAL",
+    lang_id_model_credential: str = HF_SECRET,
     lang_id_model_kind: str = "fasttext",
     lang_id_model_url: str = "facebook/fasttext-language-identification",
     lang_id_content_column_name: str = "text",

--- a/transforms/language/lang_id/lang_id-ray.ipynb
+++ b/transforms/language/lang_id/lang_id-ray.ipynb
@@ -37,12 +37,12 @@
     "##### **** Configure the transform parameters. The set of dictionary keys holding DocIDTransform configuration for values are as follows: \n",
     "| Key name  | Default  | Description |\n",
     "|------------|----------|--------------|\n",
-    "| _model_credential_ | _unset_ | specifies the credential you use to get model. This will be huggingface token. [Guide to get huggingface token](https://huggingface.co/docs/hub/security-tokens) |\n",
-    "| _model_kind_ | _unset_ | specifies what kind of model you want to use for language identification. Currently, only `fasttext` is available. |\n",
-    "| _model_url_ | _unset_ |  specifies url that model locates. For fasttext, this will be repo nme of the model, like `facebook/fasttext-language-identification` |\n",
-    "| _content_column_name_ | `contents` | specifies name of the column containing documents |\n",
-    "| _output_lang_column_name_ | `lang` | specifies name of the output column to hold predicted language code |\n",
-    "| _output_score_column_name_ | `score` | specifies name of the output column to hold score of prediction |"
+    "| _lang_id_model_credential_ | _unset_ | specifies the credential you use to get model. This will be huggingface token. [Guide to get huggingface token](https://huggingface.co/docs/hub/security-tokens) |\n",
+    "| _lang_id_model_kind_ | _unset_ | specifies what kind of model you want to use for language identification. Currently, only `fasttext` is available. |\n",
+    "| _lang_id_model_url_ | _unset_ |  specifies url that model locates. For fasttext, this will be repo nme of the model, like `facebook/fasttext-language-identification` |\n",
+    "| _lang_id_content_column_name_ | `contents` | specifies name of the column containing documents |\n",
+    "| _lang_id_output_lang_column_name_ | `lang` | specifies name of the output column to hold predicted language code |\n",
+    "| _lang_id_output_score_column_name_ | `score` | specifies name of the output column to hold score of prediction |"
    ]
   },
   {

--- a/transforms/language/lang_id/lang_id.ipynb
+++ b/transforms/language/lang_id/lang_id.ipynb
@@ -38,12 +38,12 @@
     "##### **** Configure the transform parameters. The set of dictionary keys holding DocIDTransform configuration for values are as follows: \n",
     "| Key name  | Default  | Description |\n",
     "|------------|----------|--------------|\n",
-    "| _model_credential_ | _unset_ | specifies the credential you use to get model. This will be huggingface token. [Guide to get huggingface token](https://huggingface.co/docs/hub/security-tokens) |\n",
-    "| _model_kind_ | _unset_ | specifies what kind of model you want to use for language identification. Currently, only `fasttext` is available. |\n",
-    "| _model_url_ | _unset_ |  specifies url that model locates. For fasttext, this will be repo nme of the model, like `facebook/fasttext-language-identification` |\n",
-    "| _content_column_name_ | `contents` | specifies name of the column containing documents |\n",
-    "| _output_lang_column_name_ | `lang` | specifies name of the output column to hold predicted language code |\n",
-    "| _output_score_column_name_ | `score` | specifies name of the output column to hold score of prediction |"
+    "| _lang_id_model_credential_ | _unset_ | specifies the credential you use to get model. This will be huggingface token. [Guide to get huggingface token](https://huggingface.co/docs/hub/security-tokens) |\n",
+    "| _lang_id_model_kind_ | _unset_ | specifies what kind of model you want to use for language identification. Currently, only `fasttext` is available. |\n",
+    "| _lang_id_model_url_ | _unset_ |  specifies url that model locates. For fasttext, this will be repo nme of the model, like `facebook/fasttext-language-identification` |\n",
+    "| _lang_id_content_column_name_ | `contents` | specifies name of the column containing documents |\n",
+    "| _lang_id_output_lang_column_name_ | `lang` | specifies name of the output column to hold predicted language code |\n",
+    "| _lang_id_output_score_column_name_ | `score` | specifies name of the output column to hold score of prediction |"
    ]
   },
   {

--- a/transforms/language/lang_id/test/test_lang_id.py
+++ b/transforms/language/lang_id/test/test_lang_id.py
@@ -10,6 +10,7 @@
 # limitations under the License.
 ################################################################################
 
+import os
 import pyarrow as pa
 from data_processing.test_support.transform.table_transform_test import (
     AbstractTableTransformTest,
@@ -26,7 +27,7 @@ class TestLangIdentificationTransform(AbstractTableTransformTest):
 
     def get_test_transform_fixtures(self) -> list[tuple]:
         config = {
-            "model_credential": "PUT YOUR OWN HUGGINGFACE CREDENTIAL",
+            "model_credential": os.environ.get('HF_READ_ACCESS_TOKEN', "PUT YOUR OWN HUGGINGFACE CREDENTIAL"),
             "model_kind": KIND_FASTTEXT,
             "model_url": "facebook/fasttext-language-identification",
             "content_column_name": "contents",

--- a/transforms/language/lang_id/test/test_lang_id_python.py
+++ b/transforms/language/lang_id/test/test_lang_id_python.py
@@ -28,7 +28,7 @@ class TestPythonLangIdentificationTransform(AbstractTransformLauncherTest):
 
     def get_test_transform_fixtures(self) -> list[tuple]:
         cli_params = {
-            "lang_id_model_credential": "PUT YOUR OWN HUGGINGFACE CREDENTIAL",
+            "lang_id_model_credential": os.environ.get('HF_READ_ACCESS_TOKEN', "PUT YOUR OWN HUGGINGFACE CREDENTIAL"),
             "lang_id_model_kind": KIND_FASTTEXT,
             "lang_id_model_url": "facebook/fasttext-language-identification",
             "lang_id_content_column_name": "text",

--- a/transforms/language/lang_id/test/test_lang_id_ray.py
+++ b/transforms/language/lang_id/test/test_lang_id_ray.py
@@ -37,7 +37,7 @@ class TestRayLangIdentificationTransform(AbstractTransformLauncherTest):
         basedir = "../test-data"
         basedir = os.path.abspath(os.path.join(os.path.dirname(__file__), basedir))
         config = {
-            model_credential_cli_param: "PUT YOUR OWN HUGGINGFACE CREDENTIAL",
+            model_credential_cli_param: os.environ.get('HF_READ_ACCESS_TOKEN', "PUT YOUR OWN HUGGINGFACE CREDENTIAL"),
             model_kind_cli_param: KIND_FASTTEXT,
             model_url_cli_param: "facebook/fasttext-language-identification",
             content_column_name_cli_param: "text",


### PR DESCRIPTION
This change adds a table of supported languages to the README.md file for lang_id transform.

