### PR TITLE
Fix imcompatible versions for PySpark

### DIFF
--- a/data-processing-lib/spark/requirements.txt
+++ b/data-processing-lib/spark/requirements.txt
@@ -1,3 +1,5 @@
-pyspark>=3.5.2
+## Latest release of pyspark 4.0.0 does not work with current default version of JAVA in Ubuntu-22.04
+## limit to 3.5.5 until we upgrade the github verification and validation workflow to newer JAVA release
+pyspark>=3.5.2,<=3.5.5
 psutil>=6.0.0
 PyYAML>=6.0.2


### PR DESCRIPTION
## Why are these changes needed?

The latest release of PySpark 4.0.0 on May 22, 2025 is not compatible with the current release of Java used by the workflow. Address this issue by using PySpark 3.5.5
Keep issue open as the final solution will be upgraded the workflow to use a newer version of Java
## Related issue number (if any).
#1324 1324
