### PR TITLE
Add gneissweb_classification workflow to kfp blacklist.

### DIFF
--- a/scripts/check-workflows.sh
+++ b/scripts/check-workflows.sh
@@ -17,7 +17,7 @@ if [ ! -d transforms ]; then
     echo Please run this script from the top of the repository
     exit 1
 fi
-KFP_BLACK_LIST="doc_chunk pdf2parquet pii_redactor text_encoder license_select repo_level_ordering header_cleanser fdedup hap rep_removal"
+KFP_BLACK_LIST="doc_chunk pdf2parquet pii_redactor text_encoder license_select repo_level_ordering header_cleanser fdedup hap rep_removal gneissweb_classification"
 while [ $# -ne 0 ]; do
    case $1 in
         -show-kfp-black-list)    echo $KFP_BLACK_LIST; exit 0;


### PR DESCRIPTION
## Why are these changes needed?

Add gneissweb_classification workflow to kfp blacklist due to high resource requirements.

