### PR TITLE
Modify local access class to allow caching of tables in memory

### DIFF
--- a/.github/workflows/test-chain-dpk_transform_chain.yml
+++ b/.github/workflows/test-chain-dpk_transform_chain.yml
@@ -60,6 +60,7 @@ jobs:
 
 
     test-src:
+
         needs: [check_if_allowed]
         runs-on: ubuntu-22.04
         env:
@@ -73,6 +74,10 @@ jobs:
 
             - name: Checkout
               uses: actions/checkout@v4
+              with:
+                # Requires careful code review prior to triggering workflow
+                ref: ${{ github.event.pull_request.head.sha }}
+
             - name: Test transform source in transforms/chain
               run: |
                   if [ -e "transforms/chain/Makefile" ]; then

--- a/data-processing-lib/python/src/data_processing/data_access/data_access_local.py
+++ b/data-processing-lib/python/src/data_processing/data_access/data_access_local.py
@@ -88,14 +88,21 @@ class DataAccessLocal(DataAccess):
                          files_to_use=files_to_use, files_to_checkpoint=files_to_checkpoint)
 
         ######
+        ## data_config = {'input_folder': str= 'path to input folder',
+        ##               'output_folder': str='path to output folder',
+        ##              'cache' : bool = True | False}
         ## Calling DataAccessLocal.validate_config should have caught this in a production setting
         ## but we still allow the class to be created with no configuration defined. Why ?
+        self.tables = {}
+
         if config is None:
             self.input_folder = None
             self.output_folder = None
+            self.cache = False
         else:
             self.input_folder = os.path.abspath(config["input_folder"])
             self.output_folder = os.path.abspath(config["output_folder"])
+            self.cache = config.get('cache', False)
         ######
 
         logger.debug(f"Local input folder: {self.input_folder}")
@@ -162,6 +169,10 @@ class DataAccessLocal(DataAccess):
         Returns:
             pyarrow.Table: PyArrow table if read successfully, None otherwise.
         """
+        # if the table exists in memory, use it for faster access
+        if self.tables.get(path):
+            logger.debug('Table found in memory') 
+            return self.tables[path], 0
 
         try:
             table = pq.read_table(path)
@@ -186,6 +197,10 @@ class DataAccessLocal(DataAccess):
                     - size (int): The size of the file (bytes).
                 If saving fails, file_info will be None.
         """
+        #save the table in memory for faster access
+        if self.cache:
+           self.tables[path] = table
+
         # Get table size in memory
         size_in_memory = table.nbytes
         try:

--- a/data-processing-lib/python/test/data_processing_tests/data_access/data_access_local_test.py
+++ b/data-processing-lib/python/test/data_processing_tests/data_access/data_access_local_test.py
@@ -30,6 +30,7 @@ class TestInit:
     path_dict = {
         "input_folder": os.path.join(os.sep, "tmp", "input_guf"),
         "output_folder": os.path.join(os.sep, "tmp", "output_guf"),
+        "cache": True,
     }
     dal = DataAccessLocal(path_dict, d_sets=["dset1", "dset2"], checkpoint=True, m_files=-1)
     size_stat_dict_empty = {"max_file_size": 0.0, "min_file_size": float(GB), "total_file_size": 0.0}
@@ -464,9 +465,11 @@ class TestSavePyarrowTable(TestInit):
         with patch("os.path.getsize") as mock_getsize, patch("os.path.basename") as mock_basename:
             mock_getsize.return_value = 1024
             mock_basename.return_value = "test_file.parquet"
+            assert len(self.dal.tables) == 0
             size_in_memory, file_info, _ = self.dal.save_table(self.pq_file_path, self.table)
             os.remove(self.pq_file_path)
             # Assertions about return values
+            assert len(self.dal.tables) > 0
             assert size_in_memory == self.table.nbytes
             assert file_info == {"name": "test_file.parquet", "size": 1024}
 

--- a/transforms/chain/test/test_transform_chain.py
+++ b/transforms/chain/test/test_transform_chain.py
@@ -40,7 +40,7 @@ class TestTransformChain:
         doc_quality = DocQualityTransform(dq)
 
         da_config = {
-            "local_config": {
+            "config": {
                 "input_folder": os.path.join(basedir, "input"),
                 "output_folder": os.path.join(basedir, "output"),
             },


### PR DESCRIPTION
## Why are these changes needed?

Save tables to memory in order to optimize disk access for consecutive read/write

## Related issue number (if any).


