### PR TITLE
updated valid config for io for data_access_local

### DIFF
--- a/data-processing-lib/python/requirements.txt
+++ b/data-processing-lib/python/requirements.txt
@@ -13,3 +13,4 @@ polars>=1.9.0
 transformers
 fasttext-wheel
 huggingface-hub >= 0.21.4, <1.0.0
+urllib3==1.26.19

--- a/data-processing-lib/python/requirements.txt
+++ b/data-processing-lib/python/requirements.txt
@@ -13,4 +13,3 @@ polars>=1.9.0
 transformers
 fasttext-wheel
 huggingface-hub >= 0.21.4, <1.0.0
-urllib3==1.26.19

--- a/data-processing-lib/python/src/data_processing/data_access/data_access_local.py
+++ b/data-processing-lib/python/src/data_processing/data_access/data_access_local.py
@@ -41,7 +41,7 @@ class DataAccessLocal(DataAccess):
         # If config is undefined, let is pass
         if config is None:
 #            valid_config = False
-            logger.info(f"data access factory {cli_arg_prefix}: Could not find a valid configuration")
+            logger.info(f"data access factory {cli_arg_prefix}: No config provided")
             return valid_config
 
         # If config is empty, fail
@@ -51,15 +51,19 @@ class DataAccessLocal(DataAccess):
             return valid_config
 
         if config.get("input_folder", "") == "":
-            valid_config = False
-            logger.error(
-                f"data access factory {cli_arg_prefix}: " "Could not find input folder in local config"
+            logger.info(
+                f"data access factory {cli_arg_prefix}: " "Could not find input folder in local config. "
+                "Defaulting to current directory"
             )
+            config["input_folder"] = os.getcwd()
+
         if config.get("output_folder", "") == "":
-            valid_config = False
-            logger.error(
-                f"data access factory {cli_arg_prefix}: " "Could not find output folder in local config"
+            logger.info(
+                f"data access factory {cli_arg_prefix}: " "Could not find output folder in local config. "
+                "Defaulting to current directory."
             )
+            config["output_folder"] = os.getcwd()
+
         return valid_config
 
 

--- a/data-processing-lib/python/test/data_processing_tests/data_access/data_access_local_test.py
+++ b/data-processing-lib/python/test/data_processing_tests/data_access/data_access_local_test.py
@@ -19,11 +19,27 @@ from unittest.mock import patch
 
 import pyarrow
 import pytest
-from data_processing.data_access import DataAccessLocal
+from data_processing.data_access import DataAccessLocal, DataAccessFactory
 from data_processing.utils import GB, MB, get_logger
 
 
 logger = get_logger(__name__)
+
+
+def test_no_io_config():
+    config = {"data_config": {"da_class": "data_processing.data_access.DataAccessLocal"},
+              "data_checkpoint": False,
+              }
+    factory = DataAccessFactory()
+    success = factory.apply_input_params(config)
+
+    assert success
+
+    da = factory.create_data_access()
+    assert type(da) == DataAccessLocal
+
+    assert da.get_input_folder() == os.getcwd()
+    assert da.get_output_folder() == os.getcwd()
 
 
 class TestInit:

--- a/data-processing-lib/python/test/data_processing_tests/launch/pure_python/launcher_test.py
+++ b/data-processing-lib/python/test/data_processing_tests/launch/pure_python/launcher_test.py
@@ -118,7 +118,7 @@ def test_local_config_validate():
         "runtime_job_id": "job_id",
         "runtime_code_location": ParamsUtils.convert_to_ast(code_location),
     }
-    # invalid local configurations, driver launch should fail with any of these
+    # previously invalid local configurations, driver launch should no longer fail with missing input/output_folder
     local_conf_empty = {}
     local_conf_no_input = {"output_folder": "output_folder"}
     local_conf_no_output = {"input_folder": "input_folder"}
@@ -126,15 +126,15 @@ def test_local_config_validate():
     sys.argv = ParamsUtils.dict_to_req(d=params)
     print(f"parameters {sys.argv}")
     res = TestLauncherPython().launch()
-    assert 1 == res
+    assert 0 == res
     params["data_local_config"] = ParamsUtils.convert_to_ast(local_conf_no_input)
     sys.argv = ParamsUtils.dict_to_req(d=params)
     res = TestLauncherPython().launch()
-    assert 1 == res
+    assert 0 == res
     params["data_local_config"] = ParamsUtils.convert_to_ast(local_conf_no_output)
     sys.argv = ParamsUtils.dict_to_req(d=params)
     res = TestLauncherPython().launch()
-    assert 1 == res
+    assert 0 == res
     params["data_local_config"] = ParamsUtils.convert_to_ast(local_conf)
     sys.argv = ParamsUtils.dict_to_req(d=params)
     res = TestLauncherPython().launch()
@@ -150,7 +150,7 @@ def test_s3_config_validate():
         "runtime_job_id": "job_id",
         "runtime_code_location": ParamsUtils.convert_to_ast(code_location),
     }
-    # invalid local configurations, driver launch should fail with any of these
+    # invalid local configurations, driver launch should fail with missing input or output any of these
     s3_conf_empty = {}
     s3_conf_no_input = {"output_folder": "output_folder"}
     s3_conf_no_output = {"input_folder": "input_folder"}
@@ -158,7 +158,7 @@ def test_s3_config_validate():
     sys.argv = ParamsUtils.dict_to_req(d=params)
     print(f"parameters {sys.argv}")
     res = TestLauncherPython().launch()
-    assert 1 == res
+    assert 0 == res
     params["data_s3_config"] = ParamsUtils.convert_to_ast(s3_conf_no_input)
     sys.argv = ParamsUtils.dict_to_req(d=params)
     res = TestLauncherPython().launch()

--- a/data-processing-lib/ray/test/data_processing_ray_tests/launch/ray/ray_launcher_test.py
+++ b/data-processing-lib/ray/test/data_processing_ray_tests/launch/ray/ray_launcher_test.py
@@ -133,7 +133,7 @@ def test_local_config_validate():
         "runtime_creation_delay": 0,
         "runtime_code_location": ParamsUtils.convert_to_ast(code_location),
     }
-    # invalid local configurations, driver launch should fail with any of these
+    # previously invalid local configurations, driver launch should no longer fail with missing input/output_folder
     local_conf_empty = {}
     local_conf_no_input = {"output_folder": "output_folder"}
     local_conf_no_output = {"input_folder": "input_folder"}
@@ -141,15 +141,15 @@ def test_local_config_validate():
     sys.argv = ParamsUtils.dict_to_req(d=params)
     print(f"parameters {sys.argv}")
     res = TestLauncherRay().launch()
-    assert 1 == res
+    assert 0 == res
     params["data_local_config"] = ParamsUtils.convert_to_ast(local_conf_no_input)
     sys.argv = ParamsUtils.dict_to_req(d=params)
     res = TestLauncherRay().launch()
-    assert 1 == res
+    assert 0 == res
     params["data_local_config"] = ParamsUtils.convert_to_ast(local_conf_no_output)
     sys.argv = ParamsUtils.dict_to_req(d=params)
     res = TestLauncherRay().launch()
-    assert 1 == res
+    assert 0 == res
     params["data_local_config"] = ParamsUtils.convert_to_ast(local_conf)
     sys.argv = ParamsUtils.dict_to_req(d=params)
     res = TestLauncherRay().launch()
@@ -169,7 +169,7 @@ def test_s3_config_validate():
         "runtime_creation_delay": 0,
         "runtime_code_location": ParamsUtils.convert_to_ast(code_location),
     }
-    # invalid local configurations, driver launch should fail with any of these
+    # invalid local configurations, driver launch should fail with missing input/output_folder
     s3_conf_empty = {}
     s3_conf_no_input = {"output_folder": "output_folder"}
     s3_conf_no_output = {"input_folder": "input_folder"}
@@ -177,7 +177,7 @@ def test_s3_config_validate():
     sys.argv = ParamsUtils.dict_to_req(d=params)
     print(f"parameters {sys.argv}")
     res = TestLauncherRay().launch()
-    assert 1 == res
+    assert 0 == res
     params["data_s3_config"] = ParamsUtils.convert_to_ast(s3_conf_no_input)
     sys.argv = ParamsUtils.dict_to_req(d=params)
     res = TestLauncherRay().launch()

--- a/data-processing-lib/spark/test/data_processing_spark_tests/launch/spark/spark_launcher_test.py
+++ b/data-processing-lib/spark/test/data_processing_spark_tests/launch/spark/spark_launcher_test.py
@@ -119,7 +119,7 @@ def test_local_config_validate():
         "runtime_job_id": "job_id",
         "runtime_code_location": ParamsUtils.convert_to_ast(code_location),
     }
-    # invalid local configurations, driver launch should fail with any of these
+    # previously invalid local configurations, driver launch should no longer fail with missing input/output_folder
     local_conf_empty = {}
     local_conf_no_input = {"output_folder": "output_folder"}
     local_conf_no_output = {"input_folder": "input_folder"}
@@ -127,15 +127,15 @@ def test_local_config_validate():
     sys.argv = ParamsUtils.dict_to_req(d=params)
     print(f"parameters {sys.argv}")
     res = TestLauncherSpark().launch()
-    assert 1 == res
+    assert 0 == res
     params["data_local_config"] = ParamsUtils.convert_to_ast(local_conf_no_input)
     sys.argv = ParamsUtils.dict_to_req(d=params)
     res = TestLauncherSpark().launch()
-    assert 1 == res
+    assert 0 == res
     params["data_local_config"] = ParamsUtils.convert_to_ast(local_conf_no_output)
     sys.argv = ParamsUtils.dict_to_req(d=params)
     res = TestLauncherSpark().launch()
-    assert 1 == res
+    assert 0 == res
     params["data_local_config"] = ParamsUtils.convert_to_ast(local_conf)
     sys.argv = ParamsUtils.dict_to_req(d=params)
     res = TestLauncherSpark().launch()
@@ -151,7 +151,7 @@ def test_s3_config_validate():
         "runtime_job_id": "job_id",
         "runtime_code_location": ParamsUtils.convert_to_ast(code_location),
     }
-    # invalid local configurations, driver launch should fail with any of these
+    # invalid local configurations, driver launch should fail with missing input/output_folder
     s3_conf_empty = {}
     s3_conf_no_input = {"output_folder": "output_folder"}
     s3_conf_no_output = {"input_folder": "input_folder"}
@@ -159,7 +159,7 @@ def test_s3_config_validate():
     sys.argv = ParamsUtils.dict_to_req(d=params)
     print(f"parameters {sys.argv}")
     res = TestLauncherSpark().launch()
-    assert 1 == res
+    assert 0 == res
     params["data_s3_config"] = ParamsUtils.convert_to_ast(s3_conf_no_input)
     sys.argv = ParamsUtils.dict_to_req(d=params)
     res = TestLauncherSpark().launch()


### PR DESCRIPTION
make missing input_folder and output_folder valid config for data_local_access when initiated via factory - defaulting to current dir if not set. 

ref: issue #1413 


