### PR TITLE
Change fasttext dependency to eliminate collisions with user environment 

### DIFF
--- a/.github/workflows/test-misc.yml
+++ b/.github/workflows/test-misc.yml
@@ -32,6 +32,14 @@ on:
             - "**/.dockerignore"
 
 jobs:
+    view_platform:
+        runs-on: ubuntu-22.04
+        steps:
+            - id: platform
+              run: |
+               python --version
+               python -c "import platform; print (platform.uname())"
+
     check-transform-test-workflows:
         runs-on: ubuntu-22.04
         steps:

--- a/data-processing-lib/python/requirements.txt
+++ b/data-processing-lib/python/requirements.txt
@@ -7,5 +7,10 @@ mmh3
 psutil
 polars>=1.9.0
 transformers
-fasttext-wheel
+## install fasttext-wheel or fasttext for the platforms that we have tested with including docker image we build
+fasttext-wheel ; sys_platform=='darwin' or sys_platform=="win32"
+fasttext-wheel ; sys_platform=="linux" and platform_release=="6.12.13-200.fc41.aarch64"
+fasttext-wheel ; sys_platform=="linux" and platform_release=="6.8.0-1030-azure"
+## for all other platforms, require fasttext and pre-installed by the user with gcc as required
+#fasttext ; sys_platform=="linux" and platform_release!="6.12.13-200.fc41.aarch64" and platform_release!="6.8.0-1030-azure"
 huggingface-hub >= 0.21.4, <1.0.0

--- a/transforms/language/enrichment/requirements.txt
+++ b/transforms/language/enrichment/requirements.txt
@@ -2,6 +2,5 @@ ftfy
 unicategories
 unicodedataplus
 datatrove
-fasttext
 nltk
 spacy

--- a/transforms/language/gneissweb_classification/requirements.txt
+++ b/transforms/language/gneissweb_classification/requirements.txt
@@ -1,4 +1,3 @@
-fasttext-wheel
 langcodes>=3.5.0
 huggingface-hub >= 0.21.4, <1.0.0
 numpy>=1.26.4, < 1.29.0

--- a/transforms/language/lang_id/requirements.txt
+++ b/transforms/language/lang_id/requirements.txt
@@ -1,4 +1,3 @@
-fasttext-wheel
 langcodes>=3.3.0
 huggingface-hub >= 0.21.4, <1.0.0
 numpy==1.26.4


### PR DESCRIPTION
Setup fastttext-wheel dependencies to meet our own dev/build environments and requirement user to setup their own fasttext or add fasttext-wheel to their requirements files

## Why are these changes needed?

In some environment, our explicit dependency on fasttext-weel conflict with user environment setup for fasttext
Require users to always setup fasttext depending on their own environments. In most cases, users can simply add fasttext-wheel to their requirements.txt file in more complex setup, they will need to install gcc and install fasttext from source.

## Related issue number (if any).


