### PR TITLE
Add context to S3 secret regarding local testing

### DIFF
--- a/scripts/k8s-setup/README.md
+++ b/scripts/k8s-setup/README.md
@@ -73,6 +73,24 @@ Open the Kubeflow Pipelines UI at  http://localhost:8080/
 You can work with a real S3 storage, but for testing you can use the Mino server which is deployed as part of the KFP
 installation. You can access the Minio dashboard at http://localhost:8090/
 
+
+> [!WARNING]
+> **SECURITY NOTE: LOCAL TESTING CREDENTIALS ONLY**
+> 
+> The MinIO credentials documented below (`minio`/`minio123`) are **intentionally public** and used exclusively for:
+> - Local development on Kind clusters
+> - CI/CD testing in GitHub Actions
+> - Community contributor testing
+> 
+> These credentials:
+> - Only work with cluster-internal endpoints (not accessible from the internet)
+> - Are used in ephemeral test environments only
+> - **Never** contain production data or sensitive information
+> - Are **not** production credentials
+> 
+> **Do not use these credentials for production deployments.**
+
+
 #### Create a secret
 The MinIO service, deployed as a part of KFP, uses a username (`minio`) as an access_key/password (`minio123`)
 as the secret key.

--- a/scripts/k8s-setup/populate_minio.sh
+++ b/scripts/k8s-setup/populate_minio.sh
@@ -1,5 +1,24 @@
 #!/usr/bin/env bash
 
+
+################################################################################
+# SECURITY NOTE: LOCAL TESTING CREDENTIALS ONLY
+#
+# This script uses intentionally public test credentials (minio/minio123) for:
+# - Local development on Kind clusters
+# - CI/CD testing in GitHub Actions
+# - Community contributor testing
+#
+# These credentials:
+# - Only work with cluster-internal MinIO endpoints
+# - Are used in ephemeral test environments only
+# - NEVER contain production data or sensitive information
+# - Are NOT production credentials
+#
+# DO NOT use these credentials for production deployments.
+################################################################################
+
+
 if [ "$MINIO_SERVER" == "" ]; then
     MINIO_SERVER="http://localhost:8090"
 fi

--- a/scripts/k8s-setup/s3_secret.yaml
+++ b/scripts/k8s-setup/s3_secret.yaml
@@ -1,4 +1,5 @@
 ### This is a secret to use minio as an S3 provider
+### Used for testing purposes only
 apiVersion: v1
 metadata:
     name: s3-secret


### PR DESCRIPTION
## Why are these changes needed?

This PR adds inline comments to the secret file and updates the README to explicitly clarify that the MinIO S3 credentials are strictly for local testing and must not be used in production environments.



