### PR TITLE
changing embeddings_in_parquet flag to embeddings_in_lanceDB to fix b…

### DIFF
--- a/transforms/language/text_encoder/Makefile
+++ b/transforms/language/text_encoder/Makefile
@@ -35,7 +35,6 @@ run-python-cli-sample-parquet:
 	rm -fr output && \
 	$(PYTHON) -m dpk_$(TRANSFORM_NAME).runtime \
 			--data_local_config "{ 'input_folder' : 'test-data/input/', 'output_folder' : 'output/'}" \
-			--text_encoder_embeddings_in_parquet True \
 			--text_encoder_embedding_batch_size 5 \
 
 
@@ -46,6 +45,7 @@ run-python-cli-sample-lancedb:
 	$(PYTHON) -m dpk_$(TRANSFORM_NAME).runtime \
 			--data_local_config "{ 'input_folder' : 'test-data/input/', 'output_folder' : 'output/'}" \
 			--text_encoder_lanceDB_data_uri "output/test.db/test.lance/"  \
+			--text_encoder_embeddings_in_lanceDB True \
 			--text_encoder_lanceDB_batch_size 10 \
 			--text_encoder_embedding_batch_size 5 \
 			--text_encoder_lanceDB_fragments_json_folder "output/fragments_json/" \
@@ -64,7 +64,6 @@ run-ray-cli-sample-parquet:
 	rm -fr output && \
 	$(PYTHON) -m dpk_$(TRANSFORM_NAME).ray.runtime \
 			--data_local_config "{ 'input_folder' : 'test-data/input/', 'output_folder' : 'output/'}" \
-			--text_encoder_embeddings_in_parquet True \
 			--text_encoder_embedding_batch_size 5 \
 			--run_locally True
 
@@ -76,6 +75,7 @@ run-ray-cli-sample-lancedb:
             --data_local_config "{ 'input_folder' : 'test-data/input/', 'output_folder' : 'output/'}" \
 			--text_encoder_lanceDB_data_uri "output/test.db/test.lance/"  \
 			--text_encoder_lanceDB_batch_size 10 \
+			--text_encoder_embeddings_in_lanceDB True \
 			--text_encoder_lanceDB_fragments_json_folder "output/fragments_json/" \
 			--text_encoder_embedding_batch_size 5 \
 			--text_encoder_lanceDB_table_name "test" \

--- a/transforms/language/text_encoder/README.md
+++ b/transforms/language/text_encoder/README.md
@@ -51,7 +51,7 @@ If you have already stored embeddings in parquet, you can also use this transfor
 | `lanceDB_table_name` | `"" ` | The name of the lanceDB table. |
 | `embedding_batch_size` | 8 | The number of documents as a batch to create embeddings in a `model.encode()`. |
 | `embeddings_exist` | False | Flag indicating if embeddings already exist in parquet files. |
-| `embeddings_in_parquet` | False | Flag indicating if embeddings are to be stored in parquet files. | 
+| `embeddings_in_lanceDB` | False | Flag indicating if embeddings are to be stored in lanceDB. | 
 
 
 If the embeddings are to be stored in, or converted from parquet to, lancedb, a `lance_commit.py` needs to be executed to allow the

--- a/transforms/language/text_encoder/dpk_text_encoder/transform.py
+++ b/transforms/language/text_encoder/dpk_text_encoder/transform.py
@@ -49,7 +49,7 @@ embedding_batch_size_key="embedding_batch_size"
 lanceDB_fragments_json_folder_key="lanceDB_fragments_json_folder"
 lanceDB_table_name_key="lanceDB_table_name"
 embeddings_exist_key="embeddings_exist"
-embeddings_in_parquet_key="embeddings_in_parquet"
+embeddings_in_lanceDB_key="embeddings_in_lanceDB"
 model_max_seq_length_key="model_max_seq_length"
 
 model_name_cli_param = f"{cli_prefix}{model_name_key}"
@@ -61,7 +61,7 @@ embedding_batch_size_cli_param = f"{cli_prefix}{embedding_batch_size_key}"
 lanceDB_fragments_json_folder_cli_param = f"{cli_prefix}{lanceDB_fragments_json_folder_key}"
 lanceDB_table_name_cli_param = f"{cli_prefix}{lanceDB_table_name_key}"
 embeddings_exist_cli_param = f"{cli_prefix}{embeddings_exist_key}"
-embeddings_in_parquet_cli_param = f"{cli_prefix}{embeddings_in_parquet_key}"
+embeddings_in_lanceDB_cli_param = f"{cli_prefix}{embeddings_in_lanceDB_key}"
 model_max_seq_length_cli_param = f"{cli_prefix}{model_max_seq_length_key}"
 
 default_model_name = "ibm-granite/granite-embedding-small-english-r2"
@@ -73,7 +73,7 @@ default_embedding_batch_size = 8
 default_lanceDB_fragments_json_folder = ""
 default_lanceDB_table_name = ""
 default_embeddings_exist = False
-default_embeddings_in_parquet = False
+default_embeddings_in_lanceDB = False
 default_model_max_seq_length = 2048
 
 
@@ -90,7 +90,7 @@ class TextEncoderTransform(AbstractTableTransform):
         lanceDB_fragments_json_folder: str,
         lanceDB_table_name: str,
         embeddings_exist: bool,
-        embeddings_in_parquet: bool,
+        embeddings_in_lanceDB: bool,
         model_max_seq_length: int
     """
 
@@ -128,8 +128,8 @@ class TextEncoderTransform(AbstractTableTransform):
         self.embeddings_exist = config.get(embeddings_exist_key, default_embeddings_exist)
         self.logger.info(f"{self.embeddings_exist=}")
 
-        self.embeddings_in_parquet = config.get(embeddings_in_parquet_key, default_embeddings_in_parquet)
-        self.logger.info(f"{self.embeddings_in_parquet=}")
+        self.embeddings_in_lanceDB = config.get(embeddings_in_lanceDB_key, default_embeddings_in_lanceDB)
+        self.logger.info(f"{self.embeddings_in_lanceDB=}")
 
       
         self.model_max_seq_length = config.get(model_max_seq_length_key, default_model_max_seq_length)
@@ -141,25 +141,26 @@ class TextEncoderTransform(AbstractTableTransform):
             self.model.tokenizer.model_max_length = self.model_max_seq_length
             self.model = self.model.to(self.device)
 
-        # settign up data_access, input_folder, output_folder, and lanceDB_fragments_json_folder
-        self.data_access: DataAccess = config.get("data_access", None)
-        assert self.data_access is not None, f"data_access is missing."
-        self.input_folder = self.data_access.get_input_folder()
-        assert self.input_folder is not None, f"input_folder is missing."
-        self.input_folder = self.input_folder if self.input_folder.endswith("/") else self.input_folder + "/"
-        self.output_folder = self.data_access.get_output_folder()
-        assert self.output_folder is not None, f"output_folder is missing."
-        self.output_folder = self.output_folder if self.output_folder.endswith("/") else self.output_folder + "/"
-        if not os.path.exists(self.output_folder):
-            try:
-                os.makedirs(self.output_folder, exist_ok=True)
-            except OSError as e:
-                self.logger.error(f"Cannot create directories for {self.output_folder}: {e}")
-
+        
         self.embedding_batch_size = config.get(embedding_batch_size_key, default_embedding_batch_size)
 
         # creating embeddings and storing them in lanceDB
-        if not self.embeddings_in_parquet and not self.embeddings_exist:
+        if self.embeddings_in_lanceDB:
+            # settign up data_access, input_folder, output_folder, and lanceDB_fragments_json_folder
+            self.data_access: DataAccess = config.get("data_access", None)
+            assert self.data_access is not None, f"data_access is missing."
+            self.input_folder = self.data_access.get_input_folder()
+            assert self.input_folder is not None, f"input_folder is missing."
+            self.input_folder = self.input_folder if self.input_folder.endswith("/") else self.input_folder + "/"
+            self.output_folder = self.data_access.get_output_folder()
+            assert self.output_folder is not None, f"output_folder is missing."
+            self.output_folder = self.output_folder if self.output_folder.endswith("/") else self.output_folder + "/"
+            if not os.path.exists(self.output_folder):
+                try:
+                    os.makedirs(self.output_folder, exist_ok=True)
+                except OSError as e:
+                    self.logger.error(f"Cannot create directories for {self.output_folder}: {e}")
+
             self.lanceDB_fragments_json_folder = config.get(lanceDB_fragments_json_folder_key, default_lanceDB_fragments_json_folder)
             assert bool(self.lanceDB_fragments_json_folder.strip()), f"lanceDB_fragments_json_folder is missing."
             self.lanceDB_fragments_json_folder = self.lanceDB_fragments_json_folder if self.lanceDB_fragments_json_folder.endswith("/") else self.lanceDB_fragments_json_folder + "/"
@@ -308,7 +309,7 @@ class TextEncoderTransform(AbstractTableTransform):
             embeddings_pa_array = self._converting_embeddings_list_to_pa_array(embeddings)
             new_table = table.set_column(len(table.schema)-1, self.output_embeddings_column_name, embeddings_pa_array)
         
-        if self.embeddings_in_parquet:
+        if not self.embeddings_in_lanceDB:
             metadata = {"num_rows": new_table.num_rows}
             return [new_table], metadata
         else:
@@ -320,7 +321,7 @@ class TextEncoderTransform(AbstractTableTransform):
             return [], metadata
     
     def flush(self) -> tuple[list[pa.Table], dict[str, Any]]:
-        if not self.embeddings_in_parquet:
+        if self.embeddings_in_lanceDB:
             self._lanceDB_flush()
         return [], {}
 
@@ -419,11 +420,11 @@ class TextEncoderTransformConfiguration(TransformConfiguration):
             help="A flag indicating whether or not embeddings exist in parquet",
         )
         parser.add_argument(
-            f"--{embeddings_in_parquet_cli_param}",
+            f"--{embeddings_in_lanceDB_cli_param}",
             type=bool,
             required=False,
-            default=default_embeddings_in_parquet,
-            help="A flag indicating if embeddings are to be stored in parquet, default=False",
+            default=default_embeddings_in_lanceDB,
+            help="A flag indicating if embeddings are to be stored in lanceDB, default=False",
         )
 
     def apply_input_params(self, args: Namespace) -> bool:

--- a/transforms/language/text_encoder/test/test_text_encoder_lancedb.py
+++ b/transforms/language/text_encoder/test/test_text_encoder_lancedb.py
@@ -43,6 +43,7 @@ text_encoder_params = {
     "content_column_name": "contents",
     "output_embeddings_column_name": "embeddings",
     "embedding_batch_size": 5,
+    "embeddings_in_lanceDB": True,
     "lanceDB_data_uri": lancedb_data_uri,
     "lanceDB_batch_size": 10,
     "lanceDB_fragments_json_folder": fragment_dir,

--- a/transforms/language/text_encoder/test/test_text_encoder_parquet.py
+++ b/transforms/language/text_encoder/test/test_text_encoder_parquet.py
@@ -37,7 +37,6 @@ dal = DataAccessLocal(
 text_encoder_params = {
     "data_access": dal,
     "model_name": "ibm-granite/granite-embedding-small-english-r2",
-    "embeddings_in_parquet": True,
     "content_column_name": "contents",
     "output_embeddings_column_name": "embeddings",
     "embedding_batch_size": 5,

--- a/transforms/language/text_encoder/test/test_text_encoder_parquet_python.py
+++ b/transforms/language/text_encoder/test/test_text_encoder_parquet_python.py
@@ -28,7 +28,6 @@ expected_dir = os.path.abspath(os.path.join(basedir, "../test-data/expected_parq
 text_encoder_params = {
     "data_local_config": {"input_folder": input_dir, "output_folder": output_dir},
     "text_encoder_model_name": "ibm-granite/granite-embedding-small-english-r2",
-    "text_encoder_embeddings_in_parquet": True,
     "text_encoder_content_column_name": "contents",
     "text_encoder_output_embeddings_column_name": "embeddings",
     "text_encoder_embedding_batch_size": 5,

--- a/transforms/language/text_encoder/test/test_text_encoder_parquet_ray.py
+++ b/transforms/language/text_encoder/test/test_text_encoder_parquet_ray.py
@@ -29,7 +29,6 @@ expected_dir = os.path.abspath(os.path.join(basedir, "../test-data/expected_parq
 text_encoder_params = {
     "data_local_config": {"input_folder": input_dir, "output_folder": output_dir},
     "text_encoder_model_name": "ibm-granite/granite-embedding-small-english-r2",
-    "text_encoder_embeddings_in_parquet": True,
     "text_encoder_content_column_name": "contents",
     "text_encoder_output_embeddings_column_name": "embeddings",
     "text_encoder_embedding_batch_size": 5,


### PR DESCRIPTION
…ackward compatibility

## Why are these changes needed?
This fix is to change the flag: `embeddings_in_parquet` to `embeddings_in_lanceDB`. This assumes the default is storing embeddings in parquet files, allowing backward compatibility.  The flag `embeddings_in_lanceDB` must be set to `True `to store the embeddings in `lanceDB`. The self.data_access code in the initialization is moved inside the lanceDB related scope.

## Related issue number (if any).

#1541 The initialization issue should be fixed.
