### PR TITLE
fix: update broken link of yaml file in ml_filter README

### DIFF
--- a/transforms/language/ml_filter/README.md
+++ b/transforms/language/ml_filter/README.md
@@ -10,7 +10,7 @@ testing and IDE set up.
 - Cezar Pendus (cpendus@us.ibm.com)
 
 ## Summary 
-This transform filters the data using conditions specified in a corresponding yaml file. Here is a sample [yaml file](./test-data/input/cleansing-config.yaml).
+This transform filters the data using conditions specified in a corresponding yaml file. Here is a sample [yaml file](./cleansing-config.yaml).
 
 The input table must contain all the values specified in the filtering conditions, as well as a language identifier (`lang`).
 The language identifier column name can be set with --filter_lang_column_name.


### PR DESCRIPTION
## Why are these changes needed?

Fixed the broken link to `cleansing-config.yaml` in the ml_filter README. The file was already in the correct location, just needed to update the link to point to it properly.

Fixes #1270 

