### PR TITLE
fixing deploy.doc action

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -13,8 +13,8 @@ jobs:
             REPO_URL: "https://github.com/${{ github.repository }}"
             REPO_BRANCH: "dev"
         steps:
-            - uses: actions/checkout@v2
-            - uses: actions/setup-python@v2
+            - uses: actions/checkout@v4
+            - uses: actions/setup-python@v5
               with:
                   python-version: 3.x
             - run: pip install mkdocs-material mkdocstrings[python] mkdocs-badges mkdocs-same-dir


### PR DESCRIPTION
This change was recommended by CC:

I'll look at the workflow file that deploys docs.

  Searched for 1 pattern, read 1 file, listed 1 directory

That message is a warning, not the failure — but the fix is simple: bump both actions to versions that ship Node 24-compatible builds.

⏺ Update(.github/workflows/deploy-docs.yml)
Added 2 lines, removed 2 lines
            REPO_URL: "https://github.com/${{ github.repository }}"
            REPO_BRANCH: "dev"
        steps:
            - uses: actions/checkout@v2
            - uses: actions/setup-python@v2
            - uses: actions/checkout@v4
            - uses: actions/setup-python@v5
              with:
                  python-version: 3.x
            - run: pip install mkdocs-material mkdocstrings[python] mkdocs-badges mkdocs-same-dir

Updated .github/workflows/deploy-docs.yml:16-17:
- actions/checkout@v2 → @v4
- actions/setup-python@v2 → @v5

Two things worth knowing:

That message is a warning, not an error. GitHub deprecated the Node 20 runtime; it force-runs those old actions on Node 24 anyway. It's printed as an annotation and doesn't fail the job. So if your docs deploy actually failed, the cause is somewhere else in the log — most likely the mkdocs gh-deploy step, or a YAML syntax problem in your mkdocs.yml change. If it did fail, paste that part of the log and I'll look.

One caveat on setup-python@v5: python-version: 3.x still resolves fine, but v5 is stricter about caching and version-file handling than v2. Nothing here uses those, so this should be a clean swap.

