### PR TITLE
Fix links for code transforms on main page

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ The matrix below shows the the combination of modules and supported runtimes. Al
 | Modules                                                                              |    Python-only     |        Ray         |       Spark        |     KFP on Ray     |
 |:-------------------------------------------------------------------------------------|:------------------:|:------------------:|:------------------:|:------------------:|
 | **Data Ingestion**                                                                   |                    |                    |                    |                    |
-| [Code (from zip) to Parquet](transforms/code/code2parquet/python/README.md) | :white_check_mark: | :white_check_mark: |                    | :white_check_mark: |
+| [Code (from zip) to Parquet](transforms/code/code2parquet/README.md) | :white_check_mark: | :white_check_mark: |                    | :white_check_mark: |
 | [PDF to Parquet](transforms/language/pdf2parquet/README.md)                 | :white_check_mark: | :white_check_mark: |                    | :white_check_mark: |
 | [HTML to Parquet](transforms/language/html2parquet/README.md)               | :white_check_mark: | :white_check_mark: |                    | :white_check_mark: |
 | [Web to Parquet](transforms/universal/web2parquet/README.md)                | :white_check_mark: |                    |                    |                |         
@@ -107,12 +107,12 @@ The matrix below shows the the combination of modules and supported runtimes. Al
 | [Readability scores](transforms/language/readability/README.md)          | :white_check_mark: | :white_check_mark: |                    |  |
 | [Extreme tokenized annotation](transforms/language/extreme_tokenized/README.md)          | :white_check_mark: | :white_check_mark: |                    |  |
 **Code-only**                                                                         |                    |                     |             |                    |
-| [Programming language annotation](transforms/code/proglang_select/python/README.md)  | :white_check_mark: | :white_check_mark: |                    | :white_check_mark: |
-| [Code quality annotation](transforms/code/code_quality/python/README.md)             | :white_check_mark: | :white_check_mark: |                    | :white_check_mark: |
+| [Programming language annotation](transforms/code/proglang_select/README.md)  | :white_check_mark: | :white_check_mark: |                    | :white_check_mark: |
+| [Code quality annotation](transforms/code/code_quality/README.md)             | :white_check_mark: | :white_check_mark: |                    | :white_check_mark: |
 | [Malware annotation](transforms/code/malware/python/README.md)                       | :white_check_mark: | :white_check_mark: |                    | :white_check_mark: |
 | [Header cleanser](transforms/code/header_cleanser/python/README.md)                  | :white_check_mark: | :white_check_mark: |                    | :white_check_mark: |
 | [Semantic file ordering](transforms/code/repo_level_ordering/ray/README.md)          |                    | :white_check_mark: |                    |                    |
-| [License Select Annotation](transforms/code/license_select/python/README.md)         | :white_check_mark: | :white_check_mark: |                    | :white_check_mark: |
+| [License Select Annotation](transforms/code/license_select/README.md)         | :white_check_mark: | :white_check_mark: |                    | :white_check_mark: |
 | [Code profiler](transforms/code/code_profiler/README.md)                             | :white_check_mark: | :white_check_mark: |                    |  |
 
 </details>

--- a/transforms/requirements-ray.txt
+++ b/transforms/requirements-ray.txt
@@ -1,4 +1,4 @@
-data-prep-toolkit[ray]>=0.2.5.dev0
+data-prep-toolkit[ray]
 networkx==3.3
 colorlog==6.8.2
 func-timeout==4.3.5

--- a/transforms/requirements-ray.txt
+++ b/transforms/requirements-ray.txt
@@ -1,4 +1,4 @@
-data-prep-toolkit[ray]
+data-prep-toolkit[ray]>=0.2.5.dev0
 networkx==3.3
 colorlog==6.8.2
 func-timeout==4.3.5


### PR DESCRIPTION
## Why are these changes needed?

Code transforms that were recently refactored are still poiting to old files
## Related issue number (if any).


