### PR TITLE
Adjust tagged dependencies to work with google collab

### DIFF
--- a/.github/workflows/test-code-code2parquet-kfp.yml
+++ b/.github/workflows/test-code-code2parquet-kfp.yml
@@ -16,7 +16,7 @@ on:
             - ".make.*"
             - "scripts/k8s-setup/requirements.env"
             - "transforms/.make.workflows"
-            - "transforms/code/code2parquet/**"
+            - "transforms/code/code2parquet/kfp_ray/**"
             - "!kfp/**" # This is tested in separate workflow
             - "!data-processing-lib/**" # This is tested in separate workflow
             - "!**.md"
@@ -32,7 +32,7 @@ on:
             - ".make.*"
             - "scripts/k8s-setup/requirements.env"
             - "transforms/.make.workflows"
-            - "transforms/code/code2parquet/**"
+            - "transforms/code/code2parquet/kfp_ray/**"
             - "!data-processing-lib/**" # This is tested in separate workflow
             - "!kfp/**" # This is tested in separate workflow
             - "!**.md"

--- a/.github/workflows/test-code-code_profiler-kfp.yml
+++ b/.github/workflows/test-code-code_profiler-kfp.yml
@@ -16,7 +16,7 @@ on:
             - ".make.*"
             - "scripts/k8s-setup/requirements.env"
             - "transforms/.make.workflows"
-            - "transforms/code/code_profiler/**"
+            - "transforms/code/code_profiler/kfp_ray/**"
             - "!kfp/**" # This is tested in separate workflow
             - "!data-processing-lib/**" # This is tested in separate workflow
             - "!**.md"
@@ -32,7 +32,7 @@ on:
             - ".make.*"
             - "scripts/k8s-setup/requirements.env"
             - "transforms/.make.workflows"
-            - "transforms/code/code_profiler/**"
+            - "transforms/code/code_profiler/kfp_ray/**"
             - "!data-processing-lib/**" # This is tested in separate workflow
             - "!kfp/**" # This is tested in separate workflow
             - "!**.md"

--- a/.github/workflows/test-code-code_quality-kfp.yml
+++ b/.github/workflows/test-code-code_quality-kfp.yml
@@ -16,7 +16,7 @@ on:
             - ".make.*"
             - "scripts/k8s-setup/requirements.env"
             - "transforms/.make.workflows"
-            - "transforms/code/code_quality/**"
+            - "transforms/code/code_quality/kfp_ray/**"
             - "!kfp/**" # This is tested in separate workflow
             - "!data-processing-lib/**" # This is tested in separate workflow
             - "!**.md"
@@ -34,7 +34,7 @@ on:
             - ".make.*"
             - "scripts/k8s-setup/requirements.env"
             - "transforms/.make.workflows"
-            - "transforms/code/code_quality/**"
+            - "transforms/code/code_quality/kfp_ray/**"
             - "!data-processing-lib/**" # This is tested in separate workflow
             - "!kfp/**" # This is tested in separate workflow
             - "!**.md"

--- a/.github/workflows/test-code-header_cleanser-kfp.yml
+++ b/.github/workflows/test-code-header_cleanser-kfp.yml
@@ -16,7 +16,7 @@ on:
             - ".make.*"
             - "scripts/k8s-setup/requirements.env"
             - "transforms/.make.workflows"
-            - "transforms/code/header_cleanser/**"
+            - "transforms/code/header_cleanser/kfp_ray/**"
             - "!kfp/**" # This is tested in separate workflow
             - "!data-processing-lib/**" # This is tested in separate workflow
             - "!**.md"
@@ -32,7 +32,7 @@ on:
             - ".make.*"
             - "scripts/k8s-setup/requirements.env"
             - "transforms/.make.workflows"
-            - "transforms/code/header_cleanser/**"
+            - "transforms/code/header_cleanser/kfp_ray/**"
             - "!data-processing-lib/**" # This is tested in separate workflow
             - "!kfp/**" # This is tested in separate workflow
             - "!**.md"

--- a/.github/workflows/test-code-license_select-kfp.yml
+++ b/.github/workflows/test-code-license_select-kfp.yml
@@ -16,7 +16,7 @@ on:
             - ".make.*"
             - "scripts/k8s-setup/requirements.env"
             - "transforms/.make.workflows"
-            - "transforms/code/license_select/**"
+            - "transforms/code/license_select/kfp_ray/**"
             - "!kfp/**" # This is tested in separate workflow
             - "!data-processing-lib/**" # This is tested in separate workflow
             - "!**.md"
@@ -32,7 +32,7 @@ on:
             - ".make.*"
             - "scripts/k8s-setup/requirements.env"
             - "transforms/.make.workflows"
-            - "transforms/code/license_select/**"
+            - "transforms/code/license_select/kfp_ray/**"
             - "!data-processing-lib/**" # This is tested in separate workflow
             - "!kfp/**" # This is tested in separate workflow
             - "!**.md"

--- a/.github/workflows/test-code-malware-kfp.yml
+++ b/.github/workflows/test-code-malware-kfp.yml
@@ -16,7 +16,7 @@ on:
             - ".make.*"
             - "scripts/k8s-setup/requirements.env"
             - "transforms/.make.workflows"
-            - "transforms/code/malware/**"
+            - "transforms/code/malware/kfp_ray/**"
             - "!kfp/**" # This is tested in separate workflow
             - "!data-processing-lib/**" # This is tested in separate workflow
             - "!**.md"
@@ -32,7 +32,7 @@ on:
             - ".make.*"
             - "scripts/k8s-setup/requirements.env"
             - "transforms/.make.workflows"
-            - "transforms/code/malware/**"
+            - "transforms/code/malware/kfp_ray/**"
             - "!data-processing-lib/**" # This is tested in separate workflow
             - "!kfp/**" # This is tested in separate workflow
             - "!**.md"

--- a/.github/workflows/test-code-proglang_select-kfp.yml
+++ b/.github/workflows/test-code-proglang_select-kfp.yml
@@ -16,7 +16,7 @@ on:
             - ".make.*"
             - "scripts/k8s-setup/requirements.env"
             - "transforms/.make.workflows"
-            - "transforms/code/proglang_select/**"
+            - "transforms/code/proglang_select/kfp_ray/**"
             - "!kfp/**" # This is tested in separate workflow
             - "!data-processing-lib/**" # This is tested in separate workflow
             - "!**.md"
@@ -32,7 +32,7 @@ on:
             - ".make.*"
             - "scripts/k8s-setup/requirements.env"
             - "transforms/.make.workflows"
-            - "transforms/code/proglang_select/**"
+            - "transforms/code/proglang_select/kfp_ray/**"
             - "!data-processing-lib/**" # This is tested in separate workflow
             - "!kfp/**" # This is tested in separate workflow
             - "!**.md"

--- a/.github/workflows/test-code-repo_level_order-kfp.yml
+++ b/.github/workflows/test-code-repo_level_order-kfp.yml
@@ -16,7 +16,7 @@ on:
             - ".make.*"
             - "scripts/k8s-setup/requirements.env"
             - "transforms/.make.workflows"
-            - "transforms/code/repo_level_order/**"
+            - "transforms/code/repo_level_order/kfp_ray/**"
             - "!kfp/**" # This is tested in separate workflow
             - "!data-processing-lib/**" # This is tested in separate workflow
             - "!**.md"
@@ -32,7 +32,7 @@ on:
             - ".make.*"
             - "scripts/k8s-setup/requirements.env"
             - "transforms/.make.workflows"
-            - "transforms/code/repo_level_order/**"
+            - "transforms/code/repo_level_order/kfp_ray/**"
             - "!data-processing-lib/**" # This is tested in separate workflow
             - "!kfp/**" # This is tested in separate workflow
             - "!**.md"

--- a/.github/workflows/test-language-doc_chunk-kfp.yml
+++ b/.github/workflows/test-language-doc_chunk-kfp.yml
@@ -16,7 +16,7 @@ on:
             - ".make.*"
             - "scripts/k8s-setup/requirements.env"
             - "transforms/.make.workflows"
-            - "transforms/language/doc_chunk/**"
+            - "transforms/language/doc_chunk/kfp_ray/**"
             - "!kfp/**" # This is tested in separate workflow
             - "!data-processing-lib/**" # This is tested in separate workflow
             - "!**.md"
@@ -32,7 +32,7 @@ on:
             - ".make.*"
             - "scripts/k8s-setup/requirements.env"
             - "transforms/.make.workflows"
-            - "transforms/language/doc_chunk/**"
+            - "transforms/language/doc_chunk/kfp_ray/**"
             - "!data-processing-lib/**" # This is tested in separate workflow
             - "!kfp/**" # This is tested in separate workflow
             - "!**.md"

--- a/.github/workflows/test-language-doc_quality-kfp.yml
+++ b/.github/workflows/test-language-doc_quality-kfp.yml
@@ -16,7 +16,7 @@ on:
             - ".make.*"
             - "scripts/k8s-setup/requirements.env"
             - "transforms/.make.workflows"
-            - "transforms/language/doc_quality/**"
+            - "transforms/language/doc_quality/kfp_ray/**"
             - "!kfp/**" # This is tested in separate workflow
             - "!data-processing-lib/**" # This is tested in separate workflow
             - "!**.md"
@@ -32,7 +32,7 @@ on:
             - ".make.*"
             - "scripts/k8s-setup/requirements.env"
             - "transforms/.make.workflows"
-            - "transforms/language/doc_quality/**"
+            - "transforms/language/doc_quality/kfp_ray/**"
             - "!data-processing-lib/**" # This is tested in separate workflow
             - "!kfp/**" # This is tested in separate workflow
             - "!**.md"

--- a/.github/workflows/test-language-docling2parquet-kfp.yml
+++ b/.github/workflows/test-language-docling2parquet-kfp.yml
@@ -16,7 +16,7 @@ on:
             - ".make.*"
             - "scripts/k8s-setup/requirements.env"
             - "transforms/.make.workflows"
-            - "transforms/language/docling2parquet/**"
+            - "transforms/language/docling2parquet/kfp_ray/**"
             - "!kfp/**" # This is tested in separate workflow
             - "!data-processing-lib/**" # This is tested in separate workflow
             - "!**.md"
@@ -32,7 +32,7 @@ on:
             - ".make.*"
             - "scripts/k8s-setup/requirements.env"
             - "transforms/.make.workflows"
-            - "transforms/language/docling2parquet/**"
+            - "transforms/language/docling2parquet/kfp_ray/**"
             - "!data-processing-lib/**" # This is tested in separate workflow
             - "!kfp/**" # This is tested in separate workflow
             - "!**.md"

--- a/.github/workflows/test-language-enrichment-kfp.yml
+++ b/.github/workflows/test-language-enrichment-kfp.yml
@@ -16,7 +16,7 @@ on:
             - ".make.*"
             - "scripts/k8s-setup/requirements.env"
             - "transforms/.make.workflows"
-            - "transforms/language/enrichment/**"
+            - "transforms/language/enrichment/kfp_ray/**"
             - "!kfp/**" # This is tested in separate workflow
             - "!data-processing-lib/**" # This is tested in separate workflow
             - "!**.md"
@@ -32,7 +32,7 @@ on:
             - ".make.*"
             - "scripts/k8s-setup/requirements.env"
             - "transforms/.make.workflows"
-            - "transforms/language/enrichment/**"
+            - "transforms/language/enrichment/kfp_ray/**"
             - "!data-processing-lib/**" # This is tested in separate workflow
             - "!kfp/**" # This is tested in separate workflow
             - "!**.md"

--- a/.github/workflows/test-language-extreme_tokenized-kfp.yml
+++ b/.github/workflows/test-language-extreme_tokenized-kfp.yml
@@ -16,7 +16,7 @@ on:
             - ".make.*"
             - "scripts/k8s-setup/requirements.env"
             - "transforms/.make.workflows"
-            - "transforms/language/extreme_tokenized/**"
+            - "transforms/language/extreme_tokenized/kfp_ray/**"
             - "!kfp/**" # This is tested in separate workflow
             - "!data-processing-lib/**" # This is tested in separate workflow
             - "!**.md"
@@ -32,7 +32,7 @@ on:
             - ".make.*"
             - "scripts/k8s-setup/requirements.env"
             - "transforms/.make.workflows"
-            - "transforms/language/extreme_tokenized/**"
+            - "transforms/language/extreme_tokenized/kfp_ray/**"
             - "!data-processing-lib/**" # This is tested in separate workflow
             - "!kfp/**" # This is tested in separate workflow
             - "!**.md"

--- a/.github/workflows/test-language-gneissweb_classification-kfp.yml
+++ b/.github/workflows/test-language-gneissweb_classification-kfp.yml
@@ -16,7 +16,7 @@ on:
             - ".make.*"
             - "scripts/k8s-setup/requirements.env"
             - "transforms/.make.workflows"
-            - "transforms/language/gneissweb_classification/**"
+            - "transforms/language/gneissweb_classification/kfp_ray/**"
             - "!kfp/**" # This is tested in separate workflow
             - "!data-processing-lib/**" # This is tested in separate workflow
             - "!**.md"
@@ -35,7 +35,7 @@ on:
             - ".make.*"
             - "scripts/k8s-setup/requirements.env"
             - "transforms/.make.workflows"
-            - "transforms/language/gneissweb_classification/**"
+            - "transforms/language/gneissweb_classification/kfp_ray/**"
             - "!data-processing-lib/**" # This is tested in separate workflow
             - "!kfp/**" # This is tested in separate workflow
             - "!**.md"

--- a/.github/workflows/test-language-html2parquet-kfp.yml
+++ b/.github/workflows/test-language-html2parquet-kfp.yml
@@ -16,7 +16,7 @@ on:
             - ".make.*"
             - "scripts/k8s-setup/requirements.env"
             - "transforms/.make.workflows"
-            - "transforms/language/html2parquet/**"
+            - "transforms/language/html2parquet/kfp_ray/**"
             - "!kfp/**" # This is tested in separate workflow
             - "!data-processing-lib/**" # This is tested in separate workflow
             - "!**.md"
@@ -32,7 +32,7 @@ on:
             - ".make.*"
             - "scripts/k8s-setup/requirements.env"
             - "transforms/.make.workflows"
-            - "transforms/language/html2parquet/**"
+            - "transforms/language/html2parquet/kfp_ray/**"
             - "!data-processing-lib/**" # This is tested in separate workflow
             - "!kfp/**" # This is tested in separate workflow
             - "!**.md"

--- a/.github/workflows/test-language-lang_id-kfp.yml
+++ b/.github/workflows/test-language-lang_id-kfp.yml
@@ -16,7 +16,7 @@ on:
             - ".make.*"
             - "scripts/k8s-setup/requirements.env"
             - "transforms/.make.workflows"
-            - "transforms/language/lang_id/**"
+            - "transforms/language/lang_id/kfp_ray/**"
             - "!kfp/**" # This is tested in separate workflow
             - "!data-processing-lib/**" # This is tested in separate workflow
             - "!**.md"
@@ -35,7 +35,7 @@ on:
             - ".make.*"
             - "scripts/k8s-setup/requirements.env"
             - "transforms/.make.workflows"
-            - "transforms/language/lang_id/**"
+            - "transforms/language/lang_id/kfp_ray/**"
             - "!data-processing-lib/**" # This is tested in separate workflow
             - "!kfp/**" # This is tested in separate workflow
             - "!**.md"

--- a/.github/workflows/test-language-ml_filter-kfp.yml
+++ b/.github/workflows/test-language-ml_filter-kfp.yml
@@ -16,7 +16,7 @@ on:
             - ".make.*"
             - "scripts/k8s-setup/requirements.env"
             - "transforms/.make.workflows"
-            - "transforms/language/ml_filter/**"
+            - "transforms/language/ml_filter/kfp_ray/**"
             - "!kfp/**" # This is tested in separate workflow
             - "!data-processing-lib/**" # This is tested in separate workflow
             - "!**.md"
@@ -32,7 +32,7 @@ on:
             - ".make.*"
             - "scripts/k8s-setup/requirements.env"
             - "transforms/.make.workflows"
-            - "transforms/language/ml_filter/**"
+            - "transforms/language/ml_filter/kfp_ray/**"
             - "!data-processing-lib/**" # This is tested in separate workflow
             - "!kfp/**" # This is tested in separate workflow
             - "!**.md"

--- a/.github/workflows/test-language-pii_redactor-kfp.yml
+++ b/.github/workflows/test-language-pii_redactor-kfp.yml
@@ -16,7 +16,7 @@ on:
             - ".make.*"
             - "scripts/k8s-setup/requirements.env"
             - "transforms/.make.workflows"
-            - "transforms/language/pii_redactor/**"
+            - "transforms/language/pii_redactor/kfp_ray/**"
             - "!kfp/**" # This is tested in separate workflow
             - "!data-processing-lib/**" # This is tested in separate workflow
             - "!**.md"
@@ -32,7 +32,7 @@ on:
             - ".make.*"
             - "scripts/k8s-setup/requirements.env"
             - "transforms/.make.workflows"
-            - "transforms/language/pii_redactor/**"
+            - "transforms/language/pii_redactor/kfp_ray/**"
             - "!data-processing-lib/**" # This is tested in separate workflow
             - "!kfp/**" # This is tested in separate workflow
             - "!**.md"

--- a/.github/workflows/test-language-readability-kfp.yml
+++ b/.github/workflows/test-language-readability-kfp.yml
@@ -16,7 +16,7 @@ on:
             - ".make.*"
             - "scripts/k8s-setup/requirements.env"
             - "transforms/.make.workflows"
-            - "transforms/language/readability/**"
+            - "transforms/language/readability/kfp_ray/**"
             - "!kfp/**" # This is tested in separate workflow
             - "!data-processing-lib/**" # This is tested in separate workflow
             - "!**.md"
@@ -32,7 +32,7 @@ on:
             - ".make.*"
             - "scripts/k8s-setup/requirements.env"
             - "transforms/.make.workflows"
-            - "transforms/language/readability/**"
+            - "transforms/language/readability/kfp_ray/**"
             - "!data-processing-lib/**" # This is tested in separate workflow
             - "!kfp/**" # This is tested in separate workflow
             - "!**.md"

--- a/.github/workflows/test-language-text_encoder-kfp.yml
+++ b/.github/workflows/test-language-text_encoder-kfp.yml
@@ -16,7 +16,7 @@ on:
             - ".make.*"
             - "scripts/k8s-setup/requirements.env"
             - "transforms/.make.workflows"
-            - "transforms/language/text_encoder/**"
+            - "transforms/language/text_encoder/kfp_ray/**"
             - "!kfp/**" # This is tested in separate workflow
             - "!data-processing-lib/**" # This is tested in separate workflow
             - "!**.md"
@@ -32,7 +32,7 @@ on:
             - ".make.*"
             - "scripts/k8s-setup/requirements.env"
             - "transforms/.make.workflows"
-            - "transforms/language/text_encoder/**"
+            - "transforms/language/text_encoder/kfp_ray/**"
             - "!data-processing-lib/**" # This is tested in separate workflow
             - "!kfp/**" # This is tested in separate workflow
             - "!**.md"

--- a/.github/workflows/test-universal-blocklist-kfp.yml
+++ b/.github/workflows/test-universal-blocklist-kfp.yml
@@ -16,7 +16,7 @@ on:
             - ".make.*"
             - "scripts/k8s-setup/requirements.env"
             - "transforms/.make.workflows"
-            - "transforms/universal/blocklist/**"
+            - "transforms/universal/blocklist/kfp_ray/**"
             - "!kfp/**" # This is tested in separate workflow
             - "!data-processing-lib/**" # This is tested in separate workflow
             - "!**.md"
@@ -32,7 +32,7 @@ on:
             - ".make.*"
             - "scripts/k8s-setup/requirements.env"
             - "transforms/.make.workflows"
-            - "transforms/universal/blocklist/**"
+            - "transforms/universal/blocklist/kfp_ray/**"
             - "!data-processing-lib/**" # This is tested in separate workflow
             - "!kfp/**" # This is tested in separate workflow
             - "!**.md"

--- a/.github/workflows/test-universal-collapse-kfp.yml
+++ b/.github/workflows/test-universal-collapse-kfp.yml
@@ -16,7 +16,7 @@ on:
             - ".make.*"
             - "scripts/k8s-setup/requirements.env"
             - "transforms/.make.workflows"
-            - "transforms/universal/collapse/**"
+            - "transforms/universal/collapse/kfp_ray/**"
             - "!kfp/**" # This is tested in separate workflow
             - "!data-processing-lib/**" # This is tested in separate workflow
             - "!**.md"
@@ -32,7 +32,7 @@ on:
             - ".make.*"
             - "scripts/k8s-setup/requirements.env"
             - "transforms/.make.workflows"
-            - "transforms/universal/collapse/**"
+            - "transforms/universal/collapse/kfp_ray/**"
             - "!data-processing-lib/**" # This is tested in separate workflow
             - "!kfp/**" # This is tested in separate workflow
             - "!**.md"

--- a/.github/workflows/test-universal-doc_id-kfp.yml
+++ b/.github/workflows/test-universal-doc_id-kfp.yml
@@ -16,7 +16,7 @@ on:
             - ".make.*"
             - "scripts/k8s-setup/requirements.env"
             - "transforms/.make.workflows"
-            - "transforms/universal/doc_id/**"
+            - "transforms/universal/doc_id/kfp_ray/**"
             - "!kfp/**" # This is tested in separate workflow
             - "!data-processing-lib/**" # This is tested in separate workflow
             - "!**.md"
@@ -32,7 +32,7 @@ on:
             - ".make.*"
             - "scripts/k8s-setup/requirements.env"
             - "transforms/.make.workflows"
-            - "transforms/universal/doc_id/**"
+            - "transforms/universal/doc_id/kfp_ray/**"
             - "!data-processing-lib/**" # This is tested in separate workflow
             - "!kfp/**" # This is tested in separate workflow
             - "!**.md"

--- a/.github/workflows/test-universal-ededup-kfp.yml
+++ b/.github/workflows/test-universal-ededup-kfp.yml
@@ -16,7 +16,7 @@ on:
             - ".make.*"
             - "scripts/k8s-setup/requirements.env"
             - "transforms/.make.workflows"
-            - "transforms/universal/ededup/**"
+            - "transforms/universal/ededup/kfp_ray/**"
             - "!kfp/**" # This is tested in separate workflow
             - "!data-processing-lib/**" # This is tested in separate workflow
             - "!**.md"
@@ -32,7 +32,7 @@ on:
             - ".make.*"
             - "scripts/k8s-setup/requirements.env"
             - "transforms/.make.workflows"
-            - "transforms/universal/ededup/**"
+            - "transforms/universal/ededup/kfp_ray/**"
             - "!data-processing-lib/**" # This is tested in separate workflow
             - "!kfp/**" # This is tested in separate workflow
             - "!**.md"

--- a/.github/workflows/test-universal-fdedup-kfp.yml
+++ b/.github/workflows/test-universal-fdedup-kfp.yml
@@ -16,7 +16,7 @@ on:
             - ".make.*"
             - "scripts/k8s-setup/requirements.env"
             - "transforms/.make.workflows"
-            - "transforms/universal/fdedup/**"
+            - "transforms/universal/fdedup/kfp_ray/**"
             - "!kfp/**" # This is tested in separate workflow
             - "!data-processing-lib/**" # This is tested in separate workflow
             - "!**.md"
@@ -32,7 +32,7 @@ on:
             - ".make.*"
             - "scripts/k8s-setup/requirements.env"
             - "transforms/.make.workflows"
-            - "transforms/universal/fdedup/**"
+            - "transforms/universal/fdedup/kfp_ray/**"
             - "!data-processing-lib/**" # This is tested in separate workflow
             - "!kfp/**" # This is tested in separate workflow
             - "!**.md"

--- a/.github/workflows/test-universal-filter-kfp.yml
+++ b/.github/workflows/test-universal-filter-kfp.yml
@@ -16,7 +16,7 @@ on:
             - ".make.*"
             - "scripts/k8s-setup/requirements.env"
             - "transforms/.make.workflows"
-            - "transforms/universal/filter/**"
+            - "transforms/universal/filter/kfp_ray/**"
             - "!kfp/**" # This is tested in separate workflow
             - "!data-processing-lib/**" # This is tested in separate workflow
             - "!**.md"
@@ -32,7 +32,7 @@ on:
             - ".make.*"
             - "scripts/k8s-setup/requirements.env"
             - "transforms/.make.workflows"
-            - "transforms/universal/filter/**"
+            - "transforms/universal/filter/kfp_ray/**"
             - "!data-processing-lib/**" # This is tested in separate workflow
             - "!kfp/**" # This is tested in separate workflow
             - "!**.md"

--- a/.github/workflows/test-universal-fineweb_quality_annotator-kfp.yml
+++ b/.github/workflows/test-universal-fineweb_quality_annotator-kfp.yml
@@ -16,7 +16,7 @@ on:
             - ".make.*"
             - "scripts/k8s-setup/requirements.env"
             - "transforms/.make.workflows"
-            - "transforms/universal/fineweb_quality_annotator/**"
+            - "transforms/universal/fineweb_quality_annotator/kfp_ray/**"
             - "!kfp/**" # This is tested in separate workflow
             - "!data-processing-lib/**" # This is tested in separate workflow
             - "!**.md"
@@ -32,7 +32,7 @@ on:
             - ".make.*"
             - "scripts/k8s-setup/requirements.env"
             - "transforms/.make.workflows"
-            - "transforms/universal/fineweb_quality_annotator/**"
+            - "transforms/universal/fineweb_quality_annotator/kfp_ray/**"
             - "!data-processing-lib/**" # This is tested in separate workflow
             - "!kfp/**" # This is tested in separate workflow
             - "!**.md"

--- a/.github/workflows/test-universal-gopher_repetition_annotator-kfp.yml
+++ b/.github/workflows/test-universal-gopher_repetition_annotator-kfp.yml
@@ -16,7 +16,7 @@ on:
             - ".make.*"
             - "scripts/k8s-setup/requirements.env"
             - "transforms/.make.workflows"
-            - "transforms/universal/gopher_repetition_annotator/**"
+            - "transforms/universal/gopher_repetition_annotator/kfp_ray/**"
             - "!kfp/**" # This is tested in separate workflow
             - "!data-processing-lib/**" # This is tested in separate workflow
             - "!**.md"
@@ -32,7 +32,7 @@ on:
             - ".make.*"
             - "scripts/k8s-setup/requirements.env"
             - "transforms/.make.workflows"
-            - "transforms/universal/gopher_repetition_annotator/**"
+            - "transforms/universal/gopher_repetition_annotator/kfp_ray/**"
             - "!data-processing-lib/**" # This is tested in separate workflow
             - "!kfp/**" # This is tested in separate workflow
             - "!**.md"

--- a/.github/workflows/test-universal-hap-kfp.yml
+++ b/.github/workflows/test-universal-hap-kfp.yml
@@ -16,7 +16,7 @@ on:
             - ".make.*"
             - "scripts/k8s-setup/requirements.env"
             - "transforms/.make.workflows"
-            - "transforms/universal/hap/**"
+            - "transforms/universal/hap/kfp_ray/**"
             - "!kfp/**" # This is tested in separate workflow
             - "!data-processing-lib/**" # This is tested in separate workflow
             - "!**.md"
@@ -32,7 +32,7 @@ on:
             - ".make.*"
             - "scripts/k8s-setup/requirements.env"
             - "transforms/.make.workflows"
-            - "transforms/universal/hap/**"
+            - "transforms/universal/hap/kfp_ray/**"
             - "!data-processing-lib/**" # This is tested in separate workflow
             - "!kfp/**" # This is tested in separate workflow
             - "!**.md"

--- a/.github/workflows/test-universal-noop-kfp.yml
+++ b/.github/workflows/test-universal-noop-kfp.yml
@@ -16,7 +16,7 @@ on:
             - ".make.*"
             - "scripts/k8s-setup/requirements.env"
             - "transforms/.make.workflows"
-            - "transforms/universal/noop/**"
+            - "transforms/universal/noop/kfp_ray/**"
             - "!kfp/**" # This is tested in separate workflow
             - "!data-processing-lib/**" # This is tested in separate workflow
             - "!**.md"
@@ -32,7 +32,7 @@ on:
             - ".make.*"
             - "scripts/k8s-setup/requirements.env"
             - "transforms/.make.workflows"
-            - "transforms/universal/noop/**"
+            - "transforms/universal/noop/kfp_ray/**"
             - "!data-processing-lib/**" # This is tested in separate workflow
             - "!kfp/**" # This is tested in separate workflow
             - "!**.md"

--- a/.github/workflows/test-universal-profiler-kfp.yml
+++ b/.github/workflows/test-universal-profiler-kfp.yml
@@ -16,7 +16,7 @@ on:
             - ".make.*"
             - "scripts/k8s-setup/requirements.env"
             - "transforms/.make.workflows"
-            - "transforms/universal/profiler/**"
+            - "transforms/universal/profiler/kfp_ray/**"
             - "!kfp/**" # This is tested in separate workflow
             - "!data-processing-lib/**" # This is tested in separate workflow
             - "!**.md"
@@ -32,7 +32,7 @@ on:
             - ".make.*"
             - "scripts/k8s-setup/requirements.env"
             - "transforms/.make.workflows"
-            - "transforms/universal/profiler/**"
+            - "transforms/universal/profiler/kfp_ray/**"
             - "!data-processing-lib/**" # This is tested in separate workflow
             - "!kfp/**" # This is tested in separate workflow
             - "!**.md"

--- a/.github/workflows/test-universal-rep_removal-kfp.yml
+++ b/.github/workflows/test-universal-rep_removal-kfp.yml
@@ -16,7 +16,7 @@ on:
             - ".make.*"
             - "scripts/k8s-setup/requirements.env"
             - "transforms/.make.workflows"
-            - "transforms/universal/rep_removal/**"
+            - "transforms/universal/rep_removal/kfp_ray/**"
             - "!kfp/**" # This is tested in separate workflow
             - "!data-processing-lib/**" # This is tested in separate workflow
             - "!**.md"
@@ -32,7 +32,7 @@ on:
             - ".make.*"
             - "scripts/k8s-setup/requirements.env"
             - "transforms/.make.workflows"
-            - "transforms/universal/rep_removal/**"
+            - "transforms/universal/rep_removal/kfp_ray/**"
             - "!data-processing-lib/**" # This is tested in separate workflow
             - "!kfp/**" # This is tested in separate workflow
             - "!**.md"

--- a/.github/workflows/test-universal-resize-kfp.yml
+++ b/.github/workflows/test-universal-resize-kfp.yml
@@ -16,7 +16,7 @@ on:
             - ".make.*"
             - "scripts/k8s-setup/requirements.env"
             - "transforms/.make.workflows"
-            - "transforms/universal/resize/**"
+            - "transforms/universal/resize/kfp_ray/**"
             - "!kfp/**" # This is tested in separate workflow
             - "!data-processing-lib/**" # This is tested in separate workflow
             - "!**.md"
@@ -32,7 +32,7 @@ on:
             - ".make.*"
             - "scripts/k8s-setup/requirements.env"
             - "transforms/.make.workflows"
-            - "transforms/universal/resize/**"
+            - "transforms/universal/resize/kfp_ray/**"
             - "!data-processing-lib/**" # This is tested in separate workflow
             - "!kfp/**" # This is tested in separate workflow
             - "!**.md"

--- a/.github/workflows/test-universal-tokenization-kfp.yml
+++ b/.github/workflows/test-universal-tokenization-kfp.yml
@@ -16,7 +16,7 @@ on:
             - ".make.*"
             - "scripts/k8s-setup/requirements.env"
             - "transforms/.make.workflows"
-            - "transforms/universal/tokenization/**"
+            - "transforms/universal/tokenization/kfp_ray/**"
             - "!kfp/**" # This is tested in separate workflow
             - "!data-processing-lib/**" # This is tested in separate workflow
             - "!**.md"
@@ -32,7 +32,7 @@ on:
             - ".make.*"
             - "scripts/k8s-setup/requirements.env"
             - "transforms/.make.workflows"
-            - "transforms/universal/tokenization/**"
+            - "transforms/universal/tokenization/kfp_ray/**"
             - "!data-processing-lib/**" # This is tested in separate workflow
             - "!kfp/**" # This is tested in separate workflow
             - "!**.md"

--- a/.github/workflows/test-universal-tokenization2arrow-kfp.yml
+++ b/.github/workflows/test-universal-tokenization2arrow-kfp.yml
@@ -16,7 +16,7 @@ on:
             - ".make.*"
             - "scripts/k8s-setup/requirements.env"
             - "transforms/.make.workflows"
-            - "transforms/universal/tokenization2arrow/**"
+            - "transforms/universal/tokenization2arrow/kfp_ray/**"
             - "!kfp/**" # This is tested in separate workflow
             - "!data-processing-lib/**" # This is tested in separate workflow
             - "!**.md"
@@ -32,7 +32,7 @@ on:
             - ".make.*"
             - "scripts/k8s-setup/requirements.env"
             - "transforms/.make.workflows"
-            - "transforms/universal/tokenization2arrow/**"
+            - "transforms/universal/tokenization2arrow/kfp_ray/**"
             - "!data-processing-lib/**" # This is tested in separate workflow
             - "!kfp/**" # This is tested in separate workflow
             - "!**.md"

--- a/data-processing-lib/python/requirements.txt
+++ b/data-processing-lib/python/requirements.txt
@@ -1,4 +1,8 @@
-numpy < 1.29.0
+# running into fasttext incompatibility issues with numpy >= 2.0
+#ValueError: Unable to avoid copy while creating an array as requested.
+#If using `np.array(obj, copy=False)` replace it with `np.asarray(obj)` to allow a copy when needed (no behavior change in NumPy 1.x).
+#For more details, see https://numpy.org/devdocs/numpy_2_0_migration_guide.html#adapting-to-changes-in-the-copy-keyword.
+numpy < 2.0.0
 pyarrow==16.1.0
 # Later version 1.38.7 is breaking authentication. 
 # check compatibility with other applications that depend on botocore(DMF, DSift, etc.)

--- a/kfp/kfp_ray_components/requirements.txt
+++ b/kfp/kfp_ray_components/requirements.txt
@@ -1,3 +1,3 @@
 # for fdedup
-scipy==1.13.0
+scipy
 

--- a/recipes/DPK-sequence/docling.ipynb
+++ b/recipes/DPK-sequence/docling.ipynb
@@ -58,8 +58,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%%capture cap --no-stderr\n",
-    "%pip install \"data-prep-toolkit-transforms[docling2parquet,doc_chunk]\""
+    "#%%capture cap --no-stderr\n",
+    "#%pip install \"data-prep-toolkit-transforms[docling2parquet,doc_chunk]\"\n",
+    "%pip install \"data-prep-toolkit @ git+https://github.com/touma-I/data-prep-kit-pkg@numpy-dependencies#subdirectory=data-processing-lib\"\n",
+    "%pip install \"data-prep-toolkit-transforms[docling2parquet,doc_chunk] @ git+https://github.com/touma-I/data-prep-kit-pkg@numpy-dependencies#subdirectory=transforms\"\n"
    ]
   },
   {

--- a/recipes/DPK-sequence/pdf_processing_python.ipynb
+++ b/recipes/DPK-sequence/pdf_processing_python.ipynb
@@ -60,8 +60,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%%capture cap --no-stderr\n",
-    "%pip install 'data-prep-toolkit-transforms[language]' tqdm humanfriendly"
+    "#%%capture cap --no-stderr\n",
+    "#%pip install 'data-prep-toolkit-transforms[language]' tqdm humanfriendly\n",
+    "%pip install \"data-prep-toolkit @ git+https://github.com/touma-I/data-prep-kit-pkg@numpy-dependencies#subdirectory=data-processing-lib\"\n",
+    "%pip install \"data-prep-toolkit-transforms[language] @ git+https://github.com/touma-I/data-prep-kit-pkg@numpy-dependencies#subdirectory=transforms\"\n",
+    "%pip install tqdm humanfriendly\n"
    ]
   },
   {

--- a/recipes/PII/Run_your_first_PII_redactor_transform.ipynb
+++ b/recipes/PII/Run_your_first_PII_redactor_transform.ipynb
@@ -84,8 +84,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%%capture cap --no-stderr\n",
-    "%pip install 'data-prep-toolkit-transforms[docling2parquet,pii_redactor]'\n",
+    "#%%capture cap --no-stderr\n",
+    "%pip install \"data-prep-toolkit @ git+https://github.com/touma-I/data-prep-kit-pkg@numpy-dependencies#subdirectory=data-processing-lib\"\n",
+    "%pip install \"data-prep-toolkit-transforms[docling2parquet,pii_redactor] @ git+https://github.com/touma-I/data-prep-kit-pkg@numpy-dependencies#subdirectory=transforms\"\n",
+    "#%pip install 'data-prep-toolkit-transforms[docling2parquet,pii_redactor]'\n",
     "import pandas as pd\n",
     "import os"
    ]

--- a/transforms/.make.workflows
+++ b/transforms/.make.workflows
@@ -1,3 +1,4 @@
+## Added comment line to trigger verification for all transforms in PR: https://github.com/data-prep-kit/data-prep-kit/pull/1367
 # Include the common rules.
 # Use "make help" to see them.
 include ${REPOROOT}/.make.defaults

--- a/transforms/code/repo_level_order/requirements.txt
+++ b/transforms/code/repo_level_order/requirements.txt
@@ -1,5 +1,5 @@
 networkx==3.3
 colorlog==6.8.2
 func-timeout==4.3.5
-pandas==2.2.2
+pandas
 emerge-viz==2.0.0

--- a/transforms/language/gneissweb_classification/requirements.txt
+++ b/transforms/language/gneissweb_classification/requirements.txt
@@ -1,4 +1,4 @@
 fasttext-wheel
 langcodes>=3.5.0
 huggingface-hub >= 0.21.4, <1.0.0
-numpy>=1.26.4, < 1.29.0
+numpy

--- a/transforms/language/lang_id/requirements.txt
+++ b/transforms/language/lang_id/requirements.txt
@@ -1,5 +1,5 @@
 fasttext-wheel
 langcodes>=3.3.0
 huggingface-hub >= 0.21.4, <1.0.0
-numpy==1.26.4
+numpy
 transformers

--- a/transforms/language/pii_redactor/requirements.txt
+++ b/transforms/language/pii_redactor/requirements.txt
@@ -4,7 +4,7 @@
 numpy<1.29,>=1.22
 # Force upgrade to pydantic 2.8.1 as pydantic 2.5.0 is causing error with python 3.12
 #TypeError: ForwardRef._evaluate() missing 1 required keyword-only argument: 'recursive_guard'
-pydantic==2.8.2 
+pydantic>=2.8.2
 presidio-analyzer>=2.2.355
 presidio-anonymizer>=2.2.355
 flair>=0.14.0

--- a/transforms/language/pii_redactor/requirements.txt
+++ b/transforms/language/pii_redactor/requirements.txt
@@ -1,6 +1,7 @@
-# Later versions of numpy is ausing error with:
+# Later versions of numpy is causing error with:
 # AttributeError: module 'numpy' has no attribute 'AxisError'
-numpy
+# cupy-cuda12x 13.1.0 requires numpy<1.29,>=1.22, but you have numpy 2.3.1 which is incompatible.
+numpy<1.29,>=1.22
 # Force upgrade to pydantic 2.8.1 as pydantic 2.5.0 is causing error with python 3.12
 #TypeError: ForwardRef._evaluate() missing 1 required keyword-only argument: 'recursive_guard'
 pydantic==2.8.2 

--- a/transforms/language/pii_redactor/requirements.txt
+++ b/transforms/language/pii_redactor/requirements.txt
@@ -1,6 +1,6 @@
 # Later versions of numpy is ausing error with:
 # AttributeError: module 'numpy' has no attribute 'AxisError'
-numpy < 1.29.0
+numpy
 # Force upgrade to pydantic 2.8.1 as pydantic 2.5.0 is causing error with python 3.12
 #TypeError: ForwardRef._evaluate() missing 1 required keyword-only argument: 'recursive_guard'
 pydantic==2.8.2 

--- a/transforms/universal/bloom/requirements.txt
+++ b/transforms/universal/bloom/requirements.txt
@@ -1,4 +1,4 @@
 rbloom>=1.5.2
-pandas>=2.2.2
+pandas
 pyarrow>=16.1.0
 huggingface_hub>=0.25.2

--- a/transforms/universal/fdedup/requirements.txt
+++ b/transforms/universal/fdedup/requirements.txt
@@ -3,7 +3,7 @@ boto3
 kubernetes>=30.1.0
 polars>=1.9.0, !=1.10.0, !=1.11.0, !=1.12.0
 disjoint-set>=0.8.0
-scipy>=1.12.1, <2.0.0
-numpy<1.29.0
+scipy
+numpy
 sentencepiece>=0.2.0
 mmh3>=4.1.0

--- a/transforms/universal/filter/requirements.txt
+++ b/transforms/universal/filter/requirements.txt
@@ -1,4 +1,4 @@
 ## Latest release duckdb==1.3.0 is breaking Unit Test.
 ## Will need to regenerate expected files with new release before we use latest
 duckdb>=0.10.1,<=1.2.2
-pandas>=2.2.0
+pandas


### PR DESCRIPTION
## Why are these changes needed?

allow for numpy < 2.0.0
allow for pandas latest
allow for scipy latest
Prevent KFP workflow CI/CD from triggering unless KFP folder has changed
## Related issue number (if any).

https://github.com/data-prep-kit/data-prep-kit/issues/1286
