### PR TITLE
Fixing the logo in README.md 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
-
 <p align="center">
-<img src="doc/LF_DataPrepKit_Logotype_Positive.png#gh-light-mode-only" width="60%" height="60%" />
-<img src="doc/LF_DataPrepKit_Logotype_Negative.png#gh-dark-mode-only" width="60%" height="60%"/>
+<img src="doc/LF_DataPrepKit_Logotype_Positive.png#gh-light-mode-only" width="50%" />
+<img src="doc/LF_DataPrepKit_Logotype_Negative.png#gh-dark-mode-only" width="50%" />
 </p>
 
 <div align="center">


### PR DESCRIPTION
## Why are these changes needed?
The logo was stretched because both height and width were set to 60%. I've set the width only to be 50%. Height will adjust accordingly.

## Related issue number (if any).


