### PR TITLE
[Feature] Html2ParquetTransform support output_format_value json #908

### DIFF
--- a/transforms/language/html2parquet/README.md
+++ b/transforms/language/html2parquet/README.md
@@ -51,7 +51,7 @@ The table below provides the parameters that users can adjust to control the beh
 
 | Parameter         | Default    | Description                                                                 |
 |-------------------|------------|-----------------------------------------------------------------------------|
-| `output_format`    | `markdown` | Specifies the format of the extracted content. Options: `markdown`, `txt`.  |
+| `output_format`    | `markdown` | Specifies the format of the extracted content. Options: `markdown`, `txt`, `json`.  |
 | `favor_precision`  | `True`     | Prefers less content but more accurate extraction. Options: `True`, `False`. |
 | `favor_recall`     | `True`     | Extracts more content when uncertain. Options: `True`, `False`.              |
 

--- a/transforms/language/html2parquet/dpk_html2parquet/transform.py
+++ b/transforms/language/html2parquet/dpk_html2parquet/transform.py
@@ -55,7 +55,7 @@ class Html2ParquetTransform(AbstractBinaryTransform):
         title = member_filename if member_filename else TransformUtils.get_file_basename(file_name)
 
         output_format_value = str(self.output_format)
-        if output_format_value not in ["markdown", "txt"]:
+        if output_format_value not in ["markdown", "txt", "json"]:
             raise RuntimeError(f"Unknown output_format {self.output_format}.")
 
         if self.favor_precision == html2parquet_favor_precision.TRUE:
@@ -168,6 +168,7 @@ html2parquet_favor_recall_key = f"favor_recall"
 class html2parquet_output_format(str, enum.Enum):
     MARKDOWN = "markdown"
     TEXT = "txt"
+    JSON = "json"
 
     def __str__(self):
         return str(self.value)

--- a/transforms/language/html2parquet/html2parquet.ipynb
+++ b/transforms/language/html2parquet/html2parquet.ipynb
@@ -9,10 +9,10 @@
    },
    "outputs": [],
    "source": [
-    "%%captur\n",
+    "%%capture\n",
     "!pip install data-prep-toolkit\n",
     "!pip install 'data-prep-toolkit-transforms[html2parquet]'\n",
-    "!pip install pandas"
+    "!pip install pandas lxml_html_clean"
    ]
   },
   {
@@ -140,11 +140,36 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 24,
    "id": "2fd0d13b-1ff6-4988-91fb-52c25ba998c8",
    "metadata": {},
-   "outputs": [],
-   "source": []
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "11:02:26 INFO - html2parquet parameters are : {'output_format': <html2parquet_output_format.TEXT: 'txt'>, 'favor_precision': <html2parquet_favor_precision.TRUE: 'True'>, 'favor_recall': <html2parquet_favor_recall.TRUE: 'True'>}\n",
+      "11:02:26 INFO - pipeline id pipeline_id\n",
+      "11:02:26 INFO - code location {'github': 'UNDEFINED', 'build-date': 'UNDEFINED', 'commit_hash': 'UNDEFINED', 'path': 'UNDEFINED'}\n",
+      "11:02:26 INFO - data factory data_ data configuration used: {'input_folder': 'test-data/input', 'output_folder': 'output', 'prefix': 'data_'}\n",
+      "11:02:26 INFO - data factory data_ max_files -1, n_sample -1\n",
+      "11:02:26 INFO - data factory data_ Not using data sets, checkpointing False, max files -1, random samples -1, files to use ['.html'], files to checkpoint ['.parquet']\n",
+      "11:02:26 INFO - data factory data_ Data Access:  DataAccessLocal\n",
+      "11:02:26 INFO - orchestrator html2parquet started at 2025-07-04 11:02:26\n",
+      "11:02:26 INFO - Number of files is 1, source profile {'max_file_size': 0.33743762969970703, 'min_file_size': 0.33743762969970703, 'total_file_size': 0.33743762969970703}\n",
+      "11:02:26 INFO - Completed 1 files (100.0%) in 0.001 min\n",
+      "11:02:26 INFO - Done processing 1 files, waiting for flush() completion.\n",
+      "11:02:26 INFO - done flushing in 0.0 sec\n",
+      "11:02:26 INFO - Completed execution in 0.001 min, execution result 0\n"
+     ]
+    }
+   ],
+   "source": [
+    "x=Html2Parquet(input_folder= \"test-data/input\", \n",
+    "               output_folder= \"output\", \n",
+    "               html2parquet_output_format= \"txt\", \n",
+    "               data_files_to_use=['.html']).transform()"
+   ]
   },
   {
    "cell_type": "code",
@@ -152,7 +177,74 @@
    "id": "587e43ee-7b51-4a9c-8bf2-0a23e309a7ae",
    "metadata": {},
    "outputs": [],
-   "source": []
+   "source": [
+    "table_txt = pq.read_table('output/test1.parquet')\n",
+    "table_txt.to_pandas()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d6e8b00f-b8b5-4533-89d4-7bb3fc4be435",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "table_txt.to_pandas()['contents'][0]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 25,
+   "id": "1e7e07ef-0ac6-4c70-b82e-cd1ec0b2fcb3",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "11:02:34 INFO - html2parquet parameters are : {'output_format': <html2parquet_output_format.JSON: 'json'>, 'favor_precision': <html2parquet_favor_precision.TRUE: 'True'>, 'favor_recall': <html2parquet_favor_recall.TRUE: 'True'>}\n",
+      "11:02:34 INFO - pipeline id pipeline_id\n",
+      "11:02:34 INFO - code location {'github': 'UNDEFINED', 'build-date': 'UNDEFINED', 'commit_hash': 'UNDEFINED', 'path': 'UNDEFINED'}\n",
+      "11:02:34 INFO - data factory data_ data configuration used: {'input_folder': 'test-data/input', 'output_folder': 'output', 'prefix': 'data_'}\n",
+      "11:02:34 INFO - data factory data_ max_files -1, n_sample -1\n",
+      "11:02:34 INFO - data factory data_ Not using data sets, checkpointing False, max files -1, random samples -1, files to use ['.html'], files to checkpoint ['.parquet']\n",
+      "11:02:34 INFO - data factory data_ Data Access:  DataAccessLocal\n",
+      "11:02:34 INFO - orchestrator html2parquet started at 2025-07-04 11:02:34\n",
+      "11:02:34 INFO - Number of files is 1, source profile {'max_file_size': 0.33743762969970703, 'min_file_size': 0.33743762969970703, 'total_file_size': 0.33743762969970703}\n",
+      "11:02:34 INFO - Completed 1 files (100.0%) in 0.001 min\n",
+      "11:02:34 INFO - Done processing 1 files, waiting for flush() completion.\n",
+      "11:02:34 INFO - done flushing in 0.0 sec\n",
+      "11:02:34 INFO - Completed execution in 0.002 min, execution result 0\n"
+     ]
+    }
+   ],
+   "source": [
+    "x=Html2Parquet(input_folder= \"test-data/input\", \n",
+    "               output_folder= \"output\", \n",
+    "               html2parquet_output_format= \"json\", \n",
+    "               data_files_to_use=['.html']).transform()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6c5ce9f6-f24e-499d-b27d-079817c3c9ff",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "table_json = pq.read_table('output/test1.parquet')\n",
+    "table_json.to_pandas()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b2fb8c22-ccec-4ddf-9f4c-50db77ae84d6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "table_json.to_pandas()['contents'][0]"
+   ]
   }
  ],
  "metadata": {
@@ -171,7 +263,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.10"
+   "version": "3.11.2"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
## Why are these changes needed?

dpk_html2parquet.transform_python could allow html2parquet_output_format: json which would pass-through to Trafilatura which already supports JSON. This would allow the flow of Stage-2 and beyond in the RAG example(s) to be maintained since they default to JSON.

Adding JSON support in html2parquet_output_format to align with pdf2parquet_output_format options along with the underlying Trafilatura supported options.

Supporting JSON as an additional output format for the html2parquet transform and making it consistent with the pdf2parquet transform output formats, since Trafilatura already supports this.

## Related issue number (if any).

None
