### PR TITLE
restrict version of matplotlib in requirements.txt for flair in pii_r…

### DIFF
--- a/transforms/language/pii_redactor/requirements.txt
+++ b/transforms/language/pii_redactor/requirements.txt
@@ -7,5 +7,7 @@ numpy<1.29,>=1.22
 pydantic>=2.8.2
 presidio-analyzer>=2.2.355
 presidio-anonymizer>=2.2.355
+# Fixing issue with installation with venv as flair causes matplotlib to install older version and eventulaly fails
+matplotlib>3.10
 flair>=0.14.0
 pandas


### PR DESCRIPTION
…edactor

fixing bug installing pii_redactor with docling2parquet in venv due to matplotlib installations in flair library

## Why are these changes needed?


## Related issue number (if any).


