### PR TITLE
fix(gneissweb): accumulate stats across all configured classifiers

### DIFF
--- a/transforms/language/gneissweb_classification/dpk_gneissweb_classification/transform.py
+++ b/transforms/language/gneissweb_classification/dpk_gneissweb_classification/transform.py
@@ -10,20 +10,20 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 ################################################################################
+import ast
 import os
 from argparse import ArgumentParser, Namespace
 from typing import Any
 
 import pyarrow as pa
-
-import ast
-
 from data_processing.transform import AbstractTableTransform, TransformConfiguration
 from data_processing.utils import CLIArgumentProvider, TransformUtils, load_model
-from dpk_gneissweb_classification.classification_models import FastTextModel, ClassificationModel
+from dpk_gneissweb_classification.classification_models import (
+    ClassificationModel,
+    FastTextModel,
+)
 from dpk_gneissweb_classification.nlp import get_label_ds_pa
 from dpk_gneissweb_classification.nlp_parallel import get_label_ds_pa_parallel
-
 
 
 short_name = "gcls"
@@ -69,55 +69,54 @@ class ClassificationTransform(AbstractTableTransform):
         # Make sure that the param name corresponds to the name used in apply_input_params method
         # of ClassificationTransformConfiguration class
         super().__init__(config)
-        
-        self.model_credential = config.get(model_credential_cli_param, os.environ.get('HF_READ_ACCESS_TOKEN', None))
+
+        self.model_credential = config.get(model_credential_cli_param, os.environ.get("HF_READ_ACCESS_TOKEN", None))
         self.model_file_name = ast.literal_eval(config.get(model_file_name_cli_param)[0])
         self.model_url = ast.literal_eval(config.get(model_url_cli_param)[0])
-        self.model =[]
+        self.model = []
         for url, model_filename in zip(self.model_url, self.model_file_name):
             self.logger.info(f"Loading Model: {url=}, {model_filename=} ")
-            model = load_model(url, 'fasttext', self.model_credential, model_filename=model_filename)
+            model = load_model(url, "fasttext", self.model_credential, model_filename=model_filename)
             self.model.append(model)
             self.logger.info(f"Loading Model: {url=}, {model_filename=} complete")
 
         self.n_processes = config.get(n_processes_cli_param, default_n_processes)
         self.content_column_name = config.get(content_column_name_cli_param, default_content_column_name)
-        self.output_label_column_name = ast.literal_eval(config.get(output_label_column_name_cli_param, default_output_label_column_name)[0])
-        self.output_score_column_name = ast.literal_eval(config.get(output_score_column_name_cli_param, default_output_score_column_name)[0])
+        self.output_label_column_name = ast.literal_eval(
+            config.get(output_label_column_name_cli_param, default_output_label_column_name)[0]
+        )
+        self.output_score_column_name = ast.literal_eval(
+            config.get(output_score_column_name_cli_param, default_output_score_column_name)[0]
+        )
 
-    def transform(self, table: pa.Table, file_name: str | None = None) -> tuple[list[pa.Table], dict[str, Any]]:  # pylint:disable=unused-argument
+    def transform(
+        self, table: pa.Table, file_name: str | None = None
+    ) -> tuple[list[pa.Table], dict[str, Any]]:  # pylint:disable=unused-argument
         """
         Put Transform-specific to convert one Table to 0 or more tables. It also returns
         a dictionary of execution statistics - arbitrary dictionary
         This implementation makes no modifications so effectively implements a copy of the
         input parquet to the output folder, without modification.
         """
-        
-        for label_column_name, score_column_name in zip(self.output_label_column_name,self.output_score_column_name):
+
+        for label_column_name, score_column_name in zip(self.output_label_column_name, self.output_score_column_name):
             TransformUtils.validate_columns(table, [self.content_column_name])
             if label_column_name in table.schema.names:
                 raise Exception(f"column to store label ({label_column_name}) already exist")
             if score_column_name in table.schema.names:
-                raise Exception(
-                    f"column to store score of label ({score_column_name}) already exist"
-                )
+                raise Exception(f"column to store score of label ({score_column_name}) already exist")
         self.logger.debug(f"Transforming one table with {len(table)} rows")
-        for model, url, label_column_name, score_column_name in zip(self.model, 
-                                                                    self.model_url, 
-                                                                    self.output_label_column_name,
-                                                                    self.output_score_column_name):
+        all_stats: dict[str, Any] = {}
+        for model, url, label_column_name, score_column_name in zip(
+            self.model, self.model_url, self.output_label_column_name, self.output_score_column_name
+        ):
             table, stats = get_label_ds_pa(
-                    table,
-                    model, 
-                    url,
-                    self.content_column_name,
-                    label_column_name,
-                    score_column_name,
-                    self.n_processes
-                )
-            
+                table, model, url, self.content_column_name, label_column_name, score_column_name, self.n_processes
+            )
+            all_stats.update(stats)
+
         self.logger.debug(f"Transformed one table with {len(table)} rows")
-        return [table], stats
+        return [table], all_stats
 
 
 class ClassificationTransformConfiguration(TransformConfiguration):
@@ -154,13 +153,7 @@ class ClassificationTransformConfiguration(TransformConfiguration):
             default="",
             help="filename of model",
         )
-        parser.add_argument(
-            f"--{model_url_cli_param}",
-            type=str,
-            nargs="+",
-            default="",
-            help="Url to model"
-        )
+        parser.add_argument(f"--{model_url_cli_param}", type=str, nargs="+", default="", help="Url to model")
         parser.add_argument(
             f"--{content_column_name_cli_param}",
             default=default_content_column_name,

--- a/transforms/language/gneissweb_classification/test/test_transform_stats.py
+++ b/transforms/language/gneissweb_classification/test/test_transform_stats.py
@@ -1,0 +1,78 @@
+# SPDX-License-Identifier: Apache-2.0
+# (C) Copyright IBM Corp. 2024.
+# Licensed under the Apache License, Version 2.0 (the “License”);
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#  http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an “AS IS” BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+import logging
+from unittest.mock import patch
+
+import pyarrow as pa
+from dpk_gneissweb_classification.transform import ClassificationTransform
+
+
+def _make_transform(model_urls, label_columns, score_columns):
+    """Build a ClassificationTransform without going through __init__,
+    which would try to download real fastText models over the network.
+    Only the attributes transform() actually reads are set."""
+    t = ClassificationTransform.__new__(ClassificationTransform)
+    t.model = list(model_urls)
+    t.model_url = list(model_urls)
+    t.content_column_name = "text"
+    t.output_label_column_name = list(label_columns)
+    t.output_score_column_name = list(score_columns)
+    t.n_processes = 1
+    t.logger = logging.getLogger("test")
+    return t
+
+
+def test_transform_merges_stats_across_multiple_classifiers():
+    """Regression test for #1453: stats from earlier classifiers must not
+    be overwritten by later ones when multiple classifiers are configured."""
+    t = _make_transform(
+        model_urls=["url_a", "url_b"],
+        label_columns=["label_a", "label_b"],
+        score_columns=["score_a", "score_b"],
+    )
+    table = pa.table({"text": ["doc1", "doc2"]})
+
+    fake_results = [
+        (table, {"topic_a_label": 2}),
+        (table, {"topic_b_label": 5}),
+    ]
+
+    with patch(
+        "dpk_gneissweb_classification.transform.get_label_ds_pa",
+        side_effect=fake_results,
+    ):
+        _, stats = t.transform(table)
+
+    assert stats == {"topic_a_label": 2, "topic_b_label": 5}
+
+
+def test_transform_single_classifier_unaffected():
+    """The single-classifier case (what the existing integration test
+    already covers) must produce the same result before and after the fix."""
+    t = _make_transform(
+        model_urls=["url_med"],
+        label_columns=["label_med"],
+        score_columns=["score"],
+    )
+    table = pa.table({"text": ["doc1"]})
+
+    fake_results = [(table, {"medical": 1})]
+
+    with patch(
+        "dpk_gneissweb_classification.transform.get_label_ds_pa",
+        side_effect=fake_results,
+    ):
+        _, stats = t.transform(table)
+
+    assert stats == {"medical": 1}


### PR DESCRIPTION
## What

Fixes #1453. When `ClassificationTransform` is configured with more
than one classifier, the output metadata only contained stats for the
last configured classifier, earlier classifiers' counts were silently
dropped.

## Root cause

`transform()` runs one loop iteration per configured classifier, and
each iteration does `table, stats = get_label_ds_pa(...)`. `stats` is
reassigned every iteration rather than accumulated, so after the loop
only the last iteration's dict survives to the `return` statement.
`table` doesn't have this problem, since each iteration correctly adds
a column to the same table object, it's specifically the stats
tracking that's broken.

This wasn't caught by the transform's existing test because that test
only configures a single classifier, and with one loop iteration,
"overwrite" and "accumulate" are indistinguishable.

## Fix

Accumulate into a running `all_stats` dict via `.update()` instead of
reassigning `stats` directly. Minimal logical diff: one new variable, one
`.update()` call, one return value changed.

## Testing

- Added `test/test_transform_stats.py`, a lightweight unit test that
  mocks the classifier call (`get_label_ds_pa`) so it runs in
  milliseconds with no network access or model download required.
- Confirmed the new multi-classifier test fails against the
  unmodified code (reproducing the exact reported symptom: only the
  last classifier's stats present) and passes after the fix.
- Added a second test confirming the single-classifier case (what the
  existing integration test already covers) is unaffected by this
  change.

## Scope note

Left two pre-existing, unrelated unused imports in this file
(`FastTextModel`, `get_label_ds_pa_parallel`) untouched, since they
predate this change and aren't part of the reported bug.

This repo's required `pre-commit` hooks (`black`/`isort`) reformatted
the whole `transform.py` file on commit, since the file was not
previously formatted to this repo's style. That reformat is purely
cosmetic (whitespace, quote style, line wrapping, import order) with no
logic changes beyond the 4-line fix described above; I did not run
`black` manually or expand scope myself, this is `pre-commit`'s
documented, required behavior for a file this PR touches. Happy to
split it into a separate formatting-only commit/PR if maintainers would
prefer that instead.