### PR TITLE
fix(pii_redactor): handle empty/whitespace-only text in _redact_pii

### DIFF
--- a/transforms/language/pii_redactor/dpk_pii_redactor/transform.py
+++ b/transforms/language/pii_redactor/dpk_pii_redactor/transform.py
@@ -82,6 +82,9 @@ class PIIRedactorTransform(AbstractTableTransform):
             analyze_results, entity_types = self._analyze_pii(text)
             anonymized_results = self.anonymizer.anonymize_text(text, analyze_results)
             return anonymized_results.text, entity_types
+        # Empty/whitespace-only text has nothing to analyze; without this branch the
+        # implicit None return breaks zip() in transform() for the whole file.
+        return text, []
 
     def transform(self, table: pa.Table, file_name: Optional[str] = None) -> tuple[list[pa.Table], dict[str, Any]]:
         """

--- a/transforms/language/pii_redactor/test/test_data.py
+++ b/transforms/language/pii_redactor/test/test_data.py
@@ -20,9 +20,10 @@ table = pa.Table.from_pydict(
                 "My name is Tom chandler. Captain of the ship",
                 "I work at Apple and I like to eat apples",
                 "My email is tom@chadler.com and dob is 31.05.1987",
+                "   ",
             ]
         ),
-        "doc_id": pa.array(["doc1", "doc2", "doc3"]),
+        "doc_id": pa.array(["doc1", "doc2", "doc3", "doc4"]),
     }
 )
 expected_table = table.add_column(
@@ -33,21 +34,22 @@ expected_table = table.add_column(
             "My name is <PERSON>. Captain of the ship",
             "I work at <ORGANIZATION> and I like to eat apples",
             "My email is <EMAIL_ADDRESS> and dob is <DATE_TIME>",
+            "",
         ]
     ],
 )
-detected_pii = [["PERSON"], ["ORGANIZATION"], ["EMAIL_ADDRESS", "DATE_TIME"]]
+detected_pii = [["PERSON"], ["ORGANIZATION"], ["EMAIL_ADDRESS", "DATE_TIME"], []]
 expected_table = expected_table.add_column(0, "detected_pii", [detected_pii])
 
 redacted_expected_table = table.add_column(
     0,
     "transformed_contents",
     [
-        ["My name is . Captain of the ship", "I work at  and I like to eat apples", "My email is  and dob is "],
+        ["My name is . Captain of the ship", "I work at  and I like to eat apples", "My email is  and dob is ", ""],
     ],
 )
 redacted_expected_table = redacted_expected_table.add_column(0, "detected_pii", [detected_pii])
 expected_metadata_list = [
-    {"original_table_rows": 3, "original_column_count": 2, "transformed_table_rows": 3, "transformed_column_count": 4},
+    {"original_table_rows": 4, "original_column_count": 2, "transformed_table_rows": 4, "transformed_column_count": 4},
     {},
 ]


### PR DESCRIPTION
## Root cause

`_redact_pii` (`transform.py:79-84`) strips the input text and only returns a value
inside the `if text:` branch, so an empty or whitespace-only row falls off the end of
the function with an implicit `None`. `transform()` unpacks every row's result with
`zip(*table[pii_contents_column].to_pandas().apply(self._redact_pii))`, so a single
blank row raises `TypeError: 'NoneType' object is not iterable` and drops the whole
file, not just that row. Blank/whitespace-only documents are an ordinary artifact of
real scraped/ingested corpora (truncated downloads, boilerplate-only pages), so this is
a realistic crash, not a contrived edge case.

## Fix

Add an `else` branch to `_redact_pii` that returns `(text, [])`: the stripped text
passes through unredacted with zero detected entities, matching the tuple shape the
function already returns for non-empty text. `_redact_pii` has exactly one caller
(`transform()`), so this is the only path affected.

## Verification

- Added a whitespace-only row to `test/test_data.py` (shared by both
  `test_pii_redactor_transform.py` and `test_pii_redactor_redact_anonamize.py`), fails
  on `dev` HEAD (`TypeError: 'NoneType' object is not iterable`) and passes on this
  branch, run both ways in a clean container.
- `black --config .black.toml` and `isort` report both changed files unchanged.
- I ran the two transform-level test classes above with the Presidio/Flair analyzer
  and anonymizer stubbed out (this environment can't install those model
  dependencies), keyed on the exact sentences in `test_data.py` so the existing rows'
  expected output is unchanged. I did not independently run the full
  `make test-src`/`test-image` targets that exercise the real NLP stack; the new row
  never reaches the analyzer (it returns before calling it), so it doesn't depend on
  that stack either way.

Fixes #1599
