### PR TITLE
patch v1.1.2 to address bug in filter code and relax requirements for testing with later releases of pydantic

### DIFF
--- a/transforms/language/pii_redactor/requirements.txt
+++ b/transforms/language/pii_redactor/requirements.txt
@@ -1,9 +1,10 @@
 # Later versions of numpy is ausing error with:
 # AttributeError: module 'numpy' has no attribute 'AxisError'
-numpy < 1.29.0
+# there is no such a thing as 1.29.0. Last 1.x release is 1.26.4
+numpy<=1.26.4
 # Force upgrade to pydantic 2.8.1 as pydantic 2.5.0 is causing error with python 3.12
 #TypeError: ForwardRef._evaluate() missing 1 required keyword-only argument: 'recursive_guard'
-pydantic==2.8.2 
+pydantic>=2.8.2 
 presidio-analyzer>=2.2.355
 presidio-anonymizer>=2.2.355
 flair>=0.14.0

--- a/transforms/universal/filter/dpk_filter/transform.py
+++ b/transforms/universal/filter/dpk_filter/transform.py
@@ -93,10 +93,10 @@ class FilterTransform(AbstractTableTransform):
         self.doc_id_column_name = config.get(filter_doc_id_column_name_key, filter_doc_id_column_name_default)
 
         # ensure the path endswith("/") if they are not None
-        self.input_arrow_folder = config.get(filter_input_arrow_folder_key, None)
+        self.input_arrow_folder = config.get(filter_input_arrow_folder_key, "")
         if bool(self.input_arrow_folder.strip()):
             self.input_arrow_folder = self.input_arrow_folder if self.input_arrow_folder.endswith("/") else f"{self.input_arrow_folder}/"
-        self.output_arrow_folder = config.get(filter_output_arrow_folder_key, None)
+        self.output_arrow_folder = config.get(filter_output_arrow_folder_key, "")
         if bool(self.output_arrow_folder.strip()):
             self.output_arrow_folder = self.output_arrow_folder if self.output_arrow_folder.endswith("/") else f"{self.output_arrow_folder}/"
         


### PR DESCRIPTION
## Why are these changes needed?

Patch filter code causing "NoneType has no object strip" using empty string for folder name instead of None
Patch requirements.txt for pit to allow testing with Prefect

## Related issue number (if any).

When invoked directly without the user of a runtime (e.g. Filter({}).Transform(table), the call fails with the following error:
```
---> 97 if bool(self.input_arrow_folder.strip()):
     98     self.input_arrow_folder = self.input_arrow_folder if self.input_arrow_folder.endswith("[/](http://localhost:8888/)") else f"{self.input_arrow_folder}[/](http://localhost:8888/)"
     99 self.output_arrow_folder = config.get(filter_output_arrow_folder_key, None)

AttributeError: 'NoneType' object has no attribute 'strip'

```