### PR TITLE
Define input/output path for in-memory DataAccess.

### DIFF
--- a/data-processing-lib/python/src/data_processing/data_access/data_access_memory.py
+++ b/data-processing-lib/python/src/data_processing/data_access/data_access_memory.py
@@ -59,8 +59,13 @@ class DataAccessMemory(DataAccess):
             self.input_folder = None
             self.output_folder = None
         else:
-            self.input_folder = os.path.abspath(config.get("input_folder", None))
-            self.output_folder = os.path.abspath(config.get("output_folder", None))
+            input_folder = config.get("input_folder")
+            output_folder = config.get("output_folder")
+            if input_folder:
+                self.input_folder = os.path.abspath(input_folder)
+            if output_folder:
+                self.output_folder = os.path.abspath(output_folder)
+
         self.config = config
         self.checkpoint = checkpoint
         self.logger = get_logger(__name__)

--- a/data-processing-lib/python/src/data_processing/data_access/data_access_memory.py
+++ b/data-processing-lib/python/src/data_processing/data_access/data_access_memory.py
@@ -58,11 +58,9 @@ class DataAccessMemory(DataAccess):
         if config is None:
             self.input_folder = None
             self.output_folder = None
-            self.cache = False
         else:
-            self.input_folder = os.path.abspath(config["input_folder"])
-            self.output_folder = os.path.abspath(config["output_folder"])
-            self.cache = config.get('cache', False)
+            self.input_folder = os.path.abspath(config.get("input_folder", None))
+            self.output_folder = os.path.abspath(config.get("output_folder", None))
         self.config = config
         self.checkpoint = checkpoint
         self.logger = get_logger(__name__)

--- a/data-processing-lib/python/src/data_processing/data_access/data_access_memory.py
+++ b/data-processing-lib/python/src/data_processing/data_access/data_access_memory.py
@@ -10,6 +10,7 @@
 # limitations under the License.
 ################################################################################
 
+import os
 from typing import Any
 import pyarrow as pa
 from data_processing.data_access import DataAccess
@@ -54,6 +55,14 @@ class DataAccessMemory(DataAccess):
         :param path_config: dictionary of path info
         """
         self.tables = {}
+        if config is None:
+            self.input_folder = None
+            self.output_folder = None
+            self.cache = False
+        else:
+            self.input_folder = os.path.abspath(config["input_folder"])
+            self.output_folder = os.path.abspath(config["output_folder"])
+            self.cache = config.get('cache', False)
         self.config = config
         self.checkpoint = checkpoint
         self.logger = get_logger(__name__)
@@ -92,7 +101,14 @@ class DataAccessMemory(DataAccess):
         Get output folder as a string
         :return: output_folder
         """
-        return None
+        return self.output_folder
+
+    def get_input_folder(self) -> str:
+        """
+        Get input folder as a string
+        :return: input_folder
+        """
+        return self.input_folder
 
     def table_to_buffer(table: pa.Table) -> Any:
         """


### PR DESCRIPTION
## Why are these changes needed?

This PR aligns DataAccessMemory with other DataAccess types by implementing the missing get_output_folder() and get_input_folder() methods.

By implementing these methods, we enable a standard way for transforms to access the results of preceding transforms. For example, in a Transform A -> Transform B pipeline, Transform B can now use DataAccessMemory's get_output_folder() method to retrieve the in-memory path or key to the saved output of Transform A. This ensures consistency and compatibility across all DataAccess classes, including DataAccessLocal.

## Related issue number (if any).

