### PR TITLE
remove duplicate declaration for runtime entry points

### DIFF
--- a/transforms/Makefile.transform.template
+++ b/transforms/Makefile.transform.template
@@ -2,11 +2,6 @@ REPOROOT=../../..
 # Use make help, to see the available rules
 include $(REPOROOT)/transforms/.make.cicd.targets
 
-# Until we make runtime.py the standard supported by Makefile infra
-TRANSFORM_PYTHON_SRC="-m dpk_$(TRANSFORM_NAME).runtime"
-TRANSFORM_RAY_SRC="-m dpk_$(TRANSFORM_NAME).ray.runtime"
-TRANSFORM_SPARK_SRC="-m dpk_$(TRANSFORM_NAME).spark.runtime"
-
 #
 # This is intended to be included across the Makefiles provided within
 # a given transform's directory tree,  so must use compatible syntax.
@@ -18,6 +13,8 @@ TRANSFORM_NAME=$(shell basename `pwd`)
 
 ################################################################################
 
+# Developers should adapt this according to their implementation if they do not follow the proposed template
+# We continue to refine this. The current settings are based on current template
 TRANSFORM_PYTHON_SRC="-m dpk_$(TRANSFORM_NAME).runtime"
 TRANSFORM_RAY_SRC="-m dpk_$(TRANSFORM_NAME).ray.runtime"
 TRANSFORM_SPARK_SRC="-m dpk_$(TRANSFORM_NAME).spark.runtime"


### PR DESCRIPTION
## Why are these changes needed?

Cleanup Makefile template as it repeats the same entry points  

## Related issue number (if any).


