### PR TITLE
GneissWebClassifiation: Do not require credential on Command line

### DIFF
--- a/transforms/language/gneissweb_classification/dpk_gneissweb_classification/transform.py
+++ b/transforms/language/gneissweb_classification/dpk_gneissweb_classification/transform.py
@@ -9,7 +9,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 ################################################################################
-
+import os
 from argparse import ArgumentParser, Namespace
 from typing import Any
 
@@ -69,7 +69,7 @@ class ClassificationTransform(AbstractTableTransform):
         # of ClassificationTransformConfiguration class
         super().__init__(config)
         
-        self.model_credential = config.get(model_credential_cli_param)
+        self.model_credential = config.get(model_credential_cli_param, os.environ.get('HF_READ_ACCESS_TOKEN', "PUT YOUR OWN HUGGINGFACE CREDENTIAL"))
         self.model_file_name = ast.literal_eval(config.get(model_file_name_cli_param)[0])
         self.model_url = ast.literal_eval(config.get(model_url_cli_param)[0])
         self.n_processes = config.get(n_processes_cli_param, default_n_processes)
@@ -149,7 +149,6 @@ class ClassificationTransformConfiguration(TransformConfiguration):
         """
         parser.add_argument(
             f"--{model_credential_cli_param}",
-            required=True,
             help="Credential to access huggingface model",
         )
         parser.add_argument(

--- a/transforms/language/gneissweb_classification/dpk_gneissweb_classification/transform.py
+++ b/transforms/language/gneissweb_classification/dpk_gneissweb_classification/transform.py
@@ -69,7 +69,7 @@ class ClassificationTransform(AbstractTableTransform):
         # of ClassificationTransformConfiguration class
         super().__init__(config)
         
-        self.model_credential = config.get(model_credential_cli_param, os.environ.get('HF_READ_ACCESS_TOKEN', "PUT YOUR OWN HUGGINGFACE CREDENTIAL"))
+        self.model_credential = config.get(model_credential_cli_param, os.environ.get('HF_READ_ACCESS_TOKEN', None))
         self.model_file_name = ast.literal_eval(config.get(model_file_name_cli_param)[0])
         self.model_url = ast.literal_eval(config.get(model_url_cli_param)[0])
         self.n_processes = config.get(n_processes_cli_param, default_n_processes)

--- a/transforms/language/gneissweb_classification/kfp_ray/gneissweb_classification_wf.py
+++ b/transforms/language/gneissweb_classification/kfp_ray/gneissweb_classification_wf.py
@@ -31,6 +31,7 @@ HF_SECRET = "hf-secret"
 # The secret key that holds the HugginFace token
 HF_SECRET_KEY = "hf-token"
 
+S3_SECRET="s3-secret"
 
 task_image = "quay.io/dataprep1/data-prep-kit/gneissweb_classification-ray:latest"
 
@@ -134,7 +135,7 @@ def gneissweb_classification(
     server_url: str = "http://kuberay-apiserver-service.kuberay.svc.cluster.local:8888",
     # data access
     data_s3_config: str = "{'input_folder': 'test/gneissweb_classification/input', 'output_folder': 'test/gneissweb_classification/output/'}",
-    data_s3_access_secret: str = "s3-secret",
+    data_s3_access_secret: str = S3_SECRET,
     data_max_files: int = -1,
     data_num_samples: int = -1,
     data_checkpointing: bool = False,
@@ -252,7 +253,15 @@ def gneissweb_classification(
             server_url=server_url,
         )
         ComponentUtils.add_settings_to_component(execute_job, ONE_WEEK_SEC)
-        ComponentUtils.set_s3_env_vars_to_component(execute_job, data_s3_access_secret)
+        if os.getenv("KFPv2", "0") == "1":
+            from kfp import kubernetes
+
+            # FIXME: Due to kubeflow/pipelines#10914, secret names cannot be provided as pipeline arguments.
+            # As a workaround, the secret name is hard coded.
+            env2key = ComponentUtils.set_secret_key_to_env(prefix="jjj")
+            kubernetes.use_secret_as_env(task=execute_job, secret_name=S3_SECRET, secret_key_to_env=env2key)
+        else:
+            ComponentUtils.set_s3_env_vars_to_component(execute_job, data_s3_access_secret)
         execute_job.after(ray_cluster)
 
 

--- a/transforms/language/gneissweb_classification/test/test_gneissweb_classification.py
+++ b/transforms/language/gneissweb_classification/test/test_gneissweb_classification.py
@@ -26,7 +26,6 @@ class TestLangIdentificationTransform(AbstractTableTransformTest):
 
     def get_test_transform_fixtures(self) -> list[tuple]:
         config = {
-            "gcls_model_credential": os.environ.get('HF_READ_ACCESS_TOKEN', "PUT YOUR OWN HUGGINGFACE CREDENTIAL"),
             "gcls_model_file_name": ["['fasttext_medical.bin']"],
             "gcls_model_url": ["['ibm-granite/GneissWeb.Med_classifier']"],
             "gcls_content_column_name": "contents",

--- a/transforms/language/gneissweb_classification/test/test_gneissweb_classification_python.py
+++ b/transforms/language/gneissweb_classification/test/test_gneissweb_classification_python.py
@@ -27,7 +27,6 @@ class TestPythonClassificationTransform(AbstractTransformLauncherTest):
 
     def get_test_transform_fixtures(self) -> list[tuple]:
         cli_params = {
-            "gcls_model_credential": os.environ.get('HF_READ_ACCESS_TOKEN', "PUT YOUR OWN HUGGINGFACE CREDENTIAL"),
             "gcls_model_file_name": ["fasttext_medical.bin"],
             "gcls_model_url":["ibm-granite/GneissWeb.Med_classifier"],
             "gcls_content_column_name": "text",

--- a/transforms/language/gneissweb_classification/test/test_gneissweb_classification_ray.py
+++ b/transforms/language/gneissweb_classification/test/test_gneissweb_classification_ray.py
@@ -35,7 +35,6 @@ class TestRayLangIdentificationTransform(AbstractTransformLauncherTest):
         basedir = "../test-data"
         basedir = os.path.abspath(os.path.join(os.path.dirname(__file__), basedir))
         config = {
-            model_credential_cli_param: os.environ.get('HF_READ_ACCESS_TOKEN', "PUT YOUR OWN HUGGINGFACE CREDENTIAL"),
             model_file_name_cli_param: ["fasttext_medical.bin"],
             model_url_cli_param:["ibm-granite/GneissWeb.Med_classifier"],
             content_column_name_cli_param: "text",


### PR DESCRIPTION
## Why are these changes needed?

Allow users to pass credentials as an environment variable and not always as a command line parameter.

## Related issue number (if any).


