### PR TITLE
remove argparse from requirements

### DIFF
--- a/data-processing-lib/python/requirements.txt
+++ b/data-processing-lib/python/requirements.txt
@@ -1,7 +1,6 @@
   numpy < 1.29.0
   pyarrow==16.1.0
   boto3
-  argparse
   mmh3
   psutil
   polars>=1.9.0


### PR DESCRIPTION
## Why are these changes needed?
From Python 3.2, `argparse` is a standard library, we must not require its installation, because it is abandoned library.

## Related issue number (if any).
fixes #1156 
