### PR TITLE
Taking care of remaining data-prep-lab instances and Hide the table in the main README using a twistie 

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -13,11 +13,11 @@ body:
       attributes:
           label: Search before asking
           description: >
-              Please make sure to search in the [issues](https://github.com/data-prep-kit/data-prep-lab/issues) first to see
+              Please make sure to search in the [issues](https://github.com/data-prep-kit/data-prep-kit/issues) first to see
               whether the same issue was reported already.
           options:
               - label: >
-                    I searched the [issues](https://github.com/data-prep-kit/data-prep-lab/issues) and found no similar
+                    I searched the [issues](https://github.com/data-prep-kit/data-prep-kit/issues) and found no similar
                     issues.
                 required: true
 

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -12,11 +12,11 @@ body:
       attributes:
           label: Search before asking
           description: >
-              Please make sure to search in the [issues](https://github.com/data-prep-kit/data-prep-lab/issues) first to see
+              Please make sure to search in the [issues](https://github.com/data-prep-kit/data-prep-kit/issues) first to see
               whether the same request was reported already.
           options:
               - label: >
-                    I searched the [issues](https://github.com/data-prep-kit/data-prep-lab/issues) and found no similar issues.
+                    I searched the [issues](https://github.com/data-prep-kit/data-prep-kit/issues) and found no similar issues.
                 required: true
 
     - type: dropdown

--- a/.github/mkdocs_hook.py
+++ b/.github/mkdocs_hook.py
@@ -21,7 +21,7 @@ import mkdocs.plugins
 
 log = logging.getLogger("mkdocs")
 
-GITHUB_REPO = os.getenv("REPO_URL", "https://github.com/data-prep-kit/data-prep-lab")
+GITHUB_REPO = os.getenv("REPO_URL", "https://github.com/data-prep-kit/data-prep-kit")
 GITHUB_BRANCH = os.getenv("REPO_BRANCH", "dev")
 GITHUB_VIEW_FILE = "blob"
 GITHUB_VIEW_TREE = "tree"

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ All the transforms in the kit include small sample data files for testing, but a
 ## Current list of transforms <a name="table"></a>
 
 <details>
-      <summary>Please click to expand</summary>
+      <summary>Click to expand for detailed list of transforms.</summary>
 
 The matrix below shows the the combination of modules and supported runtimes. All the modules can be accessed [here](transforms) and can be combined to form data processing pipelines, as shown in the [examples](examples) folder. 
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Data Prep Kit accelerates unstructured data preparation for LLM app developers. 
 
 ## Installation
 
-The latest version of the Data Prep Kit is available on PyPi for Python 3.10, 3.11 or 3.12. It can be installed using: 
+The latest version of the Data Prep Kit is available on PyPi for Python 3.10, 3.11 and 3.12. It can be installed using: 
 
 ```bash
 pip install  'data-prep-toolkit-transforms[all]'

--- a/README.md
+++ b/README.md
@@ -68,8 +68,10 @@ All the transforms in the kit include small sample data files for testing, but a
 
 ## Current list of transforms <a name="table"></a>
 
-The matrix below shows the the combination of modules and supported runtimes. All the modules can be accessed [here](transforms) and can be combined to form data processing pipelines, as shown in the [examples](examples) folder. 
+<details>
+      <summary>Please click to expand</summary>
 
+The matrix below shows the the combination of modules and supported runtimes. All the modules can be accessed [here](transforms) and can be combined to form data processing pipelines, as shown in the [examples](examples) folder. 
 
 | Modules                                                                              |    Python-only     |        Ray         |       Spark        |     KFP on Ray     |
 |:-------------------------------------------------------------------------------------|:------------------:|:------------------:|:------------------:|:------------------:|
@@ -109,6 +111,7 @@ The matrix below shows the the combination of modules and supported runtimes. Al
 | [License Select Annotation](transforms/code/license_select/python/README.md)         | :white_check_mark: | :white_check_mark: |                    | :white_check_mark: |
 | [Code profiler](transforms/code/code_profiler/README.md)                             | :white_check_mark: | :white_check_mark: |                    |  |
 
+</details>
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Please click [here](doc/quick-start/quick-start.md#running-transforms-on-windows
 All the transforms in the kit include small sample data files for testing, but advanced users who want to download real data files from HuggingFace and use them in testing, can refer to [this](ADVANCED.md#using-data-from-huggingface). 
 
 
-## Current list of transforms <a name="table"></a>
+## Supported data transforms <a name="table"></a>
 
 <details>
       <summary>Click to expand for detailed list of transforms.</summary>


### PR DESCRIPTION
A few instances of data-prep-lab had to be changed to data-prep-kit

