### PR TITLE
Avoid latest release of polars 1.33 that is breaking the code

### DIFF
--- a/transforms/universal/fdedup/requirements.txt
+++ b/transforms/universal/fdedup/requirements.txt
@@ -1,7 +1,7 @@
 pyyaml>=6.0.2
 boto3
 kubernetes>=30.1.0
-polars>=1.9.0, !=1.10.0, !=1.11.0, !=1.12.0
+polars>=1.9.0, <1.33, !=1.10.0, !=1.11.0, !=1.12.0
 disjoint-set>=0.8.0
 scipy
 numpy<=1.26.4


### PR DESCRIPTION
## Why are these changes needed?

Latest release on of polars 1.33 is breaking the code.  Stick to <1.33 for now

## Related issue number (if any).


