### PR TITLE
Fix a bug in transform.py when GPU is available

### DIFF
--- a/transforms/language/text_encoder/dpk_text_encoder/local_python.py
+++ b/transforms/language/text_encoder/dpk_text_encoder/local_python.py
@@ -21,7 +21,6 @@ from dpk_text_encoder.transform import (
     model_name_cli_param,
     content_column_name_cli_param,
     output_embeddings_column_name_cli_param,
-    embeddings_in_parquet_cli_param
 )
 from dpk_text_encoder.runtime import TextEncoderPythonTransformConfiguration
 
@@ -43,7 +42,6 @@ params = {
     "runtime_code_location": ParamsUtils.convert_to_ast(code_location),
     "data_checkpointing": False,
     # text_encoder params
-    embeddings_in_parquet_cli_param: True,
     model_name_cli_param: "ibm-granite/granite-embedding-small-english-r2",
     content_column_name_cli_param: "contents",
     output_embeddings_column_name_cli_param: "embeddings",

--- a/transforms/language/text_encoder/dpk_text_encoder/transform.py
+++ b/transforms/language/text_encoder/dpk_text_encoder/transform.py
@@ -119,7 +119,6 @@ class TextEncoderTransform(AbstractTableTransform):
 
         if torch.cuda.is_available():
             self.logger.info(f"GPU is available!")
-            self.model.half()
             self.device = torch.device("cuda")  # Use GPU
         else:
             self.logger.info(f"GPU is not available. Using CPU.")
@@ -131,7 +130,6 @@ class TextEncoderTransform(AbstractTableTransform):
         self.embeddings_in_lanceDB = config.get(embeddings_in_lanceDB_key, default_embeddings_in_lanceDB)
         self.logger.info(f"{self.embeddings_in_lanceDB=}")
 
-      
         self.model_max_seq_length = config.get(model_max_seq_length_key, default_model_max_seq_length)
         self.logger.info(f"{self.model_max_seq_length=}")
 
@@ -140,7 +138,9 @@ class TextEncoderTransform(AbstractTableTransform):
             self.model.max_seq_length = self.model_max_seq_length
             self.model.tokenizer.model_max_length = self.model_max_seq_length
             self.model = self.model.to(self.device)
-
+            if torch.cuda.is_available():
+                self.model.half()
+            
         
         self.embedding_batch_size = config.get(embedding_batch_size_key, default_embedding_batch_size)
 


### PR DESCRIPTION
## Why are these changes needed?
In the `init()` of `transform()` method, `self.model.half()` was referenced before` self.model `is assigned, triggering a bug. In this pull request, it is fixed.  Also removed a nonexistent parameter in `local_python.py`. 

## Related issue number (if any).

#1563 
