### PR TITLE
remove fullpath printing for log levels greater that Debug

### DIFF
--- a/data-processing-lib/python/src/data_processing/utils/log.py
+++ b/data-processing-lib/python/src/data_processing/utils/log.py
@@ -68,8 +68,13 @@ class PrefectStyleRichHandler(RichHandler):
             level_style = self.level_map.get(record.levelno, "info")
             lvl = Text(f" [{record.levelname}]", style=level_style)
 
+            if record.levelno <= logging.DEBUG:
+                location = f"{record.pathname}:{record.lineno}"
+            else:
+                location = f"{record.filename}:{record.lineno}"
+
             # --- Logger + line ---
-            logger_part = Text(f" {record.pathname}:{record.lineno} - ", style="logger")
+            logger_part = Text(f" {location} - ", style="logger")
 
             # --- Message ---
             msg = Text(str(record.getMessage()), style="color(255)")


### PR DESCRIPTION
## Why are these changes needed?


## Related issue number (if any).
/close #1551

The updated output is:
<img width="1702" height="275" alt="image" src="https://github.com/user-attachments/assets/884a67bc-7fd4-467e-b759-73b89243200f" />

