### PR TITLE
Add Spark support for doc_quality and docling2parquet.

### DIFF
--- a/transforms/language/doc_quality/dpk_doc_quality/spark/__init__.py
+++ b/transforms/language/doc_quality/dpk_doc_quality/spark/__init__.py
@@ -1,0 +1,1 @@
+# SPDX-License-Identifier: Apache-2.0

--- a/transforms/language/doc_quality/dpk_doc_quality/spark/local.py
+++ b/transforms/language/doc_quality/dpk_doc_quality/spark/local.py
@@ -1,0 +1,56 @@
+# SPDX-License-Identifier: Apache-2.0
+# (C) Copyright IBM Corp. 2025.
+# Licensed under the Apache License, Version 2.0 (the “License”);
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#  http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an “AS IS” BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+import os
+import sys
+
+from data_processing_spark.runtime.spark import SparkTransformLauncher
+from data_processing.utils import ParamsUtils
+from dpk_doc_quality.transform import (
+    bad_word_filepath_cli_param,
+    doc_content_column_cli_param,
+    text_lang_cli_param,
+)
+from dpk_doc_quality.spark.runtime import DocQualitySparkTransformConfiguration
+
+
+# create parameters
+input_folder = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "test-data", "input"))
+output_folder = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "output"))
+local_conf = {
+    "input_folder": input_folder,
+    "output_folder": output_folder,
+}
+code_location = {"github": "github", "commit_hash": "12345", "path": "path"}
+basedir = os.path.abspath(os.path.join(os.path.dirname(__file__), "."))
+
+model_path = os.path.join(basedir, "models")
+
+params = {
+    # Data access. Only required parameters are specified
+    "data_local_config": ParamsUtils.convert_to_ast(local_conf),
+    # execution info
+    "runtime_pipeline_id": "pipeline_id",
+    "runtime_job_id": "job_id",
+    "runtime_code_location": ParamsUtils.convert_to_ast(code_location),
+    # doc_quality params
+    text_lang_cli_param: "en",
+    doc_content_column_cli_param: "contents",
+    bad_word_filepath_cli_param: os.path.join(basedir, "ldnoobw", "en"),
+}
+if __name__ == "__main__":
+    # Set the simulated command line args
+    sys.argv = ParamsUtils.dict_to_req(d=params)
+    # create launcher
+    launcher = SparkTransformLauncher(runtime_config=DocQualitySparkTransformConfiguration())
+    # Launch the ray actor(s) to process the input
+    launcher.launch()

--- a/transforms/language/doc_quality/dpk_doc_quality/spark/runtime.py
+++ b/transforms/language/doc_quality/dpk_doc_quality/spark/runtime.py
@@ -1,0 +1,56 @@
+# SPDX-License-Identifier: Apache-2.0
+# (C) Copyright IBM Corp. 2025.
+# Licensed under the Apache License, Version 2.0 (the “License”);
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#  http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an “AS IS” BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+import sys
+from typing import Any
+
+from data_processing_spark.runtime.spark import (
+    DefaultSparkTransformRuntime,
+    SparkTransformLauncher,
+    SparkTransformRuntimeConfiguration,
+)
+from dpk_doc_quality.transform import DocQualityTransformConfiguration
+
+
+class DocQualitySparkTransformConfiguration(SparkTransformRuntimeConfiguration):
+    """
+    Implements the SparkTransformConfiguration for DocQuality transform.
+    """
+
+    def __init__(self):
+        """
+        Initialization
+        Pass both transform_config AND runtime_class to the parent
+        """
+        super().__init__(
+            transform_config=DocQualityTransformConfiguration(),
+            runtime_class=DocQualitySparkTransformRuntime
+        )
+
+
+class DocQualitySparkTransformRuntime(DefaultSparkTransformRuntime):
+    """
+    DocQuality Spark runtime implementation.
+    """
+
+    def __init__(self, params: dict[str, Any]):
+        """
+        Constructor
+        :param params: parameters dictionary
+        """
+        super().__init__(params=params)
+
+
+if __name__ == "__main__":
+    launcher = SparkTransformLauncher(DocQualitySparkTransformConfiguration())
+    launcher.launch()

--- a/transforms/language/doc_quality/test/test_doc_quality_spark.py
+++ b/transforms/language/doc_quality/test/test_doc_quality_spark.py
@@ -1,0 +1,42 @@
+# SPDX-License-Identifier: Apache-2.0
+# (C) Copyright IBM Corp. 2025.
+# Licensed under the Apache License, Version 2.0 (the “License”);
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#  http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an “AS IS” BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+import os
+
+from data_processing.test_support.launch.transform_test import (
+    AbstractTransformLauncherTest,
+)
+from data_processing_spark.runtime.spark import SparkTransformLauncher
+from dpk_doc_quality.spark.runtime import DocQualitySparkTransformConfiguration
+
+
+
+class TestSparkDocQualityTransform(AbstractTransformLauncherTest):
+    """
+    Extends the super-class to define the test data for the tests defined there.
+    The name of this class MUST begin with the word Test so that pytest recognizes it as a test class.
+    """
+
+    def get_test_transform_fixtures(self) -> list[tuple]:
+        basedir = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+
+        cli_params = {
+            "docq_text_lang": "en",
+            "docq_doc_content_column": "contents",
+            "docq_bad_word_filepath": os.path.join(basedir, "dpk_doc_quality", "ldnoobw", "en"),
+        }
+        basedir = os.path.abspath(os.path.join(basedir, "test-data"))
+        launcher = SparkTransformLauncher(DocQualitySparkTransformConfiguration())
+        fixtures = []
+        fixtures.append((launcher, cli_params, os.path.join(basedir, "input"), os.path.join(basedir, "expected")))
+        return fixtures

--- a/transforms/language/docling2parquet/dpk_docling2parquet/spark/__init__.py
+++ b/transforms/language/docling2parquet/dpk_docling2parquet/spark/__init__.py
@@ -1,0 +1,1 @@
+# SPDX-License-Identifier: Apache-2.0

--- a/transforms/language/docling2parquet/dpk_docling2parquet/spark/local.py
+++ b/transforms/language/docling2parquet/dpk_docling2parquet/spark/local.py
@@ -1,0 +1,47 @@
+# SPDX-License-Identifier: Apache-2.0
+# (C) Copyright IBM Corp. 2025.
+# Licensed under the Apache License, Version 2.0 (the “License”);
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#  http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an “AS IS” BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+import os
+import sys
+
+from data_processing.utils import ParamsUtils
+from data_processing_spark.runtime.spark import SparkTransformLauncher
+from dpk_docling2parquet.spark.runtime import (
+    Docling2ParquetSparkTransformConfiguration
+)
+
+
+# create parameters
+input_folder = os.path.abspath(os.path.join(os.path.dirname(__file__), "../..", "test-data", "input"))
+output_folder = os.path.abspath(os.path.join(os.path.dirname(__file__), "../..", "output"))
+local_conf = {
+    "input_folder": input_folder,
+    "output_folder": output_folder
+}
+
+code_location = {"github": "github", "commit_hash": "12345", "path": "path"}
+params = {
+    # Data access. Only required parameters are specified
+    "data_local_config": ParamsUtils.convert_to_ast(local_conf),
+    # execution info
+    "runtime_pipeline_id": "pipeline_id",
+    "runtime_job_id": "job_id",
+    "runtime_code_location": ParamsUtils.convert_to_ast(code_location),
+    "data_files_to_use": ['.pdf','.zip','.xml']
+}
+if __name__ == "__main__":
+    # Set the simulated command line args
+    sys.argv = ParamsUtils.dict_to_req(d=params)
+    # create launcher
+    launcher = SparkTransformLauncher(runtime_config=Docling2ParquetSparkTransformConfiguration())
+    # Launch the ray actor(s) to process the input
+    launcher.launch()

--- a/transforms/language/docling2parquet/dpk_docling2parquet/spark/runtime.py
+++ b/transforms/language/docling2parquet/dpk_docling2parquet/spark/runtime.py
@@ -1,0 +1,50 @@
+# SPDX-License-Identifier: Apache-2.0
+# (C) Copyright IBM Corp. 2025.
+# Licensed under the Apache License, Version 2.0 (the “License”);
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#  http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an “AS IS” BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+
+from typing import Any
+
+from data_processing_spark.runtime.spark import (
+    DefaultSparkTransformRuntime,
+    SparkTransformLauncher,
+    SparkTransformRuntimeConfiguration,
+)
+
+from dpk_docling2parquet.transform import Docling2ParquetTransformConfiguration
+
+
+class Docling2ParquetSparRuntime(DefaultSparkTransformRuntime):
+    def __init__(self, params: dict[str, Any]):
+        """
+        Create/config this runtime.
+        :param params: parameters, often provided by the CLI arguments as defined by a TableTansformConfiguration.
+        """
+        super().__init__(params)
+
+
+class Docling2ParquetSparkTransformConfiguration(SparkTransformRuntimeConfiguration):
+    """
+    Implements the SparkTransformConfiguration for Docling2Parquet transform.
+    """
+
+    def __init__(self):
+        """
+        Initialization
+        Pass both transform_config AND runtime_class to the parent
+        """
+        super().__init__(transform_config=Docling2ParquetTransformConfiguration(), runtime_class=Docling2ParquetSparRuntime)
+
+
+if __name__ == "__main__":
+    launcher = SparkTransformLauncher(Docling2ParquetSparkTransformConfiguration())
+    launcher.launch()

--- a/transforms/language/docling2parquet/test/test_docling2parquet_spark.py
+++ b/transforms/language/docling2parquet/test/test_docling2parquet_spark.py
@@ -1,0 +1,48 @@
+# SPDX-License-Identifier: Apache-2.0
+# (C) Copyright IBM Corp. 2025.
+# Licensed under the Apache License, Version 2.0 (the “License”);
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#  http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an “AS IS” BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+import ast
+import os
+
+from data_processing.test_support.launch.transform_test import (
+    AbstractTransformLauncherTest,
+)
+from data_processing_spark.runtime.spark import SparkTransformLauncher
+from dpk_docling2parquet.spark.runtime import Docling2ParquetSparkTransformConfiguration
+
+
+class TestSparkDocling2ParquetTransform(AbstractTransformLauncherTest):
+    """
+    Extends the super-class to define the test data for the tests defined there.
+    The name of this class MUST begin with the word Test so that pytest recognizes it as a test class.
+    """
+
+    def get_test_transform_fixtures(self) -> list[tuple]:
+        basedir = "../test-data"
+        basedir = os.path.abspath(os.path.join(os.path.dirname(__file__), basedir))
+        config = {
+            "data_files_to_use": ast.literal_eval("['.pdf','.xml','.zip']"),
+        }
+        fixtures = []
+        launcher = SparkTransformLauncher(Docling2ParquetSparkTransformConfiguration())
+        fixtures.append(
+            (
+                launcher,
+                config,
+                basedir + "/input",
+                basedir + "/expected",
+                # this is added as a fixture to remove these columns from comparison
+                ["date_acquired", "document_id", "document_convert_time"],
+            )
+        )
+        return fixtures


### PR DESCRIPTION
## Why are these changes needed?
The changes are needed in order to enable running these transforms (`doc_quality` and `docling2parquet`) using spark runtime.

## Related issue number (if any).


