### PR TITLE
fix: updates web2parquet DataAccessLocal usage

### DIFF
--- a/transforms/universal/web2parquet/dpk_web2parquet/transform.py
+++ b/transforms/universal/web2parquet/dpk_web2parquet/transform.py
@@ -108,7 +108,7 @@ class Web2ParquetTransform(AbstractTableTransform):
         #############################################################################
         ## The same transform can also be used to store crawled files to local folder
         if self.folder:
-            dao=DataAccessLocal(local_config={'output_folder':self.folder,'input_folder':'.'})
+            dao=DataAccessLocal({'output_folder': self.folder, 'input_folder': '.'})
             for x in self.docs:
                 dao.save_file(self.folder+'/'+x['filename'], x['contents'])
             


### PR DESCRIPTION
954f1ba938bcc1300b2965f2647a45673ae54bd3 -> changes `local_config` to `config` in DataAccessLocal init

- updates dpk_web2parquet/transform usage of DataAccessLocal to match the change in config key name usage
- fixes reported issue https://github.com/data-prep-kit/data-prep-kit/issues/1410

## Why are these changes needed?
DataAccessLocal constructor was previously changed to a unified key pattern with the other DataAccess types. This corrects what appears to be the last remaining use pattern of a DataAccessLocal using the `local_config={}` pattern.

## Related issue number (if any).
https://github.com/data-prep-kit/data-prep-kit/issues/1410