### PR TITLE
Fix ZeroDivisionError in ededup runtime stats on empty-input runs

### DIFF
--- a/transforms/universal/ededup/dpk_ededup/ray/runtime.py
+++ b/transforms/universal/ededup/dpk_ededup/ray/runtime.py
@@ -194,7 +194,10 @@ class EdedupRayRuntime(DefaultRayTransformRuntime):
                 sum_hash = sum_hash + h_size
                 sum_hash_mem = sum_hash_mem + h_memory
             remote_replies = not_ready
-        dedup_prst = 100 * (1.0 - stats.get("result_documents", 1) / stats.get("source_documents", 1))
+        source_documents = stats.get("source_documents", 0)
+        # dict.get()'s default only applies when the key is absent, not when it's present with
+        # value 0 (e.g. a run over an empty input set) - guard explicitly to avoid a ZeroDivisionError.
+        dedup_prst = 100 * (1.0 - stats.get("result_documents", 0) / source_documents) if source_documents else 0.0
         # snapshot execution results
         remote_replies = [f.snapshot.remote() for f in self.filters]
         while remote_replies:

--- a/transforms/universal/ededup/dpk_ededup/runtime.py
+++ b/transforms/universal/ededup/dpk_ededup/runtime.py
@@ -84,7 +84,10 @@ class EdedupRuntime(DefaultPythonTransformRuntime):
         h_size, h_memory = self.filter.get_hash_size()
         stats.add_stats({"number of hashes": h_size, "hash memory, GB": h_memory})
         current = stats.get_execution_stats()
-        dedup_prst = 100 * (1.0 - current.get("result_documents", 1) / current.get("source_documents", 1))
+        source_documents = current.get("source_documents", 0)
+        # dict.get()'s default only applies when the key is absent, not when it's present with
+        # value 0 (e.g. a run over an empty input set) - guard explicitly to avoid a ZeroDivisionError.
+        dedup_prst = 100 * (1.0 - current.get("result_documents", 0) / source_documents) if source_documents else 0.0
         stats.add_stats({"de duplication %": dedup_prst})
         # snapshot execution result
         self.filter.snapshot()

--- a/transforms/universal/ededup/test/test_ededup_runtime_stats.py
+++ b/transforms/universal/ededup/test/test_ededup_runtime_stats.py
@@ -1,0 +1,58 @@
+# SPDX-License-Identifier: Apache-2.0
+# (C) Copyright IBM Corp. 2024.
+# Licensed under the Apache License, Version 2.0 (the “License”);
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#  http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an “AS IS” BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+from unittest.mock import MagicMock
+
+import pytest
+from data_processing.transform import TransformStatistics
+from dpk_ededup.runtime import EdedupRuntime
+from dpk_ededup.transform_base import HashFilter
+
+
+def _make_runtime() -> EdedupRuntime:
+    runtime = EdedupRuntime({})
+    # get_transform_config() normally sets this up; construct a fresh, empty filter directly
+    # since these tests exercise compute_execution_stats()'s stats computation in isolation.
+    # snapshot() needs a real data-access backend to persist to, which is unrelated to what's
+    # under test here, so it's mocked out.
+    runtime.filter = HashFilter({})
+    runtime.filter.snapshot = MagicMock()
+    return runtime
+
+
+def test_compute_execution_stats_with_zero_source_documents_does_not_raise():
+    """
+    Regression test: a run over an empty input set (source_documents == 0) must not raise
+    ZeroDivisionError. dict.get(key, default) only applies the default when the key is absent,
+    not when it is present with value 0, so a naive `stats.get("source_documents", 1)` guard
+    does not actually protect against this case.
+    """
+    runtime = _make_runtime()
+    stats = TransformStatistics()
+    stats.add_stats({"source_documents": 0, "result_documents": 0})
+
+    runtime.compute_execution_stats(stats)
+
+    result = stats.get_execution_stats()
+    assert result["de duplication %"] == 0.0
+
+
+def test_compute_execution_stats_normal_case_unchanged():
+    runtime = _make_runtime()
+    stats = TransformStatistics()
+    stats.add_stats({"source_documents": 10, "result_documents": 7})
+
+    runtime.compute_execution_stats(stats)
+
+    result = stats.get_execution_stats()
+    assert result["de duplication %"] == pytest.approx(30.0)


### PR DESCRIPTION
Closes #1601.

### What

`EdedupRuntime.compute_execution_stats()` (both `transforms/universal/ededup/dpk_ededup/runtime.py` and its Ray counterpart in `dpk_ededup/ray/runtime.py`) computed the "de duplication %" stat as:

```python
dedup_prst = 100 * (1.0 - current.get("result_documents", 1) / current.get("source_documents", 1))
```

`dict.get(key, default)`'s default only applies when `key` is **absent**, not when it's present with value `0`. `source_documents` is accumulated across every file processed in the run, so a run over an empty input set (or a set of entirely zero-row files) legitimately ends up with `source_documents == 0`, and `.get("source_documents", 1)` returns that real `0` — raising `ZeroDivisionError` instead of falling back to `1`.

### Fix

Guard explicitly on `source_documents == 0` in both the pure-python and Ray runtime variants, reporting `0.0` for an empty run instead of raising. Applied identically to both since they had the identical bug.

### Testing

- Added `test/test_ededup_runtime_stats.py`: a regression test that reproduces the crash on `source_documents=0` (fails against the old code, passes against the fix) plus a normal-case test confirming the dedup-percentage math is unchanged for a non-empty run.
- Ran the full relevant local test suite (`test_ededup.py`, `test_ededup_python.py`, `test_ededup_python_incremental.py`, plus the new file) — **5/5 passing, no regressions**.
- `black --check` and `isort --check` both clean on all changed files.
- Syntax-checked the Ray variant (`py_compile`) since a full Ray-dependent test run wasn't set up in my environment.

### Note on commit signing

I don't have an SSH commit-signing key configured in the environment I used for this contribution, so this commit is DCO sign-off'd (`-s`) but not GPG/SSH "verified"-signed. I understand from CONTRIBUTING.md that a verified signature is required before merge — happy to add one, or let me know if there's a preferred way to handle this.