### PR TITLE
Making consistent use of pip

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Data Prep Kit can readily scale from a commodity laptop all the way to data cent
 The latest version of the Data Prep Kit is available on PyPi for Python 3.10, 3.11 and 3.12. It can be installed using: 
 
 ```bash
-pip install  'data-prep-toolkit-transforms[all]'
+pip install 'data-prep-toolkit-transforms[all]'
 ```
 
 This will install all available transforms. 

--- a/doc/quick-start/quick-start.md
+++ b/doc/quick-start/quick-start.md
@@ -35,22 +35,21 @@ The command above should say: 3.11
 **install data prep toolkit**
 
 ```shell
-pip3 install 'data-prep-toolkit-transforms[ray,all]'
+pip install 'data-prep-toolkit-transforms[ray,all]'
 ```
 the command above install the complete library with all the tansforms. In certain situations, it may be desirable to install a specific transform with or without the ray runtime. In that case, the command can specify the name of the transform in the \[extra\] value such as:
 
-To install the lang_id transform, use the following command:
+To install the lang_id transform (lang_id transform is used for identifying the language of the content ), use the following command:
 
 ```shell
-pip3 install 'data-prep-toolkit-transforms[lang_id]' 
+pip install 'data-prep-toolkit-transforms[lang_id]' 
 ```
 
 to install the lang_id transform with the ray runtime, use the following command:
 
 ```shell
-pip3 install 'data-prep-toolkit-transforms[ray,lang_id]' 
+pip install 'data-prep-toolkit-transforms[ray,lang_id]' 
 ```
-
 
 
 ## Setting up Jupyter lab for local experimentation with transform notebooks <a name = "jupyter"></a>
@@ -87,4 +86,3 @@ python -m ipykernel install --user --name=data-prep-kit --display-name "dataprep
 ## Creating transforms
 
 * [Tutorial](contribute-your-own-transform.md) - shows how to use the library to add a new transform.
-

--- a/examples/pdf-processing-1/README.md
+++ b/examples/pdf-processing-1/README.md
@@ -27,7 +27,7 @@ conda activate data-prep-kit
 
 # install the following in 'data-prep-kit' environment
 cd examples/pdf-processing-1
-pip3 install  -r requirements.txt
+pip install  -r requirements.txt
 
 # start jupyter and run the notebooks with this jupyter
 jupyter lab
@@ -51,5 +51,3 @@ If you encounter any errors loading libraries, try creating a custom kernel and 
 python -m ipykernel install --user --name=data-prep-kit --display-name "dataprepkit"
 # and select this kernel within jupyter notebook
 ```
-
-

--- a/examples/pdf-processing-1/README.md
+++ b/examples/pdf-processing-1/README.md
@@ -27,7 +27,7 @@ conda activate data-prep-kit
 
 # install the following in 'data-prep-kit' environment
 cd examples/pdf-processing-1
-pip install  -r requirements.txt
+pip install -r requirements.txt
 
 # start jupyter and run the notebooks with this jupyter
 jupyter lab


### PR DESCRIPTION
## Why are these changes needed?

Documentation was mostly using `pip3` whereas scripts mostly using `pip`. Making it consistent.
 
## Related issue number (if any).


