### PR TITLE
fix code_quality transform failure with empty contents

### DIFF
--- a/transforms/code/code_quality/dpk_code_quality/transform.py
+++ b/transforms/code/code_quality/dpk_code_quality/transform.py
@@ -60,7 +60,7 @@ def is_html(data, lang):
 
         # get text
         text = soup.get_text()
-        ratio = len(text) / len(html)
+        ratio = (len(text) / len(html)) if len(html) > 0 else 0
         if ratio > 0.2 and len(text) > 100:
             return True
     return False
@@ -72,6 +72,13 @@ def calculate_line_stats(data, lines_max=7):
     Calculates mean and max line length of file
     """
     line_lengths = np.array([len(line) for line in data.splitlines()])
+    if line_lengths.shape[0] == 0:
+        return {
+            "line_mean": 0,
+            "line_max": 0,
+            "avg_longest_lines": 0,
+            "num_lines": 0,
+        }
     if line_lengths.shape[0] < lines_max:
         lines_max = line_lengths.shape[0]
     longest_lines = np.sort(line_lengths)[::-1][:lines_max]
@@ -87,7 +94,7 @@ def calculate_alpha_stats(data):
     """
     Calculates mean alpha numeric of input data
     """
-    alphanum_frac = np.mean([c.isalnum() for c in data])
+    alphanum_frac = np.mean([c.isalnum() for c in data]) if len(data) > 0 else 0
     return {"alphanum_frac": alphanum_frac}
 
 
@@ -96,7 +103,7 @@ def calculate_char_token_ratio(data, tokenizer):
     Compute character/token ratio of the file with tokenizer.
     """
     input_ids = tokenizer(data, truncation=False)["input_ids"]
-    ratio = len(data) / len(input_ids)
+    ratio = (len(data) / len(input_ids)) if len(input_ids) > 0 else 0
     return {"char_token_ratio": ratio}
 
 
@@ -212,7 +219,7 @@ def top_most_frequent_word_percent(data):
 def alphabetic_percent(data):
     total_chars = len(data)
     alphabetic_chars_count = sum(1 for char in data if char.isalpha())
-    alphabetic_percent = (alphabetic_chars_count / total_chars) * 100 if total_chars > 0 else 0
+    alphabetic_percent = ((alphabetic_chars_count / total_chars) * 100) if total_chars > 0 else 0
     return alphabetic_percent
 
 
@@ -241,7 +248,7 @@ def encoded_data_stats(data):
         if max_encoded_data_length < match_length:
             max_encoded_data_length = match_length
 
-    encoded_data_percent = total_matched_length / len(data)
+    encoded_data_percent = (total_matched_length / len(data)) if len(data) > 0 else 0
     return max_encoded_data_length, encoded_data_percent
 
 

--- a/transforms/code/code_quality/dpk_code_quality/transform.py
+++ b/transforms/code/code_quality/dpk_code_quality/transform.py
@@ -74,9 +74,9 @@ def calculate_line_stats(data, lines_max=7):
     line_lengths = np.array([len(line) for line in data.splitlines()])
     if line_lengths.shape[0] == 0:
         return {
-            "line_mean": 0,
+            "line_mean": 0.0,
             "line_max": 0,
-            "avg_longest_lines": 0,
+            "avg_longest_lines": 0.0,
             "num_lines": 0,
         }
     if line_lengths.shape[0] < lines_max:
@@ -94,16 +94,16 @@ def calculate_alpha_stats(data):
     """
     Calculates mean alpha numeric of input data
     """
-    alphanum_frac = np.mean([c.isalnum() for c in data]) if len(data) > 0 else 0
+    alphanum_frac = np.mean([c.isalnum() for c in data]) if len(data) > 0 else 0.0
     return {"alphanum_frac": alphanum_frac}
 
 
-def calculate_char_token_ratio(data, tokenizer):
+def calculate_char_token_ratio(data, tokenizer) -> dict[str, float]:
     """
     Compute character/token ratio of the file with tokenizer.
     """
     input_ids = tokenizer(data, truncation=False)["input_ids"]
-    ratio = (len(data) / len(input_ids)) if len(input_ids) > 0 else 0
+    ratio:float = (len(data) / len(input_ids)) if len(input_ids) > 0 else 0.0
     return {"char_token_ratio": ratio}
 
 
@@ -195,32 +195,32 @@ def has_few_assignments(data, language, minimum=4):
 
 
 # metrics inspired from OLMOE https://huggingface.co/datasets/allenai/OLMoE-mix-0924
-def top_most_frequent_word_percent(data):
+def top_most_frequent_word_percent(data) -> tuple[float, float]:
     # Convert to lowercase and remove punctuation
     words = re.findall(r"\b\w+\b", data.lower())
 
     total_words = len(words)
     if total_words == 0:
-        return 0, 0
+        return 0.0, 0.0
 
     word_counts = Counter(words)
     most_common = word_counts.most_common(2)
     _, top_word_count = most_common[0]
-    top_word_percent = (top_word_count / total_words) * 100
+    top_word_percent: float = (top_word_count / total_words) * 100.0
 
-    top_two_words_percent = 0
+    top_two_words_percent: float= 0.0
     if len(most_common) >= 2:
         _, second_top_word_count = most_common[1]
-        top_two_words_percent = ((top_word_count + second_top_word_count) / total_words) * 100
+        top_two_words_percent = ((top_word_count + second_top_word_count) / total_words) * 100.0
 
     return top_word_percent, top_two_words_percent
 
 
-def alphabetic_percent(data):
+def alphabetic_percent(data) -> float:
     total_chars = len(data)
     alphabetic_chars_count = sum(1 for char in data if char.isalpha())
-    alphabetic_percent = ((alphabetic_chars_count / total_chars) * 100) if total_chars > 0 else 0
-    return alphabetic_percent
+    _alphabetic_percent:float = ((alphabetic_chars_count / total_chars) * 100.0) if total_chars > 0 else 0.0
+    return _alphabetic_percent
 
 
 def encoded_data_stats(data):


### PR DESCRIPTION
## Why are these changes needed?
#1299 
`code.code_quality` transform fails when the value of `contents` column is an empty string by the following errors:

```console
00:36:56 WARNING - Exception zero-size array to reduction operation maximum which has no identity processing file cos-optimal-llm-pile/bluepile-processing/code_rel0_4/tables/processed/combinedcode/header_cleanser_filtered_cq_size/data/dataset=bluepile_github/language=C%2B%2B/01688-29727-d8abf43d-4cce-4e5c-9422-c0895f4adc71-0-00001.parquet: Traceback (most recent call last):
  File "/home/ray/anaconda3/lib/python3.10/site-packages/data_processing/runtime/transform_file_processor.py", line 62, in process_file
    out_files, stats = self.transform.transform_binary(file_name=f_name, byte_array=filedata)
  File "/home/ray/anaconda3/lib/python3.10/site-packages/data_processing/transform/table_transform.py", line 59, in transform_binary
    out_tables, stats = self.transform(table=table, file_name=file_name)
  File "/home/ray/code_quality_transform_ray_ibm.py", line 323, in transform
    tables, metadata = super().transform(table, file_name)
  File "/home/ray/python-transform/src/code_quality_transform.py", line 230, in transform
    stats = calculate_line_stats(c)
  File "/home/ray/python-transform/src/code_quality_transform.py", line 79, in calculate_line_stats
    "line_max": np.max(line_lengths),
  File "<__array_function__ internals>", line 200, in amax
  File "/home/ray/anaconda3/lib/python3.10/site-packages/numpy/core/fromnumeric.py", line 2820, in amax
    return _wrapreduction(a, np.maximum, 'max', axis, None, out,
  File "/home/ray/anaconda3/lib/python3.10/site-packages/numpy/core/fromnumeric.py", line 86, in _wrapreduction
    return ufunc.reduce(obj, axis, dtype, out, **passkwargs)
ValueError: zero-size array to reduction operation maximum which has no identity
```
```console
00:55:33 WARNING - Exception division by zero processing file cos-optimal-llm-pile/bluepile-processing/code_rel0_4/tables/processed/combinedcode/header_cleanser_filtered_cq_size/data/dataset=starcoder/language=ocaml/00062-6974-8461031e-4899-483c-8fe3-58c5a2951b4c-0-00007.parquet: Traceback (most recent call last):
  File "/home/ray/anaconda3/lib/python3.10/site-packages/data_processing/runtime/transform_file_processor.py", line 62, in process_file
    out_files, stats = self.transform.transform_binary(file_name=f_name, byte_array=filedata)
  File "/home/ray/anaconda3/lib/python3.10/site-packages/data_processing/transform/table_transform.py", line 59, in transform_binary
    out_tables, stats = self.transform(table=table, file_name=file_name)
  File "/home/ray/code_quality_transform_ray_ibm.py", line 345, in transform
    max_encoded_data_length, encoded_data_percent = encoded_data_stats(c)
  File "/home/ray/code_quality_transform_ray_ibm.py", line 306, in encoded_data_stats
    encoded_data_percent = total_matched_length / len(data)
ZeroDivisionError: division by zero
```
```console
00:44:35 WARNING - Exception division by zero processing file cos-optimal-llm-pile/bluepile-processing/code_rel0_4/tables/processed/combinedcode/header_cleanser_filtered_cq_size/data/dataset=starcoder/language=ocaml/00063-6599-9e036d4d-4633-43ee-ac88-efc6372dcbfc-0-00002.parquet: Traceback (most recent call last):
  File "/home/ray/anaconda3/lib/python3.10/site-packages/data_processing/runtime/transform_file_processor.py", line 62, in process_file
    out_files, stats = self.transform.transform_binary(file_name=f_name, byte_array=filedata)
  File "/home/ray/anaconda3/lib/python3.10/site-packages/data_processing/transform/table_transform.py", line 59, in transform_binary
    out_tables, stats = self.transform(table=table, file_name=file_name)
  File "/home/ray/code_quality_transform_ray_ibm.py", line 323, in transform
    tables, metadata = super().transform(table, file_name)
  File "/home/ray/python-transform/src/code_quality_transform.py", line 244, in transform
    char_token_ratio_values.append(calculate_char_token_ratio(c, self.tokenizer)["char_token_ratio"])
  File "/home/ray/python-transform/src/code_quality_transform.py", line 105, in calculate_char_token_ratio
    ratio = len(data) / len(input_ids)
ZeroDivisionError: division by zero
```
```console
02:03:48 WARNING - Exception division by zero processing file cos-optimal-llm-pile/bluepile-processing/code_rel0_4/tables/processed/combinedcode/header_cleanser_filtered_cq_size/data/dataset=bluepile_github/language=HTML/01738-23691-f58a0dd5-11c1-4082-93c2-b683faaf9c4a-0-00001.parquet: Traceback (most recent call last):
  File "/home/ray/anaconda3/lib/python3.10/site-packages/data_processing/runtime/transform_file_processor.py", line 62, in process_file
    out_files, stats = self.transform.transform_binary(file_name=f_name, byte_array=filedata)
  File "/home/ray/anaconda3/lib/python3.10/site-packages/data_processing/transform/table_transform.py", line 59, in transform_binary
    out_tables, stats = self.transform(table=table, file_name=file_name)
  File "/home/ray/code_quality_transform_ray_ibm.py", line 323, in transform
    tables, metadata = super().transform(table, file_name)
  File "/home/ray/python-transform/src/code_quality_transform.py", line 251, in transform
    is_html_values.append(is_html(c, languages[i]))
  File "/home/ray/python-transform/src/code_quality_transform.py", line 62, in is_html
    ratio = len(text) / len(html)
ZeroDivisionError: division by zero
```
```console
03:43:06 WARNING - Exception {"snaphotId":null,"status":null,"elapsedTimeSeconds":1.811,"message":"com.ibm.arc.lakehousedata.exception.SchemaException: Field top_two_words_percent should have type double and it has type long"} processing file cos-optimal-llm-pile/bluepile-processing/code_rel0_4/tables/processed/combinedcode/header_cleanser_filtered_cq_size/data/dataset=github_fullscan_v1/language=RDoc/00315-19354-07ec7163-a930-4dbd-9f6b-4a9b5b401d81-0-00017.parquet: Traceback (most recent call last):
  File "/home/ray/anaconda3/lib/python3.10/site-packages/data_processing/runtime/transform_file_processor.py", line 68, in process_file
    self._submit_file(t_start=t_start, out_files=out_files, stats=stats)
  File "/home/ray/anaconda3/lib/python3.10/site-packages/ray/util/tracing/tracing_helper.py", line 467, in _resume_span
    return method(self, *_args, **_kwargs)
  File "/home/ray/anaconda3/lib/python3.10/site-packages/data_processing/runtime/transform_file_processor.py", line 127, in _submit_file
    save_res, retries = self.data_access.save_file(path=output_name, data=file_ext[0])
  File "/home/ray/anaconda3/lib/python3.10/site-packages/data_processing_ibm/data_access/data_access_lh.py", line 356, in save_file
    return self.save_table(path, table)
  File "/home/ray/anaconda3/lib/python3.10/site-packages/data_processing_ibm/data_access/data_access_lh.py", line 230, in save_table
    status = self.lh.update_table(path)
  File "/home/ray/anaconda3/lib/python3.10/site-packages/lakehouse/services.py", line 220, in update_table
    return self.target_catalog.update_table(self.output_table_name, file_path)
  File "/home/ray/anaconda3/lib/python3.10/site-packages/lakehouse/catalog.py", line 292, in update_table
    return self.api.populate_output_iceberg_table(output_table_name=output_table_name,parquet_file_paths=[file_path])
  File "/home/ray/anaconda3/lib/python3.10/site-packages/lakehouse/api.py", line 531, in populate_output_iceberg_table
    raise exception
  File "/home/ray/anaconda3/lib/python3.10/site-packages/lakehouse/api.py", line 525, in populate_output_iceberg_table
    return self._make_api_post_call(payload=payload, params="", path='data/addFiles')
  File "/home/ray/anaconda3/lib/python3.10/site-packages/lakehouse/api.py", line 553, in _make_api_post_call
    raise Exception(response.text)
Exception: {"snaphotId":null,"status":null,"elapsedTimeSeconds":1.811,"message":"com.ibm.arc.lakehousedata.exception.SchemaException: Field top_two_words_percent should have type double and it has type long"}
```